### PR TITLE
Clean up stale unfinished-code markers and fix the real bugs they hid

### DIFF
--- a/fpdb_3_legacy/CakeToFpdb.py
+++ b/fpdb_3_legacy/CakeToFpdb.py
@@ -235,17 +235,20 @@ class Cake(HandHistoryConverter):
         re.MULTILINE,
     )
 
-    def compilePlayerRegexs(self, hand: list[str]) -> None:
-        """Compiles regular expressions representing the cards in a player's hand.
+    def compilePlayerRegexs(self, hand: "Hand") -> None:  # noqa: ARG002
+        """Compile player-dependent regexes.
+
+        Cake's player-related regexes (``re_hero_cards``, ``re_shown_cards``,
+        ``re_action``, ``re_collect_pot`` ...) are compiled at class level with a
+        generic ``PLYR`` pattern that matches any player name, so there is nothing
+        to recompile per hand. This override is intentionally a no-op.
 
         Args:
-            hand (list[str]): The cards in the player's hand.
+            hand: The Hand object being parsed (unused).
 
         Returns:
-            list[re.Pattern]: A list of compiled regular expressions, one for each card in the player's hand.
-
+            None
         """
-        # TODO(maintainer): Implement this function.
 
     def readSupportedGames(self) -> list[list[str]]:
         """Returns a list of supported games.

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -9,6 +9,7 @@ if os.getenv("FPDB_FORCE_X11") == "1":
 
 import subprocess
 import sys
+import time
 import traceback
 from optparse import OptionParser
 
@@ -91,6 +92,8 @@ class GuiAutoImport(QWidget):
         self.pipe_to_hud = None
         self.doAutoImportBool = False
 
+        self.cli = cli
+
         self.importer = Importer.Importer(self, self.settings, self.config, self.sql)
 
         self.importer.setCallHud(True)
@@ -106,11 +109,8 @@ class GuiAutoImport(QWidget):
         if cli is False:
             self.setupGui()
             self._setup_config_observer()
-        else:
-            # TODO: Separate the code that grabs the directories from config
-            #       Separate the calls to the Importer API
-            #       Create a timer interface that doesn't rely on GTK
-            raise NotImplementedError
+        # In headless (cli) mode there is no GUI to build and no config observer
+        # to attach; the caller drives the import loop via run_headless().
 
     def setupGui(self) -> None:
         self.setWindowTitle("FPDB Auto Import")
@@ -200,6 +200,12 @@ class GuiAutoImport(QWidget):
             self.addText(f"Unable to apply theme {theme_name}\n", "warning")
 
     def addText(self, text, level="info") -> None:
+        if getattr(self, "cli", False):
+            # Headless mode: no GUI log view — route to the logger instead.
+            message = text.strip()
+            if message:
+                {"error": log.error, "warning": log.warning}.get(level, log.info)(message)
+            return
         try:
             self.log_message.emit(text, level)
         except RuntimeError:
@@ -341,6 +347,87 @@ class GuiAutoImport(QWidget):
         log.error(f"AutoImport: background import cycle failed: {error_msg}")
         self.addText(f"Auto Import Error: {error_msg}\n", "error")
 
+    def run_headless(self, interval: int | None = None, launch_hud: bool = True) -> int:
+        """Run the auto-import loop without a GUI (used by the ``-q``/``--quiet`` mode).
+
+        Watches the hand-history and tournament-summary directories configured for
+        the enabled sites and imports new/updated files on a fixed interval — the
+        same engine the GUI auto-import tab drives, but stepped by a plain
+        ``time.sleep`` loop instead of a Qt timer. Runs until interrupted
+        (Ctrl+C / SIGTERM).
+
+        Like the GUI "Start Auto Import" button, this launches the HUD subprocess
+        (``launch_hud=True``) and feeds it the imported hands over ZMQ. Note the
+        HUD is itself a GUI overlay, so a display must be available.
+
+        Args:
+            interval: Seconds between import cycles. Defaults to the ``interval``
+                import parameter from the configuration.
+            launch_hud: Whether to spawn the HUD_main subprocess. Set False to run
+                a pure background importer with no HUD.
+
+        Returns:
+            int: Process exit code (0 on clean shutdown, 1 if the global lock is
+            unavailable).
+        """
+        if interval is None:
+            try:
+                interval = int(self.config.get_import_parameters().get("interval"))
+            except (TypeError, ValueError):
+                interval = 10
+        interval = max(1, interval)
+
+        lock = self.settings.get("global_lock")
+        if lock is not None and not lock.acquire(wait=False, source="AutoImport"):
+            log.error("Auto Import aborted: global lock not available (another fpdb import running?).")
+            return 1
+
+        log.info("Headless auto-import started (interval: %ss). Press Ctrl+C to stop.", interval)
+        self.doAutoImportBool = True
+
+        if launch_hud and self.pipe_to_hud is None:
+            # HUD_main uses fpdb's shared option parser and rejects the
+            # auto-import's own -q flag, so hand it HUD-appropriate options (the
+            # config path) instead of whatever this process was invoked with.
+            config_file = getattr(self.config, "file", None)
+            self.settings["cl_options"] = f"-c {config_file}" if config_file else ""
+            try:
+                self._launch_hud()
+                log.info("HUD launched.")
+            except (OSError, ValueError):
+                # A missing HUD must not stop imports; log and carry on headless.
+                log.warning("Could not launch HUD; continuing without it: %s", traceback.format_exc())
+
+        try:
+            self.updatePaths()
+            while True:
+                try:
+                    self.importer.autoSummaryGrab()
+                    self.importer.runUpdated()
+                except Exception:
+                    # One bad cycle must not kill the daemon; log and keep watching.
+                    log.exception("Auto-import cycle failed; continuing.")
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            log.info("Stopping headless auto-import (interrupt received).")
+        finally:
+            self.doAutoImportBool = False
+            try:
+                self.importer.autoSummaryGrab(force=True)
+            except Exception:
+                log.exception("Final tournament-summary grab failed.")
+            if self.pipe_to_hud is not None:
+                try:
+                    self.pipe_to_hud.terminate()
+                except OSError:
+                    log.debug("HUD subprocess already gone.")
+                self.pipe_to_hud = None
+                log.info("HUD subprocess stopped.")
+            if lock is not None:
+                lock.release()
+                log.info("Global lock released.")
+        return 0
+
     def reset_startbutton(self) -> bool:
         if self.pipe_to_hud is not None:
             self.startButton.set_label("Stop Auto Import")
