### PR TITLE
Replace Py2-era bytes-decode dirty hack with an isinstance check

### DIFF
--- a/fpdb_3_legacy/IdentifySite.py
+++ b/fpdb_3_legacy/IdentifySite.py
@@ -493,10 +493,9 @@ class IdentifySite:
     def fetchGameTypes(self) -> None:
         for name, f in list(self.filelist.items()):
             if f.ftype is not None and f.ftype == "hh":
-                try:  # TODO: this is a dirty hack. Borrowed from fpdb_import
-                    name = str(name, "utf8", "replace")
-                except TypeError:
-                    log.exception(TypeError)
+                # Filenames are str on Python 3; decode only if a bytes path slips in.
+                if isinstance(name, bytes):
+                    name = name.decode("utf8", "replace")
                 obj = get_parser_class(f.site.filter_name)
                 hhc = obj(
                     self.config,

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -400,10 +400,9 @@ class Importer:
             fpdbfile: The file object to add and update with a file ID.
         """
         file = os.path.splitext(os.path.basename(fpdbfile.path))[0]
-        try:  # TODO: this is a dirty hack. GBI needs it, GAI fails with it.
-            file = str(file, "utf8", "replace")
-        except TypeError:
-            pass
+        # Filenames are str on Python 3; decode only if a bytes path slips in.
+        if isinstance(file, bytes):
+            file = file.decode("utf8", "replace")
         fpdbfile.fileId = self.database.get_id(file)
         if not fpdbfile.fileId:
             now = datetime.datetime.utcnow()


### PR DESCRIPTION
## Summary

Follow-up to #143 (the bytes-decode commit landed after #143 was already merged, so it needs its own PR).

`IdentifySite.fetchGameTypes` and `Importer.addFileToList` decoded filenames with `str(x, "utf8", "replace")` wrapped in a `try/except TypeError`. On Python 3 filenames are always `str`, so that call always raised `TypeError` and was always swallowed — a no-op that also made `IdentifySite` log an exception for **every** hand-history file.

Replaced both with `if isinstance(x, bytes): x = x.decode("utf8", "replace")`:
- behaviour-preserving for `str` (the normal case),
- still correct for a stray bytes path,
- no more per-file exception logging.

## Verification

Compile OK (uv/3.13), ruff unchanged, behaviour equivalent. Pre-existing test failures (`'Mock' object is not iterable` in `test_pokerstars*`, bare `import Importer` in `test_error_triggers_autopop`) are unrelated — verified identical with the change stashed.
