### PR TITLE
Feature/add hud name to hud window config

### DIFF
--- a/Aux_Hud.py
+++ b/Aux_Hud.py
@@ -350,6 +350,7 @@ class Simple_table_popup_menu(QWidget):
         grid.addLayout(vbox1, 0, 0)
         grid.addLayout(vbox2, 0, 1)
         grid.addLayout(vbox3, 0, 2)
+        grid.addWidget(QLabel(f"Stat set: {self.parentwin.aw.game_params.name}"), 1, 0)
 
         self.show()
         self.raise_()

--- a/Aux_Hud.py
+++ b/Aux_Hud.py
@@ -272,7 +272,7 @@ class Simple_table_popup_menu(QWidget):
         self.move(
             self.parentwin.hud.table.x + self.parentwin.aw.xshift, self.parentwin.hud.table.y + self.parentwin.aw.yshift
         )
-        self.setWindowTitle(self.parentwin.menu_label)
+        self.setWindowTitle(self.parentwin.menu_label + " - HUD configuration")
 
         # combobox statrange
         stat_range_combo_dict = {

--- a/HUD_main.pyw
+++ b/HUD_main.pyw
@@ -269,7 +269,6 @@ class HUD_main(QObject):
 
     def read_stdin(self, new_hand_id):
         log.debug(f"Processing new hand id: {new_hand_id}")
-        print(f"Entering read_stdin with hand_id: {new_hand_id}")
 
         self.hero, self.hero_ids = {}, {}
         found = False
@@ -277,7 +276,6 @@ class HUD_main(QObject):
         enabled_sites = self.config.get_supported_sites()
         if not enabled_sites:
             log.error("No enabled sites found")
-            print("No enabled sites found")
             self.db_connection.connection.rollback()
             self.destroy()
             return
@@ -286,14 +284,13 @@ class HUD_main(QObject):
         for i in enabled_sites:
             if not self.config.get_site_parameters(i)["aux_enabled"]:
                 log.info(f"Aux disabled for site {i}")
-                print(f"Aux disabled for site {i}")
                 aux_disabled_sites.append(i)
 
         self.db_connection.connection.rollback()  # Libérer le verrou de l'itération précédente
 
         if not found:
             for site in enabled_sites:
-                print("not found ... site in enabled_site")
+                log.debug("not found ... site in enabled_site")
                 if result := self.db_connection.get_site_id(site):
                     site_id = result[0][0]
                     self.hero[site_id] = self.config.supported_sites[site].screen_name
@@ -305,19 +302,16 @@ class HUD_main(QObject):
 
         if new_hand_id != "":
             log.debug("HUD_main.read_stdin: Hand processing starting.")
-            print("HUD_main.read_stdin: Hand processing starting.")
             if new_hand_id in self.cache:
                 log.debug(f"Using cached data for hand {new_hand_id}")
-                print(f"Data found in cache for hand_id: {new_hand_id}")
                 table_info = self.cache[new_hand_id]
             else:
-                print(f"Data not found in cache for hand_id: {new_hand_id}")
+                log.debug(f"Data not found in cache for hand_id: {new_hand_id}")
                 try:
                     table_info = self.db_connection.get_table_info(new_hand_id)
                     self.cache[new_hand_id] = table_info  # Mise en cache des informations
                 except Exception as e:
                     log.error(f"Database error while processing hand {new_hand_id}: {e}", exc_info=True)
-                    print("Database error while processing hand")
                     return
 
         (table_name, max, poker_game, type, fast, site_id, site_name, num_seats, tour_number, tab_number) = table_info

--- a/Hand.py
+++ b/Hand.py
@@ -750,9 +750,9 @@ class Hand(object):
         if match:
             # print('if match', match)
             # print("if match.gr:",match.groupdict())
-            print("type self.streets", type(self.streets))
+            log.debug("type self.streets", type(self.streets))
             self.streets.update(match.groupdict())
-            print("streets:", str(self.streets))
+            log.debug("streets:", str(self.streets))
             log.debug("markStreets:\n" + str(self.streets))
         else:
             tmp = self.handText[0:100]
@@ -1113,7 +1113,7 @@ class Hand(object):
         return retstring
 
     def printHand(self):
-        self.writeHand(sys.stdout)
+        log.debug(self.writeHand(sys.stdout))
 
     def actionString(self, act, street=None):
         log.debug("Hand.actionString(act=%s, street=%s)", act, street)
@@ -1344,7 +1344,7 @@ class HoldemOmahaHand(Hand):
             hhc.readShownCards(self)
             self.pot.handid = self.handid  # This is only required so Pot can throw it in totalPot
             self.totalPot()  # finalise it (total the pot)
-            print("self.totalpot", self.totalpot)
+            log.debug("self.totalpot", self.totalpot)
             hhc.getRake(self)
             if self.maxseats is None:
                 self.maxseats = hhc.guessMaxSeats(self)
@@ -2146,7 +2146,7 @@ class Pot(object):
 
     def end(self):
         # Initialize
-        print("Starting pot calculation...")
+        log.debug("Starting pot calculation...")
 
         self.total = sum(self.committed.values()) + sum(self.common.values()) + self.stp
 

--- a/HandHistoryConverter.py
+++ b/HandHistoryConverter.py
@@ -255,8 +255,8 @@ HandHistoryConverter: '%(sitename)s'
             # TODO: not ideal, just trying to not error. Throw ParseException?
             self.numErrors += 1
         else:
-            print(gametype)
-            print("gametypecategory", gametype["category"])
+            log.debug(gametype)
+            log.debug("gametypecategory", gametype["category"])
             if gametype["category"] in self.import_parameters["importFilters"]:
                 raise FpdbHandSkipped("Skipped %s hand" % gametype["type"])
 
@@ -492,10 +492,10 @@ or None if we fail to get the info """
     # Some sites don't report the rake. This will be called at the end of the hand after the pot total has been calculated
     # an inheriting class can calculate it for the specific site if need be.
     def getRake(self, hand):
-        print("total pot", hand.totalpot)
-        print("collected pot", hand.totalcollected)
+        log.debug("total pot", hand.totalpot)
+        log.debug("collected pot", hand.totalcollected)
         if hand.totalcollected > hand.totalpot:
-            print("collected pot>total pot")
+            log.debug("collected pot>total pot")
         if hand.rake is None:
             hand.rake = hand.totalpot - hand.totalcollected  #  * Decimal('0.05') # probably not quite right
         if self.siteId == 9 and hand.gametype["type"] == "tour":
@@ -506,7 +506,7 @@ or None if we fail to get the info """
             round = -0.01
         if self.siteId == 15 and hand.totalcollected > hand.totalpot:
             hand.rake = old_div(hand.totalpot, 10)
-            print(hand.rake)
+            log.debug(hand.rake)
         if hand.rake < 0 and (not hand.roundPenny or hand.rake < round) and not hand.cashedOut:
             if self.siteId == 28 and (
                 (hand.rake + Decimal(str(hand.sb)) - (0 if hand.rakes.get("rake") is None else hand.rakes["rake"])) == 0
@@ -550,7 +550,7 @@ or None if we fail to get the info """
             sane = True
 
         if self.in_path != "-" and self.out_path == self.in_path:
-            print(("Output and input files are the same, check config."))
+            log.debug(("Output and input files are the same, check config."))
             sane = False
 
         return sane

--- a/IdentifySite.py
+++ b/IdentifySite.py
@@ -179,15 +179,15 @@ class IdentifySite(object):
             return [x]
 
     def processFile(self, path):
-        print("process fill identify", path)
+        log.debug("process fill identify", path)
         if path not in self.filelist:
-            print("filelist", self.filelist)
+            log.debug("filelist", self.filelist)
             whole_file, kodec = self.read_file(path)
-            # print('whole_file',whole_file)
-            print("kodec", kodec)
+            # log.debug('whole_file',whole_file)
+            log.debug("kodec", kodec)
             if whole_file:
                 fobj = self.idSite(path, whole_file, kodec)
-                print("siteid obj")
+                log.debug("siteid obj")
                 # print(fobj.path)
                 if fobj is False:  # Site id failed
                     log.debug(("DEBUG:") + " " + ("siteId Failed for: %s") % path)


### PR DESCRIPTION
It can be tricky reading config file to understand which HUD display configuration is being used so I propose to add this information in the HUD configuration window:

![image](https://github.com/user-attachments/assets/d579b600-6e01-47bc-8569-6bc4da31224d)

Bonus: I also changed the name of this window to make it identifiable by my window manager and let it be floating (identified by its name)