### PR TITLE
 Fix GitHub Pages deployment: unified documentation with Sphinx and  …

### DIFF
--- a/.github/workflows/docs_deployment.yml
+++ b/.github/workflows/docs_deployment.yml
@@ -1,7 +1,10 @@
 name: Deploy Documentation to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
     branches:
       - main
 
@@ -14,12 +17,21 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage-html/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,10 +49,19 @@ jobs:
       - name: Build Sphinx documentation
         run: uv run sphinx-build -b html docs/source docs/build
 
+      - name: Create dual documentation structure
+        run: |
+          mkdir -p site_root/docs
+          mkdir -p site_root/coverage
+          cp -r docs/build/* site_root/docs/
+          cp -r coverage-html/* site_root/coverage/
+          cp site_index.html site_root/index.html
+          touch site_root/.nojekyll
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build
+          path: site_root
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,10 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+    - name: Upload coverage HTML artifacts
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html
+        path: htmlcov/

--- a/site_index.html
+++ b/site_index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FPDB-3 Documentation</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            background-color: #f8f9fa;
+        }
+        .container {
+            background: white;
+            padding: 3rem;
+            border-radius: 10px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #2c3e50;
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+        .doc-links {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+        .doc-card {
+            background: #f8f9fa;
+            padding: 2rem;
+            border-radius: 8px;
+            text-align: center;
+            text-decoration: none;
+            color: inherit;
+            transition: transform 0.2s, box-shadow 0.2s;
+            border: 1px solid #dee2e6;
+        }
+        .doc-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+            text-decoration: none;
+        }
+        .doc-card h2 {
+            color: #495057;
+            margin-bottom: 1rem;
+        }
+        .doc-card p {
+            color: #6c757d;
+            margin: 0;
+        }
+        .icon {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+        }
+        @media (max-width: 600px) {
+            .doc-links {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>FPDB-3 Documentation</h1>
+        <p style="text-align: center; color: #6c757d; margin-bottom: 3rem;">
+            Welcome to the FPDB-3 documentation portal. Choose the documentation you need:
+        </p>
+
+        <div class="doc-links">
+            <a href="docs/" class="doc-card">
+                <div class="icon">📚</div>
+                <h2>API Documentation</h2>
+                <p>Complete API reference, user guides, and developer documentation generated with Sphinx</p>
+            </a>
+
+            <a href="coverage/" class="doc-card">
+                <div class="icon">📊</div>
+                <h2>Test Coverage</h2>
+                <p>Detailed test coverage reports showing code coverage statistics and uncovered lines</p>
+            </a>
+        </div>
+
+        <footer style="text-align: center; margin-top: 3rem; color: #6c757d; font-size: 0.9rem;">
+            <p>Generated automatically by GitHub Actions</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION

- Add .nojekyll file to prevent Jekyll processing of Sphinx docs
  - Modify tests.yml to upload coverage HTML artifacts
  - Update docs_deployment.yml to trigger after tests completion
  - Create dual documentation structure: /docs/ for Sphinx, /coverage/ for test reports
  - Add landing page with navigation to both documentation types
  - Coordinate workflows: tests.yml generates coverage, docs_deployment.yml builds and deploys