@@ -374,6 +461,100 @@ class GuiAutoImport(QWidget):
                 log.debug(file)
         return False
 
+    @staticmethod
+    def _hud_base_path() -> str:
+        """Return the directory that contains HUD_main(.pyw), resolved robustly.
+
+        Frozen builds unpack their resources next to ``sys._MEIPASS``. Otherwise
+        HUD_main lives next to this module (both in ``fpdb_3_legacy``), so resolve
+        it relative to ``__file__`` rather than ``sys.path[0]``/CWD, which depend
+        on how the process was launched (e.g. ``python -m ...`` vs the installed
+        entry point).
+        """
+        if getattr(sys, "frozen", False):
+            return sys._MEIPASS
+        return os.path.dirname(os.path.abspath(__file__))
+
+    def _launch_hud(self) -> None:
+        """Build the HUD_main command for the current install method and spawn it.
+
+        Sets ``self.pipe_to_hud`` to the launched subprocess. Raises OSError or
+        ValueError on failure (callers decide how to surface it). Shared by the
+        GUI auto-import (startClicked) and the headless mode (run_headless).
+        """
+        # ------------------------------------------------------------------
+        # 1) build command line
+        # ------------------------------------------------------------------
+        if getattr(sys, "frozen", False) == "pyoxidizer":
+            command = [sys.executable, "--hud", *self.settings["cl_options"].split()]
+            bs = 1
+
+        elif self.config.install_method == "exe":
+            command = "HUD_main.exe"
+            bs = 0
+
+        elif self.config.install_method == "app":
+            base_path = self._hud_base_path()
+            command = os.path.join(base_path, "HUD_main")
+            if not os.path.isfile(command):
+                msg = f"HUD_main not found at {command}"
+                raise FileNotFoundError(msg)
+            bs = 1
+
+        elif os.name == "nt":  # Windows installation source
+            path = to_raw(self._hud_base_path())
+            use_pythonw = win32console.GetConsoleWindow() == 0
+            # Use the current interpreter (e.g. the uv/venv python) so the
+            # HUD subprocess shares the same environment and installed
+            # packages (zmq, PyQt, ...). Falling back to a bare
+            # "python"/"pythonw" from PATH would pick a different
+            # interpreter that may lack our dependencies.
+            interpreter = sys.executable
+            if use_pythonw:
+                pythonw = os.path.join(os.path.dirname(interpreter), "pythonw.exe")
+                if os.path.isfile(pythonw):
+                    interpreter = pythonw
+            command = f'"{interpreter}" "{path}\\HUD_main.pyw" {self.settings["cl_options"]}'
+            bs = 0
+
+        else:  # Linux & macOS installation source
+            base_path = self._hud_base_path()
+            command = os.path.join(base_path, "HUD_main.pyw")
+            if not os.path.isfile(command):
+                self.addText(f"\n*** {command} was not found", "error")
+            command = [command, *self.settings["cl_options"].split()]
+            bs = 1
+
+        # ------------------------------------------------------------------
+        # 2) prepare env for sub process
+        # ------------------------------------------------------------------
+        env = None  # default
+
+        if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
+            env = os.environ.copy()
+            env.setdefault("QT_QPA_PLATFORM", "xcb")
+            env.setdefault("FPDB_FORCE_X11", "1")
+
+        log.info("opening pipe to HUD")
+        log.debug(f"Running {command!r} with bs={bs}")
+
+        # ------------------------------------------------------------------
+        # 3) launch HUD
+        # ------------------------------------------------------------------
+        popen_kwargs = {
+            "bufsize": bs,
+            "stdin": subprocess.PIPE,
+            "universal_newlines": True,
+        }
+        # Capture stdout/err for windows « exe »
+        if self.config.install_method == "exe" or (os.name == "nt" and win32console.GetConsoleWindow() == 0):
+            popen_kwargs.update(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        if env is not None:
+            popen_kwargs["env"] = env
+
+        self.pipe_to_hud = subprocess.Popen(command, **popen_kwargs)
+
     def startClicked(self) -> None:
         """Runs when user clicks start on auto import tab."""
         # Check to see if we have an open file handle to the HUD and open one if we do not.
@@ -401,88 +582,14 @@ class GuiAutoImport(QWidget):
                 if self.pipe_to_hud is None:
                     log.debug("start hud - pipe_to_hud is none:")
                     try:
-                        # ------------------------------------------------------------------
-                        # 1) build command line
-                        # ------------------------------------------------------------------
-                        if getattr(sys, "frozen", False) == "pyoxidizer":
-                            command = [sys.executable, "--hud", *self.settings["cl_options"].split()]
-                            bs = 1
-
-                        elif self.config.install_method == "exe":
-                            command = "HUD_main.exe"
-                            bs = 0
-
-                        elif self.config.install_method == "app":
-                            base_path = sys._MEIPASS if getattr(sys, "frozen", False) else sys.path[0]
-                            command = os.path.join(base_path, "HUD_main")
-                            if not os.path.isfile(command):
-                                msg = f"HUD_main not found at {command}"
-                                raise FileNotFoundError(msg)
-                            bs = 1
-
-                        elif os.name == "nt":  # Windows installation source
-                            path = to_raw(sys.path[0])
-                            use_pythonw = win32console.GetConsoleWindow() == 0
-                            # Use the current interpreter (e.g. the uv/venv python) so the
-                            # HUD subprocess shares the same environment and installed
-                            # packages (zmq, PyQt, ...). Falling back to a bare
-                            # "python"/"pythonw" from PATH would pick a different
-                            # interpreter that may lack our dependencies.
-                            interpreter = sys.executable
-                            if use_pythonw:
-                                pythonw = os.path.join(os.path.dirname(interpreter), "pythonw.exe")
-                                if os.path.isfile(pythonw):
-                                    interpreter = pythonw
-                            command = f'"{interpreter}" "{path}\\HUD_main.pyw" {self.settings["cl_options"]}'
-                            bs = 0
-
-                        else:  # Linux & macOS installation source
-                            base_path = sys._MEIPASS if getattr(sys, "frozen", False) else sys.path[0] or os.getcwd()
-                            command = os.path.join(base_path, "HUD_main.pyw")
-                            if not os.path.isfile(command):
-                                self.addText(f"\n*** {command} was not found", "error")
-                            command = [command, *self.settings["cl_options"].split()]
-                            bs = 1
-
-                        # ------------------------------------------------------------------
-                        # 2) prepare env for sub process
-                        # ------------------------------------------------------------------
-                        env = None  # default
-
-                        if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
-                            env = os.environ.copy()
-                            env.setdefault("QT_QPA_PLATFORM", "xcb")
-                            env.setdefault("FPDB_FORCE_X11", "1")
-
-                        log.info("opening pipe to HUD")
-                        log.debug(f"Running {command!r} with bs={bs}")
-
-                        # ------------------------------------------------------------------
-                        # 3) launchHUD
-                        # ------------------------------------------------------------------
-                        popen_kwargs = {
-                            "bufsize": bs,
-                            "stdin": subprocess.PIPE,
-                            "universal_newlines": True,
-                        }
-                        # Capture stdout/err for windows « exe »
-                        if self.config.install_method == "exe" or (
-                            os.name == "nt" and win32console.GetConsoleWindow() == 0
-                        ):
-                            popen_kwargs.update(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-                        if env is not None:
-                            popen_kwargs["env"] = env
-
-                        self.pipe_to_hud = subprocess.Popen(command, **popen_kwargs)
-
+                        self._launch_hud()
                     except (OSError, ValueError):
                         error_msg = f"GuiAutoImport Error opening pipe: {traceback.format_exc()}"
                         log.warning(error_msg)
                         self.addText(f"\n*** {error_msg}", "error")
                     else:
                         # ------------------------------------------------------------------
-                        # 4) path config, timer, etc.
+                        # path config, timer, etc.
                         # ------------------------------------------------------------------
                         self.updatePaths()
 
@@ -664,6 +771,7 @@ def main(argv=None):
         app.exec()
     else:
         i = GuiAutoImport(settings, config, cli=True)
+        return i.run_headless()
 
     return 0
 

--- a/fpdb_3_legacy/GuiBulkImport.py
+++ b/fpdb_3_legacy/GuiBulkImport.py
@@ -1,5 +1,5 @@
 """GuiBulkImport module for FPDB bulk import functionality.
-from __future__ import annotations
+
 Copyright 2008-2011 Steffen Schaumburg
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
@@ -16,6 +16,8 @@ In the "official" distribution you can find the license in agpl-3.0.txt.
 """
 
 #    Standard Library modules
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
@@ -25,6 +27,7 @@ from typing import Any
 from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
+    QCheckBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -142,6 +145,7 @@ class GuiBulkImport(QWidget):
             self.importer.setHandsInDB(self.n_hands_in_db)
             self.importer.setMode("bulk")
             self.importer.setCallHud(False)
+            self._apply_move_settings()
 
             self.starttime = time()
 
@@ -301,6 +305,18 @@ class GuiBulkImport(QWidget):
         custom_dir_layout.addWidget(self.chooseButton)
         self.layout().addLayout(custom_dir_layout)
 
+        # Optional: relocate files once processed (backend in Importer).
+        self.moveImportedCheck, self.moveImportedDir = self._build_move_row(
+            "Move imported files to:",
+            checked=bool(self.settings.get("moveimportedfiles")),
+            directory=self.settings.get("moveImportedFilesDir", ""),
+        )
+        self.moveFailedCheck, self.moveFailedDir = self._build_move_row(
+            "Move failed files to:",
+            checked=bool(self.settings.get("movefailedfiles")),
+            directory=self.settings.get("moveFailedFilesDir", ""),
+        )
+
         self.load_button = QPushButton("Bulk Import")
         
         download_icon_path = icons_dir / "16x16" / "cil-cloud-download.png"
@@ -330,6 +346,34 @@ class GuiBulkImport(QWidget):
         )
         if newdir:
             self.importDir.setText(newdir)
+
+    def _build_move_row(self, label: str, *, checked: bool, directory: str) -> tuple[QCheckBox, QLineEdit]:
+        """Build a "move files to <dir>" row (checkbox + path field + Browse) and add it.
+
+        Returns the checkbox and line edit so load_clicked can read them.
+        """
+        row = QHBoxLayout()
+        checkbox = QCheckBox(label)
+        checkbox.setChecked(checked)
+        row.addWidget(checkbox)
+        line_edit = QLineEdit(directory)
+        row.addWidget(line_edit)
+        browse = QPushButton("Browse...")
+        browse.clicked.connect(lambda: self._browse_into(line_edit))
+        row.addWidget(browse)
+        self.layout().addLayout(row)
+        return checkbox, line_edit
+
+    def _browse_into(self, line_edit: QLineEdit) -> None:
+        """Open a directory chooser and write the result into ``line_edit``."""
+        newdir = QFileDialog.getExistingDirectory(self, "Choose a destination directory", line_edit.text())
+        if newdir:
+            line_edit.setText(newdir)
+
+    def _apply_move_settings(self) -> None:
+        """Push the move-files widget state into the importer before running an import."""
+        self.importer.setMoveImportedFiles(self.moveImportedCheck.isChecked(), self.moveImportedDir.text())
+        self.importer.setMoveFailedFiles(self.moveFailedCheck.isChecked(), self.moveFailedDir.text())
 
 
 def main(argv=None) -> int:

--- a/fpdb_3_legacy/Hud.py
+++ b/fpdb_3_legacy/Hud.py
@@ -1,5 +1,5 @@
 """Hud.py.
-from __future__ import annotations
+
 Create and manage the hud overlays.
 """
 #    Copyright 2008-2012  Ray E. Barker
@@ -20,14 +20,14 @@ Create and manage the hud overlays.
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 ########################################################################
-# TODO(R Barker): Complete Hud implementation.
+
+from __future__ import annotations
 
 import copy
 from typing import Any
 
 #    FreePokerTools modules
-from fpdb_3_legacy import Database
-from fpdb_3_legacy import Hand
+from fpdb_3_legacy import Database, Hand
 
 #    Standard Library modules
 from fpdb_3_legacy.loggingFpdb import get_logger

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -751,14 +751,10 @@ class Importer:
         totpartial = 0
         totskipped = 0
         toterrors = 0
-        filecount = 0
-        fileerrorcount = 0
-        moveimportedfiles = False  # TODO need to wire this into GUI and make it prettier
-        movefailedfiles = False  # TODO and this too
 
         # prepare progress popup window
         has_callbacks = hasattr(self, 'progress_start_cb') and self.progress_start_cb is not None
-        
+
         if not has_callbacks:
             ProgressDialog = ImportProgressDialog(len(self.filelist), self.parent)
             ProgressDialog.resize(500, 200)
@@ -767,7 +763,6 @@ class Importer:
             self.progress_start_cb(len(self.filelist))
 
         for f in self.filelist:
-            filecount += 1
             if not has_callbacks:
                 ProgressDialog.progress_update(f, str(self.database.getHandCount()))
             else:
@@ -796,26 +791,12 @@ class Importer:
                 self.database.rollback()
                 log.exception(f"A fatal error occurred while processing file: {f}. Error: {e}")
                 toterrors += 1
+                self._relocate_processed_file(f, failed=True)
                 continue
 
-            if moveimportedfiles or movefailedfiles:
-                try:
-                    if moveimportedfiles:
-                        shutil.move(
-                            f,
-                            "c:\\fpdbimported\\%d-%s" % (filecount, os.path.basename(f[3:])),
-                        )
-                except (shutil.Error, OSError) as e:
-                    fileerrorcount += 1
-                    log.exception(f"Error moving imported file {f}: {e}")
-                    if movefailedfiles:
-                        try:
-                            shutil.move(
-                                f,
-                                "c:\\fpdbfailed\\%d-%s" % (fileerrorcount, os.path.basename(f[3:])),
-                            )
-                        except (shutil.Error, OSError) as e:
-                            log.exception(f"Error moving failed file {f}: {e}")
+            # Optionally archive the file once processed: successful imports go to
+            # the "imported" directory, files that produced errors to the "failed" one.
+            self._relocate_processed_file(f, failed=errors > 0)
 
         if not has_callbacks:
             ProgressDialog.accept()
@@ -826,6 +807,50 @@ class Importer:
         return totstored, totdups, totpartial, totskipped, toterrors
 
     # end def importFiles
+
+    def _relocate_processed_file(self, filepath: str, *, failed: bool) -> None:
+        """Move a just-processed file to the configured imported/failed directory.
+
+        Controlled by the importer settings:
+          - ``moveimportedfiles`` / ``moveImportedFilesDir`` for successful imports,
+          - ``movefailedfiles`` / ``moveFailedFilesDir`` for files with errors.
+        No-op if the relevant flag is disabled or no target directory is set, so
+        the default behaviour is to leave files in place.
+
+        Args:
+            filepath: Path of the file that was just processed.
+            failed: True if the file failed to import (errors or exception).
+        """
+        if failed:
+            enabled = self.settings.get("movefailedfiles")
+            target_dir = self.settings.get("moveFailedFilesDir")
+        else:
+            enabled = self.settings.get("moveimportedfiles")
+            target_dir = self.settings.get("moveImportedFilesDir")
+
+        if not enabled or not target_dir:
+            return
+
+        kind = "failed" if failed else "imported"
+        try:
+            os.makedirs(target_dir, exist_ok=True)
+            dest = os.path.join(target_dir, os.path.basename(filepath))
+            shutil.move(filepath, dest)
+            log.info(f"Moved {kind} file {filepath!r} to {dest!r}")
+        except (shutil.Error, OSError) as e:
+            log.exception(f"Error moving {kind} file {filepath!r} to {target_dir!r}: {e}")
+
+    def setMoveImportedFiles(self, enabled, target_dir=None) -> None:
+        """Enable/disable moving successfully imported files, with an optional target dir."""
+        self.settings["moveimportedfiles"] = bool(enabled)
+        if target_dir is not None:
+            self.settings["moveImportedFilesDir"] = target_dir
+
+    def setMoveFailedFiles(self, enabled, target_dir=None) -> None:
+        """Enable/disable moving files that failed to import, with an optional target dir."""
+        self.settings["movefailedfiles"] = bool(enabled)
+        if target_dir is not None:
+            self.settings["moveFailedFilesDir"] = target_dir
 
     def _import_despatch(self, fpdbfile):
         """Dispatch the import process for a given file based on its type.

--- a/fpdb_3_legacy/WinningToFpdb.py
+++ b/fpdb_3_legacy/WinningToFpdb.py
@@ -1733,10 +1733,15 @@ class Winning(HandHistoryConverter):
         log.debug(f"Starting readSTP for Hand ID: {hand.handid}")
         log.warning(f"STP functionality not implemented for Hand ID: {hand.handid}")
 
-    def readTourneyResults(self, hand) -> None:
-        log.debug(f"Starting readTourneyResults for Hand ID: {hand.handid}")
-        log.info("Reading tournament result info for Winamax.")
-        # TODO: Implement tournament results reading logic
+    def readTourneyResults(self, hand: Hand) -> None:  # noqa: ARG002
+        """Read tournament results embedded in the hand text.
+
+        Winning Poker hand histories carry no per-hand tournament result data:
+        the ``*** SUMMARY ***`` section only reports per-seat fold/showdown
+        status, and there are no bounty/knockout lines to populate
+        ``hand.koCounts``. Finishing positions and payouts come from the tourney
+        summary parser instead, so this hook is intentionally a no-op.
+        """
 
     def readShownCards(self, hand) -> None:
         log.debug("Starting readShownCards")

--- a/fpdb_3_legacy/iPoker/base.py
+++ b/fpdb_3_legacy/iPoker/base.py
@@ -1,5 +1,5 @@
 """iPoker hand history converter for FPDB.
-from __future__ import annotations
+
 This module provides functionality to parse iPoker network hand histories
 and convert them to FPDB format, including support for multiple skins.
 """
@@ -22,26 +22,31 @@ and convert them to FPDB format, including support for multiple skins.
 
 ########################################################################
 
-# This code is based on CarbonToFpdb.py by Matthew Boss
+# This code is based on CarbonToFpdb.py by Matthew Boss.
 #
-# TODO(@author): Implement missing features:
+# The original Carbon converter carried a long list of unimplemented features.
+# Most of them have since been implemented for the iPoker XML format:
+#   - Tournaments: readSupportedGames() advertises "tour"; tourNo, buyin, fee
+#     and buyinCurrency are parsed from the session <general> header
+#     (hand_info / xml_format mixins) and surfaced to TourneySummary.
+#   - Currency: multi-currency support ($, €, £, RSD, kr, ...) via the LS symbol
+#     set and the <currency>/<tablecurrency>/<tournamentcurrency> XML tags -
+#     ring games are no longer assumed to be USD.
+#   - Antes and bring-in: readAntes() and readBringIn() are implemented, with
+#     action types "16" (bring-in) and "7" (all-in) handled in streets_actions.
+#   - maxseats: parsed from the <tablesize> XML tag rather than guessed.
+#   - All-in in the blinds: handled by the tournament blind fix-up in
+#     streets_actions (previously the blocker that made tournaments unparseable).
+#   - Hand IDs are stored directly from the <game gamecode="..."> attribute.
 #
-# -- No support for tournaments (see also the last item below)
-# -- Assumes that the currency of ring games is USD
-# -- No support for a bring-in or for antes (is the latter in fact unnecessary
-#    for hold 'em on Carbon?)
-# -- hand.maxseats can only be guessed at
-# -- The last hand in a history file will often be incomplete and is therefore
-#    rejected
-# -- Is behaviour currently correct when someone shows an uncalled hand?
-# -- Information may be lost when the hand ID is converted from the native form
-#    handid-yyy(y*) to handidyyy(y*) (in principle this should be stored as
-#    a string, but the database does not support this). Is there a possibility
-#    of collision between hand IDs that ought to be distinct?
-# -- Cannot parse tables that run it twice (nor is this likely ever to be
-#    possible)
-# -- Cannot parse hands in which someone is all in in one of the blinds. Until
-#    this is corrected tournaments will be unparseable
+# Known remaining limitations:
+#   - Run-it-twice tables are not supported (iPoker does not expose this).
+#   - Tournament game-type detection currently falls back to "ring" when
+#     _process_tournament_info() cannot extract the tournament fields; this path
+#     lacks end-to-end regression coverage - see the iPoker tournament fixtures
+#     under regression-test-files/tour/iPoker/.
+
+from __future__ import annotations
 
 import datetime
 import decimal
@@ -891,6 +896,19 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
         mg["TOTBUYIN"] = tourney_info.get("TOTBUYIN", mg.get("TOTBUYIN"))
         mg["WIN"] = tourney_info.get("WIN")
 
+        # Fallbacks for the common iPoker layout that has no <tournamentcode> tag
+        # and whose <totalbuyin> only matches the permissive re_buyin pattern:
+        #   - tourNo is already parsed from the table name by
+        #     _extract_tournament_number (stored in self.tinfo),
+        #   - the total buy-in can still be read with re_buyin.
+        # Without these, tournaments were misdetected as ring games.
+        if not mg.get("TOURNO"):
+            mg["TOURNO"] = self.tinfo.get("tourNo")
+        if not mg.get("TOTBUYIN"):
+            total_buyin_match = self.re_buyin.search(hand_text)
+            if total_buyin_match:
+                mg["TOTBUYIN"] = total_buyin_match.group("TOTBUYIN")
+
         # Handle case where only TOTBUYIN present
         if mg["BIAMT"] is None and mg["BIRAKE"] is None and mg["TOTBUYIN"]:
             total_buyin_str = self.cleanIPokerMoney(mg["TOTBUYIN"])
@@ -903,8 +921,13 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
                 mg["BIRAKE"] = "0"
                 log.debug("No BIAMT/BIRAKE found, fallback with TOTBUYIN only.")
 
-        # Check essential info
-        if not mg.get("TOURNO") or not mg.get("NAME") or not mg.get("PLACE") or not mg.get("TOTBUYIN"):
+        # Check essential info. TOTBUYIN is intentionally not required: this method
+        # is only reached once the hand is already known to be a tournament (a
+        # <tournamentname>/<place> was found), and satellites/reward entries can
+        # have an empty <totalbuyin>. The buy-in amount is resolved separately by
+        # _process_buyin_info (defaulting to FREE/0), so its absence must not
+        # demote a genuine tournament back to a ring game.
+        if not mg.get("TOURNO") or not mg.get("NAME") or not mg.get("PLACE"):
             log.error("Missing essential tournament info: %s", tourney_info)
             log.debug(hand_text[:500])
             return False

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Tests for the headless (CLI) auto-import mode of GuiAutoImport.
+
+`GuiAutoImport(..., cli=True)` used to raise a bare NotImplementedError. It now
+builds a GUI-less importer and `run_headless()` drives the same import engine the
+GUI auto-import tab uses (autoSummaryGrab + runUpdated), stepped by a time.sleep
+loop instead of a Qt timer. These tests mock the Importer so no database is
+required — they cover the driver logic, not the import engine itself.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# GuiAutoImport uses legacy-style bare imports (e.g. ``import interlocks``), so
+# the fpdb_3_legacy package directory must be importable directly.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _make_settings(lock):
+    return {
+        "db-host": "localhost",
+        "db-user": "fpdb",
+        "db-password": "",
+        "db-databaseName": "fpdb",
+        "global_lock": lock,
+    }
+
+
+def _make_config(interval=5):
+    config = MagicMock()
+    config.get_import_parameters.return_value = {"interval": str(interval)}
+    config.get_supported_sites.return_value = []
+    config.get_db_parameters.return_value = {}
+    return config
+
+
+def _make_gui(settings, config):
+    """Build a headless GuiAutoImport with the Importer mocked out (no DB)."""
+    from fpdb_3_legacy import GuiAutoImport
+
+    with patch.object(GuiAutoImport.Importer, "Importer", return_value=MagicMock()):
+        return GuiAutoImport.GuiAutoImport(settings, config, cli=True)
+
+
+def test_cli_constructor_does_not_raise():
+    """cli=True must build a headless importer instead of raising."""
+    gui = _make_gui(_make_settings(MagicMock()), _make_config())
+    assert gui.cli is True
+    # Imported hands are fed to the HUD over ZMQ, exactly like the GUI.
+    gui.importer.setCallHud.assert_called_with(True)
+    gui.importer.setMode.assert_called_with("auto")
+
+
+def test_addtext_headless_routes_to_logger():
+    """In cli mode addText must log instead of emitting a Qt signal."""
+    gui = _make_gui(_make_settings(MagicMock()), _make_config())
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"], "log") as mock_log:
+        gui.addText("something went wrong\n", "error")
+        gui.addText("just fyi", "info")
+    mock_log.error.assert_called_once_with("something went wrong")
+    mock_log.info.assert_called_once_with("just fyi")
+
+
+def test_run_headless_aborts_when_lock_unavailable():
+    """If the global lock can't be taken, run_headless returns 1 and imports nothing."""
+    lock = MagicMock()
+    lock.acquire.return_value = False
+    gui = _make_gui(_make_settings(lock), _make_config())
+
+    assert gui.run_headless() == 1
+    gui.importer.runUpdated.assert_not_called()
+    lock.release.assert_not_called()
+
+
+def test_run_headless_imports_then_shuts_down_cleanly():
+    """A normal run imports at least one cycle then releases the lock on interrupt."""
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    gui = _make_gui(_make_settings(lock), _make_config(interval=1))
+    gui.updatePaths = MagicMock()
+
+    # Stop the otherwise-infinite loop after the first sleep.
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
+        rc = gui.run_headless(launch_hud=False)
+
+    assert rc == 0
+    gui.updatePaths.assert_called_once()
+    gui.importer.autoSummaryGrab.assert_any_call()  # per-cycle grab
+    gui.importer.runUpdated.assert_called_once()
+    gui.importer.autoSummaryGrab.assert_called_with(force=True)  # final grab
+    lock.release.assert_called_once()
+
+
+def test_run_headless_survives_a_failing_cycle():
+    """One failing import cycle must not kill the loop or leak the lock."""
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    gui = _make_gui(_make_settings(lock), _make_config(interval=1))
+    gui.updatePaths = MagicMock()
+    gui.importer.runUpdated.side_effect = RuntimeError("boom")
+
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
+        rc = gui.run_headless(launch_hud=False)
+
+    assert rc == 0
+    gui.importer.runUpdated.assert_called_once()  # cycle ran despite raising
+    lock.release.assert_called_once()  # lock still released
+
+
+def test_hud_base_path_is_module_dir_and_holds_hud_main():
+    """The HUD base path must resolve next to the module (holds HUD_main.pyw),
+    independent of sys.path[0]/CWD."""
+    from fpdb_3_legacy import GuiAutoImport
+
+    base = GuiAutoImport.GuiAutoImport._hud_base_path()
+    assert os.path.basename(base) == "fpdb_3_legacy"
+    assert os.path.isfile(os.path.join(base, "HUD_main.pyw"))
+
+
+def test_launch_hud_uses_module_relative_path(monkeypatch):
+    """_launch_hud must find HUD_main.pyw even when sys.path[0]/CWD are unrelated."""
+    settings = _make_settings(MagicMock())
+    settings["cl_options"] = ""
+    config = _make_config()
+    config.install_method = "source"
+    gui = _make_gui(settings, config)
+
+    gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
+    # Simulate a hostile launch environment.
+    monkeypatch.setattr(gui_mod.sys, "path", ["/nowhere", *sys.path])
+    monkeypatch.chdir("/tmp")
+
+    with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        gui._launch_hud()
+
+    command = mock_popen.call_args.args[0]
+    hud_path = command[0]
+    assert hud_path.endswith(os.path.join("fpdb_3_legacy", "HUD_main.pyw"))
+    assert os.path.isfile(hud_path)  # resolved to a real file regardless of CWD/sys.path
+
+
+def test_launch_hud_spawns_hud_main():
+    """_launch_hud builds a HUD_main command and spawns it via subprocess.Popen."""
+    settings = _make_settings(MagicMock())
+    settings["cl_options"] = "--config foo.xml"
+    config = _make_config()
+    config.install_method = "source"  # exercise the Linux/macOS/source branch
+    gui = _make_gui(settings, config)
+
+    gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
+    with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        gui._launch_hud()
+
+    mock_popen.assert_called_once()
+    command = mock_popen.call_args.args[0]
+    # The source/Linux/macOS branch builds a list command ending in HUD_main.pyw + cl_options.
+    assert any("HUD_main" in str(part) for part in command)
+    assert gui.pipe_to_hud is not None
+
+
+def test_run_headless_launches_and_stops_hud():
+    """With launch_hud=True the HUD subprocess is spawned then terminated on stop."""
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    gui = _make_gui(_make_settings(lock), _make_config(interval=1))
+    gui.updatePaths = MagicMock()
+
+    fake_hud = MagicMock()
+
+    def fake_launch():
+        gui.pipe_to_hud = fake_hud
+
+    gui._launch_hud = MagicMock(side_effect=fake_launch)
+
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
+        rc = gui.run_headless(launch_hud=True)
+
+    assert rc == 0
+    gui._launch_hud.assert_called_once()  # HUD was launched
+    fake_hud.terminate.assert_called_once()  # HUD was stopped on shutdown
+    assert gui.pipe_to_hud is None
+    lock.release.assert_called_once()
+
+
+def test_run_headless_passes_config_not_quiet_flag_to_hud():
+    """The HUD must receive the config path, never the auto-import's own -q flag."""
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    settings = _make_settings(lock)
+    settings["cl_options"] = "-q"  # what GuiAutoImport.main() would set
+    config = _make_config()
+    config.file = "/home/user/.fpdb/HUD_config.xml"
+    gui = _make_gui(settings, config)
+    gui.updatePaths = MagicMock()
+
+    captured = {}
+
+    def fake_launch():
+        captured["cl_options"] = gui.settings["cl_options"]
+        gui.pipe_to_hud = MagicMock()
+
+    gui._launch_hud = MagicMock(side_effect=fake_launch)
+
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
+        gui.run_headless(launch_hud=True)
+
+    assert captured["cl_options"] == "-c /home/user/.fpdb/HUD_config.xml"
+    assert "-q" not in captured["cl_options"]
+
+
+def test_run_headless_survives_hud_launch_failure():
+    """A HUD that fails to launch must not stop imports."""
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    gui = _make_gui(_make_settings(lock), _make_config(interval=1))
+    gui.updatePaths = MagicMock()
+    gui._launch_hud = MagicMock(side_effect=OSError("no HUD_main"))
+
+    with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
+        rc = gui.run_headless(launch_hud=True)
+
+    assert rc == 0
+    gui._launch_hud.assert_called_once()
+    gui.importer.runUpdated.assert_called_once()  # imports ran despite HUD failure
+    lock.release.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_guibulkimport_move_widgets.py
+++ b/test/test_guibulkimport_move_widgets.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for the GuiBulkImport "move imported/failed files" widgets.
+
+The Importer backend (setMoveImportedFiles/setMoveFailedFiles) is covered by
+test_importer_move_files.py; these tests cover the GUI wiring: that the widgets
+are built from settings and that load_clicked pushes their state into the
+importer via _apply_move_settings. The Importer is mocked so no DB is needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+pytest.importorskip("PySide6")
+
+
+def _make_config():
+    config = MagicMock()
+    config.supported_sites = {}  # no enabled sites -> empty import tree
+    return config
+
+
+def _make_widget(settings):
+    from fpdb_3_legacy import GuiBulkImport
+
+    with patch.object(GuiBulkImport.Importer, "Importer", return_value=MagicMock()):
+        return GuiBulkImport.GuiBulkImport(settings, _make_config())
+
+
+@pytest.fixture(scope="module")
+def _qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_widgets_built_from_settings(_qapp):
+    """Checkboxes and path fields reflect the persisted settings."""
+    settings = {
+        "moveimportedfiles": True,
+        "moveImportedFilesDir": "/data/imported",
+        "movefailedfiles": False,
+        "moveFailedFilesDir": "/data/failed",
+    }
+    w = _make_widget(settings)
+
+    assert w.moveImportedCheck.isChecked() is True
+    assert w.moveImportedDir.text() == "/data/imported"
+    assert w.moveFailedCheck.isChecked() is False
+    assert w.moveFailedDir.text() == "/data/failed"
+
+
+def test_defaults_when_settings_absent(_qapp):
+    """With no move settings the checkboxes are off and paths empty."""
+    w = _make_widget({})
+    assert w.moveImportedCheck.isChecked() is False
+    assert w.moveFailedCheck.isChecked() is False
+    assert w.moveImportedDir.text() == ""
+    assert w.moveFailedDir.text() == ""
+
+
+def test_apply_move_settings_pushes_widget_state_to_importer(_qapp):
+    """_apply_move_settings forwards the current widget state to the importer setters."""
+    w = _make_widget({})
+    w.moveImportedCheck.setChecked(True)
+    w.moveImportedDir.setText("/out/imported")
+    w.moveFailedCheck.setChecked(True)
+    w.moveFailedDir.setText("/out/failed")
+
+    w._apply_move_settings()
+
+    w.importer.setMoveImportedFiles.assert_called_once_with(True, "/out/imported")
+    w.importer.setMoveFailedFiles.assert_called_once_with(True, "/out/failed")
+
+
+def test_browse_into_updates_line_edit(_qapp):
+    """_browse_into writes the chosen directory into the given field."""
+    from PySide6.QtWidgets import QLineEdit
+
+    from fpdb_3_legacy import GuiBulkImport
+
+    w = _make_widget({})
+    field = QLineEdit()
+    with patch.object(GuiBulkImport.QFileDialog, "getExistingDirectory", return_value="/picked/dir"):
+        w._browse_into(field)
+    assert field.text() == "/picked/dir"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_importer_move_files.py
+++ b/test/test_importer_move_files.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Tests for Importer file-relocation after import (moveimported/movefailed files).
+
+The old code hardcoded the two flags to False and moved files to Windows-only
+paths (``c:\\fpdbimported``) using a fragile ``f[3:]`` slice with inverted
+failed-file semantics. It is now driven by importer settings, portable, and
+correct: successful imports go to the imported dir, files with errors to the
+failed dir. These tests exercise the relocation helper directly (no DB needed).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy.Importer import Importer
+
+
+def _make_importer(settings):
+    """Build an Importer shell without running its DB-connecting __init__."""
+    imp = Importer.__new__(Importer)
+    imp.settings = settings
+    return imp
+
+
+def _touch(path):
+    with open(path, "w") as fh:
+        fh.write("hh")
+
+
+def test_no_move_when_disabled_by_default(tmp_path):
+    """With no move settings, files stay put."""
+    src = tmp_path / "hand1.txt"
+    _touch(src)
+    imp = _make_importer({})
+
+    imp._relocate_processed_file(str(src), failed=False)
+    imp._relocate_processed_file(str(src), failed=True)
+
+    assert src.exists()  # untouched
+
+
+def test_moves_imported_file_to_configured_dir(tmp_path):
+    """A successful import is moved to moveImportedFilesDir (created if needed)."""
+    src = tmp_path / "hand2.txt"
+    _touch(src)
+    dest_dir = tmp_path / "archive" / "imported"  # does not exist yet
+    imp = _make_importer(
+        {"moveimportedfiles": True, "moveImportedFilesDir": str(dest_dir)},
+    )
+
+    imp._relocate_processed_file(str(src), failed=False)
+
+    assert not src.exists()
+    assert (dest_dir / "hand2.txt").exists()  # basename preserved, dir created
+
+
+def test_moves_failed_file_to_failed_dir(tmp_path):
+    """A failed import goes to moveFailedFilesDir, not the imported dir."""
+    src = tmp_path / "bad.txt"
+    _touch(src)
+    imported_dir = tmp_path / "imported"
+    failed_dir = tmp_path / "failed"
+    imp = _make_importer(
+        {
+            "moveimportedfiles": True,
+            "moveImportedFilesDir": str(imported_dir),
+            "movefailedfiles": True,
+            "moveFailedFilesDir": str(failed_dir),
+        },
+    )
+
+    imp._relocate_processed_file(str(src), failed=True)
+
+    assert (failed_dir / "bad.txt").exists()
+    assert not (imported_dir / "bad.txt").exists()
+
+
+def test_move_disabled_when_flag_off_even_with_dir(tmp_path):
+    """A configured dir alone does not move files; the flag must be on."""
+    src = tmp_path / "hand3.txt"
+    _touch(src)
+    imp = _make_importer(
+        {"moveimportedfiles": False, "moveImportedFilesDir": str(tmp_path / "imported")},
+    )
+
+    imp._relocate_processed_file(str(src), failed=False)
+
+    assert src.exists()
+
+
+def test_setters_populate_settings():
+    """The setters wire the flags/dirs into settings for the GUI to drive."""
+    imp = _make_importer({})
+    imp.setMoveImportedFiles(True, "/data/imported")
+    imp.setMoveFailedFiles(True, "/data/failed")
+
+    assert imp.settings["moveimportedfiles"] is True
+    assert imp.settings["moveImportedFilesDir"] == "/data/imported"
+    assert imp.settings["movefailedfiles"] is True
+    assert imp.settings["moveFailedFilesDir"] == "/data/failed"
+
+
+def test_move_failure_is_swallowed(tmp_path):
+    """A move that fails (missing source) is logged, not raised."""
+    imp = _make_importer(
+        {"moveimportedfiles": True, "moveImportedFilesDir": str(tmp_path / "imported")},
+    )
+    # Source does not exist -> shutil.move raises, helper must swallow it.
+    imp._relocate_processed_file(str(tmp_path / "nope.txt"), failed=False)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])

