### PR TITLE
Fix HUD_main.pyw launch to use virtual environment Python interpreter

### DIFF
--- a/GuiAutoImport.py
+++ b/GuiAutoImport.py
@@ -385,8 +385,9 @@ class GuiAutoImport(QWidget):
                         elif os.name == "nt":  # Windows installation source
                             path = to_raw(sys.path[0])
                             use_pythonw = win32console.GetConsoleWindow() == 0
-                            interpreter = "pythonw" if use_pythonw else "python"
-                            command = f'{interpreter} "{path}\\HUD_main.pyw" ' f"{self.settings['cl_options']}"
+                            # Use sys.executable to get the current Python interpreter path
+                            interpreter = sys.executable.replace("python.exe", "pythonw.exe") if use_pythonw else sys.executable
+                            command = f'"{interpreter}" "{path}\\HUD_main.pyw" ' f"{self.settings['cl_options']}"
                             bs = 0
 
                         else:  # Linux & macOS installation source


### PR DESCRIPTION
Fixed ModuleNotFoundError when launching HUD_main.pyw on Windows. The issue occurred because HUD_main.pyw was launched using 'python' or 'pythonw' from PATH, which pointed to the system Python instead of the virtual environment Python where dependencies are installed.

Changes:
- Use sys.executable to get the current Python interpreter path
- Ensures HUD_main.pyw uses the same Python environment as fpdb.pyw
- Properly quotes interpreter path to handle spaces in paths

This fix allows HUD to access all installed dependencies (pyzmq, etc.) when using virtual environments (uv, venv, virtualenv).