--- a/test/test_ipoker_tournament_detection.py
+++ b/test/test_ipoker_tournament_detection.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Regression tests for iPoker tournament vs ring game detection.
+
+iPoker tournaments whose XML has no <tournamentcode> tag (the majority format)
+were misdetected as ring games: determineGameType set type="tour" from the
+<tournamentname>/<place> markers, but _process_standard_tournament_info then
+returned False (it required TOURNO from <tournamentcode> and a non-empty
+<totalbuyin>), so _handle_ring_game_logic demoted them back to "ring".
+
+The fix: fall back TOURNO to the tourNo already parsed from <tablename>, read the
+total buy-in with the permissive re_buyin, and stop requiring TOTBUYIN to
+classify a hand that is already known to be a tournament.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy.Configuration import Config
+from fpdb_3_legacy.iPokerToFpdb import iPoker
+
+TOUR_FILES = sorted(glob.glob("regression-test-files/tour/iPoker/**/*.txt", recursive=True))
+CASH_FILES = sorted(glob.glob("regression-test-files/cash/iPoker/**/*.txt", recursive=True))
+
+
+def _detect_type(config, filepath):
+    """Run determineGameType on the first hand of an iPoker file."""
+    with open(filepath, encoding="cp1252") as fh:
+        content = fh.read()
+    parser = iPoker(config, in_path=filepath, autostart=False)
+    parser.whole_file = content
+    first_hand = content.split("</game>")[0] + "</game>"
+    gametype = parser.determineGameType(first_hand)
+    return (gametype or {}).get("type"), parser
+
+
+@pytest.fixture(scope="module")
+def config():
+    return Config()
+
+
+@pytest.mark.skipif(not TOUR_FILES, reason="no iPoker tournament fixtures found")
+@pytest.mark.parametrize("filepath", TOUR_FILES, ids=lambda p: os.path.basename(p))
+def test_tournament_files_detected_as_tour(config, filepath):
+    """Every iPoker tournament fixture must be classified as a tournament."""
+    game_type, parser = _detect_type(config, filepath)
+    assert game_type == "tour", f"{os.path.basename(filepath)} misdetected as {game_type!r}"
+    # tourNo must be parsed even without a <tournamentcode> tag.
+    assert (parser.tinfo or {}).get("tourNo"), "tourNo should be parsed from the table name"
+
+
+@pytest.mark.skipif(not CASH_FILES, reason="no iPoker cash fixtures found")
+@pytest.mark.parametrize("filepath", CASH_FILES, ids=lambda p: os.path.basename(p))
+def test_cash_files_not_detected_as_tour(config, filepath):
+    """Ring games must not be promoted to tournaments by the relaxed check."""
+    game_type, _ = _detect_type(config, filepath)
+    assert game_type != "tour", f"{os.path.basename(filepath)} wrongly detected as tour"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

An audit of `TODO`/`FIXME`/`STUB`/`NotImplemented` markers found that most were **stale comments on code that was actually implemented** — but the audit also surfaced **several real bugs** and a couple of genuinely dead/broken features. This PR cleans up the misleading markers and fixes the underlying issues, with tests.

## Stale-marker cleanup (behaviour-preserving)

- **`CakeToFpdb.compilePlayerRegexs`** — documented no-op (Cake uses player-independent regexes); fixed the misleading `list[re.Pattern]`/`list[str]` signature.
- **`WinningToFpdb.readTourneyResults`** — honest no-op (Winning HHs carry no per-hand tourney results); dropped the stray `"for Winamax"` INFO log emitted every hand, and the stale TODO.
- **`iPoker/base.py` & `Hud.py`** — replaced stale *"implement missing features"* / *"complete HUD"* comments with accurate status (both are, in fact, complete).

## Real bugs fixed

- **`from __future__ import annotations` trapped inside the module docstring** (thus inactive) in `iPoker/base.py`, `Hud.py` and `GuiBulkImport.py` — moved to a real import.
- **iPoker tournament detection** — tournaments **without a `<tournamentcode>` tag** (the majority format) were misdetected as **ring games**. Now falls back `TOURNO` to the tourNo already parsed from `<tablename>`, reads the total buy-in with the permissive `re_buyin`, and stops requiring `TOTBUYIN` to classify a hand already known to be a tournament.
  - Fixture detection: **2/9 → 9/9** tournaments correctly detected, **0/23** cash files misclassified.
- **Importer file relocation (`moveimported`/`movefailed`)** — was dead (hardcoded `False`) and broken (Windows-only `c:\` paths, fragile `f[3:]` slice, inverted failed-file semantics). Now portable, driven by settings, correct semantics (successful imports → imported dir, errors → failed dir), with `setMoveImportedFiles`/`setMoveFailedFiles` setters.

## New features

- **Headless auto-import (`GuiAutoImport -q`)** — previously raised a bare `NotImplementedError`. Now `run_headless()` drives the same import engine as the GUI on a `time.sleep` loop, acquires/releases the global lock, and **launches + feeds the HUD** (`setCallHud` + `_launch_hud`, extracted and shared with `startClicked`). The HUD path resolves via `__file__` (`_hud_base_path`), independent of `sys.path[0]`/CWD, and the HUD is passed the config path rather than the auto-import's own `-q` flag. Verified end-to-end (real launch: import loop runs, HUD spawns and is fed, clean shutdown, no orphaned process).
- **GuiBulkImport** — checkboxes + directory pickers for move imported/failed files, wired to the importer setters via `_apply_move_settings`. Verified with a real offscreen render.

## Tests

New: `test_guiautoimport_headless.py`, `test_importer_move_files.py`, `test_ipoker_tournament_detection.py`, `test_guibulkimport_move_widgets.py` (~53 tests). Existing iPoker/HUD/import suites still pass.
