### PR TITLE
GUI database configuration for SQLite / PostgreSQL / MySQL (Phase 0+1)

### DIFF
--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -2228,17 +2228,17 @@ class Config:
                 db_node.removeAttribute("default")
         if db_name in self.supported_databases:
             if db_desc is not None:
-                self.supported_databases[db_name].dp_desc = db_desc
+                self.supported_databases[db_name].db_desc = db_desc
             if db_ip is not None:
-                self.supported_databases[db_name].dp_ip = db_ip
+                self.supported_databases[db_name].db_ip = db_ip
             if db_port is not None:
-                self.supported_databases[db_name].dp_port = db_port
+                self.supported_databases[db_name].db_port = db_port
             if db_user is not None:
-                self.supported_databases[db_name].dp_user = db_user
+                self.supported_databases[db_name].db_user = db_user
             if db_pass is not None:
-                self.supported_databases[db_name].dp_pass = db_pass
+                self.supported_databases[db_name].db_pass = db_pass
             if db_server is not None:
-                self.supported_databases[db_name].dp_server = db_server
+                self.supported_databases[db_name].db_server = db_server
             self.supported_databases[db_name].db_selected = defaultb
         if defaultb:
             self.db_selected = db_name
@@ -2311,17 +2311,17 @@ class Config:
 
         if db_name in self.supported_databases:
             if db_desc is not None:
-                self.supported_databases[db_name].dp_desc = db_desc
+                self.supported_databases[db_name].db_desc = db_desc
             if db_ip is not None:
-                self.supported_databases[db_name].dp_ip = db_ip
+                self.supported_databases[db_name].db_ip = db_ip
             if db_port is not None:
-                self.supported_databases[db_name].dp_port = db_port
+                self.supported_databases[db_name].db_port = db_port
             if db_user is not None:
-                self.supported_databases[db_name].dp_user = db_user
+                self.supported_databases[db_name].db_user = db_user
             if db_pass is not None:
-                self.supported_databases[db_name].dp_pass = db_pass
+                self.supported_databases[db_name].db_pass = db_pass
             if db_server is not None:
-                self.supported_databases[db_name].dp_server = db_server
+                self.supported_databases[db_name].db_server = db_server
             self.supported_databases[db_name].db_selected = defaultb
         else:
             db = Database(node=db_node)
@@ -2329,6 +2329,19 @@ class Config:
 
         if defaultb:
             self.db_selected = db_name
+
+    def del_db_parameters(self, db_name="fpdb") -> None:
+        """Remove a database from the config (both the XML node and the cache).
+
+        If the removed database was the selected one, another configured
+        database (if any) becomes the selection.
+        """
+        db_node = self.get_db_node(db_name)
+        if db_node is not None and db_node.parentNode is not None:
+            db_node.parentNode.removeChild(db_node)
+        self.supported_databases.pop(db_name, None)
+        if self.db_selected == db_name:
+            self.db_selected = next(iter(self.supported_databases), None)
 
     def get_backend(self, name):
         """Returns the number of the currently used backend."""

--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -226,6 +226,11 @@ class GuiDatabase(QWidget):
         self.refresh()
 
     def apply_delete(self, db_name: str) -> None:
+        # fpdb refuses to start with an empty <supported_databases>, so never
+        # remove the last configured database.
+        if len(getattr(self.config, "supported_databases", {})) <= 1:
+            msg = "Cannot delete the last database — fpdb needs at least one."
+            raise ValueError(msg)
         self.config.del_db_parameters(db_name)
         self.config.save()
         self.refresh()
@@ -260,6 +265,14 @@ class GuiDatabase(QWidget):
     def _on_delete(self) -> None:
         name = self.selected_db_name()
         if name is None:
+            return
+        if len(getattr(self.config, "supported_databases", {})) <= 1:
+            QMessageBox.warning(
+                self,
+                "Delete database",
+                "This is the only configured database and cannot be deleted — "
+                "fpdb needs at least one. Add another database first.",
+            )
             return
         confirm = QMessageBox.question(
             self, "Delete database", f"Remove '{name}' from the configuration?\n(The database itself is not deleted.)",

--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -1,0 +1,273 @@
+"""GuiDatabase — configure the fpdb database backend from the GUI.
+
+Lets the user list, add, edit, delete and select the configured databases and
+test a connection before saving, for all supported backends (SQLite, PostgreSQL,
+MySQL/MariaDB). The heavy lifting lives elsewhere: connection testing in
+``db_backends`` and persistence in ``Configuration`` (``add_db_parameters`` /
+``set_db_parameters`` / ``del_db_parameters`` + ``save``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fpdb_3_legacy import db_backends
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("gui_database")
+
+# Server fields that only apply to client/server backends (not SQLite).
+_SERVER_BACKENDS = ("postgresql", "mysql")
+
+
+class DatabaseEditDialog(QDialog):
+    """Add/edit form for a single database entry, with a connection tester."""
+
+    def __init__(self, config: Any, existing: Any = None, parent: Any = None) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.existing = existing  # a Configuration.Database or None (add mode)
+        self.setWindowTitle("Edit database" if existing else "Add database")
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.nameEdit = QLineEdit(getattr(existing, "db_name", ""))
+        if existing is not None:
+            self.nameEdit.setEnabled(False)  # the name is the identity key
+        form.addRow("Name:", self.nameEdit)
+
+        self.backendCombo = QComboBox()
+        self._populate_backends(getattr(existing, "db_server", "sqlite"))
+        self.backendCombo.currentIndexChanged.connect(self._on_backend_changed)
+        form.addRow("Backend:", self.backendCombo)
+
+        self.hostEdit = QLineEdit(getattr(existing, "db_ip", "") or "localhost")
+        self.portEdit = QLineEdit(getattr(existing, "db_port", "") or "")
+        self.userEdit = QLineEdit(getattr(existing, "db_user", "") or "")
+        self.passwordEdit = QLineEdit(getattr(existing, "db_pass", "") or "")
+        self.passwordEdit.setEchoMode(QLineEdit.EchoMode.Password)
+        self._host_row = ("Host:", self.hostEdit)
+        form.addRow(*self._host_row)
+        form.addRow("Port:", self.portEdit)
+        form.addRow("User:", self.userEdit)
+        form.addRow("Password:", self.passwordEdit)
+        self._form = form
+        layout.addLayout(form)
+
+        # Test connection row.
+        test_row = QHBoxLayout()
+        self.testButton = QPushButton("Test connection")
+        self.testButton.clicked.connect(self._on_test)
+        test_row.addWidget(self.testButton)
+        self.testResult = QLabel("")
+        test_row.addWidget(self.testResult)
+        layout.addLayout(test_row)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self._on_backend_changed()
+
+    def _populate_backends(self, selected: str) -> None:
+        """Fill the backend combo; disable backends whose driver is missing."""
+        available = db_backends.available_backends()
+        for server, (label, _driver, _needs) in db_backends.BACKENDS.items():
+            display = label if available[server] else f"{label} (driver not installed)"
+            self.backendCombo.addItem(display, server)
+            index = self.backendCombo.count() - 1
+            if not available[server]:
+                # Disable the item so an unusable backend cannot be selected.
+                self.backendCombo.model().item(index).setEnabled(False)
+        idx = self.backendCombo.findData(selected or "sqlite")
+        if idx >= 0:
+            self.backendCombo.setCurrentIndex(idx)
+
+    def current_backend(self) -> str:
+        return self.backendCombo.currentData()
+
+    def _on_backend_changed(self, *_args) -> None:
+        """Show host/port/user/password only for client/server backends."""
+        is_server = self.current_backend() in _SERVER_BACKENDS
+        for widget in (self.hostEdit, self.portEdit, self.userEdit, self.passwordEdit):
+            widget.setVisible(is_server)
+            label = self._form.labelForField(widget)
+            if label is not None:
+                label.setVisible(is_server)
+        self.testResult.setText("")
+
+    def values(self) -> dict[str, str]:
+        """Return the entered values as a dict of Configuration setter kwargs."""
+        server = self.current_backend()
+        result = {"db_name": self.nameEdit.text().strip(), "db_server": server}
+        if server in _SERVER_BACKENDS:
+            result["db_ip"] = self.hostEdit.text().strip()
+            result["db_port"] = self.portEdit.text().strip()
+            result["db_user"] = self.userEdit.text().strip()
+            result["db_pass"] = self.passwordEdit.text()
+        return result
+
+    def _on_test(self) -> None:
+        result = self.test_connection()
+        color = "green" if result.ok else "red"
+        mark = "✓" if result.ok else "✗"
+        self.testResult.setText(f"{mark} {result.message}")
+        self.testResult.setStyleSheet(f"color: {color};")
+
+    def test_connection(self) -> db_backends.ConnectionResult:
+        """Test the currently entered parameters (used by the Test button and tests)."""
+        vals = self.values()
+        server = vals["db_server"]
+        if not vals["db_name"]:
+            return db_backends.ConnectionResult(ok=False, message="A database name is required.")
+        if server == "sqlite":
+            return db_backends.test_connection(
+                "sqlite", database=vals["db_name"], sqlite_dir=getattr(self.config, "dir_database", None),
+            )
+        return db_backends.test_connection(
+            server,
+            database=vals["db_name"],
+            host=vals.get("db_ip"),
+            port=vals.get("db_port"),
+            user=vals.get("db_user"),
+            password=vals.get("db_pass"),
+        )
+
+
+class GuiDatabase(QWidget):
+    """Panel listing configured databases with add/edit/delete/select actions."""
+
+    _COLUMNS = ("Name", "Backend", "Host / Path", "User", "Default")
+
+    def __init__(self, config: Any, parent: Any = None) -> None:
+        super().__init__(parent)
+        self.config = config
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Configured databases:"))
+
+        self.table = QTableWidget(0, len(self._COLUMNS))
+        self.table.setHorizontalHeaderLabels(self._COLUMNS)
+        self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        buttons = QHBoxLayout()
+        self.addButton = QPushButton("Add...")
+        self.editButton = QPushButton("Edit...")
+        self.deleteButton = QPushButton("Delete")
+        self.defaultButton = QPushButton("Set as default")
+        self.addButton.clicked.connect(self._on_add)
+        self.editButton.clicked.connect(self._on_edit)
+        self.deleteButton.clicked.connect(self._on_delete)
+        self.defaultButton.clicked.connect(self._on_set_default)
+        for b in (self.addButton, self.editButton, self.deleteButton, self.defaultButton):
+            buttons.addWidget(b)
+        layout.addLayout(buttons)
+
+        self.refresh()
+
+    # --- table -------------------------------------------------------------
+
+    def refresh(self) -> None:
+        """Rebuild the table from the current config.supported_databases."""
+        databases = getattr(self.config, "supported_databases", {})
+        selected = getattr(self.config, "db_selected", None)
+        self.table.setRowCount(0)
+        for db in databases.values():
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            host_or_path = db.db_ip if db.db_server in _SERVER_BACKENDS else (db.db_path or "(default dir)")
+            cells = [
+                db.db_name,
+                db_backends.BACKENDS.get(db.db_server, (db.db_server,))[0],
+                host_or_path or "",
+                db.db_user or "",
+                "✓" if db.db_name == selected else "",
+            ]
+            for col, text in enumerate(cells):
+                self.table.setItem(row, col, QTableWidgetItem(str(text)))
+
+    def selected_db_name(self) -> str | None:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        return item.text() if item is not None else None
+
+    # --- actions (config mutation is factored out so it can be unit-tested) ---
+
+    def apply_add(self, values: dict[str, str]) -> None:
+        self.config.add_db_parameters(**values)
+        self.config.save()
+        self.refresh()
+
+    def apply_edit(self, values: dict[str, str]) -> None:
+        self.config.set_db_parameters(**values)
+        self.config.save()
+        self.refresh()
+
+    def apply_delete(self, db_name: str) -> None:
+        self.config.del_db_parameters(db_name)
+        self.config.save()
+        self.refresh()
+
+    def apply_set_default(self, db_name: str) -> None:
+        self.config.set_db_parameters(db_name=db_name, default="True")
+        self.config.save()
+        self.refresh()
+
+    # --- button handlers ---------------------------------------------------
+
+    def _on_add(self) -> None:
+        dialog = DatabaseEditDialog(self.config, existing=None, parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            values = dialog.values()
+            if not values["db_name"]:
+                QMessageBox.warning(self, "Add database", "A database name is required.")
+                return
+            try:
+                self.apply_add(values)
+            except ValueError as exc:  # duplicate name
+                QMessageBox.warning(self, "Add database", str(exc))
+
+    def _on_edit(self) -> None:
+        name = self.selected_db_name()
+        if name is None:
+            return
+        dialog = DatabaseEditDialog(self.config, existing=self.config.supported_databases.get(name), parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            self.apply_edit(dialog.values())
+
+    def _on_delete(self) -> None:
+        name = self.selected_db_name()
+        if name is None:
+            return
+        confirm = QMessageBox.question(
+            self, "Delete database", f"Remove '{name}' from the configuration?\n(The database itself is not deleted.)",
+        )
+        if confirm == QMessageBox.StandardButton.Yes:
+            self.apply_delete(name)
+
+    def _on_set_default(self) -> None:
+        name = self.selected_db_name()
+        if name is not None:
+            self.apply_set_default(name)

--- a/fpdb_3_legacy/db_backends.py
+++ b/fpdb_3_legacy/db_backends.py
@@ -1,0 +1,187 @@
+"""Backend-agnostic helpers for the database configuration GUI.
+
+Pure helpers (no Config or Database instance required) to discover which
+database drivers are installed and to test a set of connection parameters
+before persisting them. This keeps the GUI decoupled from the heavyweight
+``Database`` class, which mutates a lot of global/instance state on connect.
+
+The ``db_server`` strings match the ``<database db_server="...">`` values in
+HUD_config.xml, and the numeric ids match the backend constants used by
+``Database`` (MYSQL_INNODB=2, PGSQL=3, SQLITE=4) via ``Config.get_backend``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from dataclasses import dataclass
+
+# db_server -> (human label, driver module name, needs host/port/user/pass fields)
+BACKENDS: dict[str, tuple[str, str, bool]] = {
+    "sqlite": ("SQLite", "sqlite3", False),
+    "postgresql": ("PostgreSQL", "psycopg", True),
+    "mysql": ("MySQL / MariaDB", "MySQLdb", True),
+}
+
+# db_server -> numeric backend id (kept in sync with Database.{MYSQL_INNODB,PGSQL,SQLITE}).
+BACKEND_IDS: dict[str, int] = {"mysql": 2, "postgresql": 3, "sqlite": 4}
+
+
+def backend_id(server: str) -> int:
+    """Return the numeric backend id for a ``db_server`` string."""
+    try:
+        return BACKEND_IDS[server]
+    except KeyError:
+        msg = f"Unsupported database backend: {server}"
+        raise ValueError(msg) from None
+
+
+def driver_available(server: str) -> bool:
+    """Return True if the Python driver for ``server`` is importable."""
+    try:
+        module_name = BACKENDS[server][1]
+    except KeyError:
+        return False
+    return importlib.util.find_spec(module_name) is not None
+
+
+def available_backends() -> dict[str, bool]:
+    """Map each supported ``db_server`` to whether its driver is installed."""
+    return {server: driver_available(server) for server in BACKENDS}
+
+
+@dataclass
+class ConnectionResult:
+    """Outcome of a connection test: success flag plus a human-readable message."""
+
+    ok: bool
+    message: str
+
+
+def test_connection(
+    server: str,
+    *,
+    database: str | None = None,
+    host: str | None = None,
+    port: str | int | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    sqlite_dir: str | None = None,
+) -> ConnectionResult:
+    """Attempt a real connection with the given parameters and report the result.
+
+    The connection is opened and immediately closed; nothing is written. For
+    SQLite, if the test has to create a brand-new empty database file it is
+    removed again so the test stays non-destructive.
+
+    Args:
+        server: One of ``sqlite`` / ``postgresql`` / ``mysql``.
+        database: Database name (SQLite: file name, or ``:memory:``).
+        host, port, user, password: Server connection parameters (PG/MySQL).
+        sqlite_dir: Directory that holds the SQLite file (``Config.dir_database``).
+
+    Returns:
+        ConnectionResult: ``ok`` and a message suitable for display.
+    """
+    if server not in BACKENDS:
+        return ConnectionResult(ok=False, message=f"Unsupported database backend: {server!r}")
+    if not driver_available(server):
+        driver = BACKENDS[server][1]
+        return ConnectionResult(ok=False, message=f"Driver '{driver}' is not installed for {server}.")
+
+    try:
+        if server == "sqlite":
+            return _test_sqlite(database, sqlite_dir)
+        if server == "postgresql":
+            return _test_postgresql(database, host, port, user, password)
+        return _test_mysql(database, host, port, user, password)
+    except Exception as exc:  # noqa: BLE001 - surface any driver error as a friendly message
+        return ConnectionResult(ok=False, message=str(exc))
+
+
+def _coerce_port(port: str | int | None) -> int | None:
+    if port in (None, ""):
+        return None
+    return int(port)
+
+
+def _test_sqlite(database: str | None, sqlite_dir: str | None) -> ConnectionResult:
+    import sqlite3
+
+    name = database or "fpdb.db3"
+    if name == ":memory:":
+        path = ":memory:"
+        pre_existing = True  # nothing to clean up
+    else:
+        path = os.path.join(sqlite_dir, name) if sqlite_dir else name
+        pre_existing = os.path.exists(path)
+        parent = os.path.dirname(path) or "."
+        if not pre_existing and not os.path.isdir(parent):
+            return ConnectionResult(ok=False, message=f"Directory does not exist: {parent}")
+
+    conn = sqlite3.connect(path, timeout=5.0)
+    try:
+        conn.execute("SELECT 1")
+    finally:
+        conn.close()
+        # Do not leave an empty file behind if the test created it.
+        if path != ":memory:" and not pre_existing and os.path.exists(path) and os.path.getsize(path) == 0:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+    return ConnectionResult(ok=True, message=f"SQLite OK — {path}")
+
+
+def _test_postgresql(database, host, port, user, password) -> ConnectionResult:
+    import psycopg
+
+    try:
+        conn = psycopg.connect(
+            host=host or None,
+            port=_coerce_port(port),
+            user=user or None,
+            password=password or None,
+            dbname=database or None,
+            connect_timeout=5,
+        )
+    except psycopg.OperationalError as exc:
+        text = str(exc)
+        if "password authentication" in text or "role" in text:
+            return ConnectionResult(ok=False, message=f"Access denied: {text.strip()}")
+        if "does not exist" in text:
+            return ConnectionResult(ok=False, message=f"Database not found: {text.strip()}")
+        if "Connection refused" in text or "could not connect" in text:
+            return ConnectionResult(ok=False, message=f"Server unreachable: {text.strip()}")
+        return ConnectionResult(ok=False, message=text.strip())
+    conn.close()
+    return ConnectionResult(ok=True, message=f"PostgreSQL OK — {database}@{host or 'localhost'}")
+
+
+def _test_mysql(database, host, port, user, password) -> ConnectionResult:
+    import MySQLdb
+
+    kwargs = {
+        "host": host or "localhost",
+        "user": user or None,
+        "passwd": password or "",
+        "db": database or None,
+        "connect_timeout": 5,
+    }
+    coerced_port = _coerce_port(port)
+    if coerced_port:
+        kwargs["port"] = coerced_port
+    try:
+        conn = MySQLdb.connect(**kwargs)
+    except MySQLdb.Error as exc:
+        code = exc.args[0] if exc.args else 0
+        text = exc.args[1] if len(exc.args) > 1 else str(exc)
+        if code == 1045:
+            return ConnectionResult(ok=False, message=f"Access denied: {text}")
+        if code in (2002, 2003):
+            return ConnectionResult(ok=False, message=f"Server unreachable: {text}")
+        if code == 1049:
+            return ConnectionResult(ok=False, message=f"Database not found: {text}")
+        return ConnectionResult(ok=False, message=text)
+    conn.close()
+    return ConnectionResult(ok=True, message=f"MySQL OK — {database}@{host or 'localhost'}")

--- a/test/test_config_db_parameters.py
+++ b/test/test_config_db_parameters.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Round-trip tests for the Configuration database-parameter API.
+
+Covers add_db_parameters / set_db_parameters / del_db_parameters against a real
+Config backed by a temporary copy of HUD_config.xml — including the in-memory
+supported_databases cache (which previously had a dp_/db_ typo) and persistence
+across reload.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy import Configuration
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG_TEMPLATE = os.path.join(REPO_ROOT, "HUD_config.xml")
+
+
+@pytest.fixture
+def config(tmp_path):
+    cfg_path = tmp_path / "HUD_config.xml"
+    shutil.copy(CONFIG_TEMPLATE, cfg_path)
+    return Configuration.Config(file=str(cfg_path))
+
+
+def test_add_database_appears_in_supported(config):
+    config.add_db_parameters(
+        db_name="pgtest", db_server="postgresql",
+        db_ip="dbhost", db_port="5432", db_user="alice", db_pass="secret",
+    )
+    assert "pgtest" in config.supported_databases
+    db = config.supported_databases["pgtest"]
+    assert db.db_server == "postgresql"
+    assert db.db_ip == "dbhost"
+    assert db.db_user == "alice"
+
+
+def test_add_duplicate_name_raises(config):
+    config.add_db_parameters(db_name="dup", db_server="sqlite")
+    with pytest.raises(ValueError, match="unique"):
+        config.add_db_parameters(db_name="dup", db_server="sqlite")
+
+
+def test_set_updates_in_memory_cache(config):
+    """set_db_parameters must update supported_databases (regression: dp_/db_ typo)."""
+    config.add_db_parameters(
+        db_name="edit_me", db_server="mysql", db_ip="old", db_user="olduser",
+    )
+    config.set_db_parameters(db_name="edit_me", db_ip="newhost", db_user="newuser")
+    db = config.supported_databases["edit_me"]
+    assert db.db_ip == "newhost"
+    assert db.db_user == "newuser"
+
+
+def test_set_default_switches_selection(config):
+    config.add_db_parameters(db_name="other", db_server="sqlite")
+    config.set_db_parameters(db_name="other", default="True")
+    assert config.db_selected == "other"
+    assert config.supported_databases["other"].db_selected is True
+
+
+def test_delete_removes_database(config):
+    config.add_db_parameters(db_name="temp", db_server="sqlite")
+    assert "temp" in config.supported_databases
+    config.del_db_parameters("temp")
+    assert "temp" not in config.supported_databases
+
+
+def test_delete_selected_reassigns_selection(config):
+    config.add_db_parameters(db_name="willgo", db_server="sqlite", default="True")
+    assert config.db_selected == "willgo"
+    config.del_db_parameters("willgo")
+    # Selection must fall back to some remaining database, not dangle.
+    assert config.db_selected != "willgo"
+    assert config.db_selected in set(config.supported_databases) | {None}
+
+
+def test_changes_persist_after_save_and_reload(config, tmp_path):
+    config.add_db_parameters(
+        db_name="persisted", db_server="postgresql", db_ip="h", db_user="u", db_pass="p",
+    )
+    config.save()
+    reloaded = Configuration.Config(file=config.file)
+    assert "persisted" in reloaded.supported_databases
+    assert reloaded.supported_databases["persisted"].db_server == "postgresql"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_db_backends.py
+++ b/test/test_db_backends.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the backend-agnostic DB helpers (fpdb_3_legacy/db_backends.py)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy import db_backends
+
+
+def test_backend_id_matches_database_constants():
+    assert db_backends.backend_id("mysql") == 2
+    assert db_backends.backend_id("postgresql") == 3
+    assert db_backends.backend_id("sqlite") == 4
+
+
+def test_backend_id_rejects_unknown():
+    with pytest.raises(ValueError, match="Unsupported"):
+        db_backends.backend_id("oracle")
+
+
+def test_sqlite_driver_always_available():
+    backends = db_backends.available_backends()
+    assert backends["sqlite"] is True
+    assert set(backends) == {"sqlite", "postgresql", "mysql"}
+
+
+def test_available_backends_reflects_missing_driver():
+    with patch.object(db_backends.importlib.util, "find_spec", return_value=None):
+        backends = db_backends.available_backends()
+    assert backends == {"sqlite": False, "postgresql": False, "mysql": False}
+
+
+# --- SQLite (real driver, real filesystem) ---------------------------------
+
+
+def test_sqlite_connection_ok_in_memory():
+    result = db_backends.test_connection("sqlite", database=":memory:")
+    assert result.ok is True
+
+
+def test_sqlite_connection_ok_existing_file(tmp_path):
+    result = db_backends.test_connection("sqlite", database="fpdb.db3", sqlite_dir=str(tmp_path))
+    assert result.ok is True
+    # A brand-new empty test DB must not be left behind.
+    assert not (tmp_path / "fpdb.db3").exists()
+
+
+def test_sqlite_connection_fails_on_missing_directory():
+    result = db_backends.test_connection(
+        "sqlite", database="fpdb.db3", sqlite_dir="/no/such/directory/here",
+    )
+    assert result.ok is False
+    assert "Directory does not exist" in result.message
+
+
+def test_sqlite_preserves_existing_file(tmp_path):
+    import sqlite3
+
+    db_file = tmp_path / "existing.db3"
+    # Create a real (non-empty) SQLite database up front.
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    result = db_backends.test_connection("sqlite", database="existing.db3", sqlite_dir=str(tmp_path))
+    assert result.ok is True
+    assert db_file.exists()  # pre-existing file untouched
+
+
+# --- Unsupported / missing driver ------------------------------------------
+
+
+def test_unsupported_backend():
+    result = db_backends.test_connection("oracle")
+    assert result.ok is False
+    assert "Unsupported" in result.message
+
+
+def test_missing_driver_reported():
+    with patch.object(db_backends, "driver_available", return_value=False):
+        result = db_backends.test_connection("postgresql", database="fpdb")
+    assert result.ok is False
+    assert "not installed" in result.message
+
+
+# --- PostgreSQL / MySQL (driver mocked) ------------------------------------
+
+
+def test_postgresql_success_with_mocked_driver():
+    fake_psycopg = MagicMock()
+    fake_conn = MagicMock()
+    fake_psycopg.connect.return_value = fake_conn
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"psycopg": fake_psycopg},
+    ):
+        result = db_backends.test_connection(
+            "postgresql", database="fpdb", host="localhost", port="5432", user="u", password="p",
+        )
+    assert result.ok is True
+    fake_conn.close.assert_called_once()
+
+
+def test_postgresql_access_denied_is_friendly():
+    fake_psycopg = MagicMock()
+
+    class OperationalError(Exception):
+        pass
+
+    fake_psycopg.OperationalError = OperationalError
+    fake_psycopg.connect.side_effect = OperationalError("password authentication failed for user")
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"psycopg": fake_psycopg},
+    ):
+        result = db_backends.test_connection("postgresql", database="fpdb", user="u", password="bad")
+    assert result.ok is False
+    assert "Access denied" in result.message
+
+
+def test_mysql_success_with_mocked_driver():
+    fake_mysqldb = MagicMock()
+    fake_conn = MagicMock()
+    fake_mysqldb.connect.return_value = fake_conn
+    fake_mysqldb.Error = Exception
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"MySQLdb": fake_mysqldb},
+    ):
+        result = db_backends.test_connection(
+            "mysql", database="fpdb", host="localhost", port="3306", user="u", password="p",
+        )
+    assert result.ok is True
+    fake_conn.close.assert_called_once()
+    # Port must be coerced to int for the driver.
+    assert fake_mysqldb.connect.call_args.kwargs["port"] == 3306
+
+
+def test_mysql_access_denied_is_friendly():
+    fake_mysqldb = MagicMock()
+
+    class MySQLError(Exception):
+        pass
+
+    fake_mysqldb.Error = MySQLError
+    fake_mysqldb.connect.side_effect = MySQLError(1045, "Access denied for user")
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"MySQLdb": fake_mysqldb},
+    ):
+        result = db_backends.test_connection("mysql", database="fpdb", user="u", password="bad")
+    assert result.ok is False
+    assert "Access denied" in result.message
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -69,12 +69,32 @@ def test_apply_add_calls_config_and_refreshes(_qapp):
 def test_apply_delete_and_set_default(_qapp):
     from fpdb_3_legacy.GuiDatabase import GuiDatabase
 
-    config = _fake_config([_fake_db("fpdb", "sqlite")])
+    config = _fake_config([_fake_db("fpdb", "sqlite"), _fake_db("other", "postgresql")])
     panel = GuiDatabase(config)
     panel.apply_delete("fpdb")
     config.del_db_parameters.assert_called_once_with("fpdb")
     panel.apply_set_default("fpdb")
     config.set_db_parameters.assert_called_once_with(db_name="fpdb", default="True")
+
+
+def test_apply_delete_refuses_last_database(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("only", "sqlite")])
+    panel = GuiDatabase(config)
+    with pytest.raises(ValueError, match="last database"):
+        panel.apply_delete("only")
+    config.del_db_parameters.assert_not_called()
+    config.save.assert_not_called()
+
+
+def test_apply_delete_allowed_when_more_than_one(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("a", "sqlite"), _fake_db("b", "postgresql")])
+    panel = GuiDatabase(config)
+    panel.apply_delete("a")
+    config.del_db_parameters.assert_called_once_with("a")
 
 
 def test_selected_db_name(_qapp):

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for the GuiDatabase panel and DatabaseEditDialog (offscreen, mocked config)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+pytest.importorskip("PySide6")
+
+
+def _fake_db(name, server="sqlite", ip="", port="", user="", selected=False):
+    return SimpleNamespace(
+        db_name=name, db_server=server, db_ip=ip, db_port=port,
+        db_user=user, db_pass="", db_path="", db_desc="", db_selected=selected,
+    )
+
+
+def _fake_config(dbs=None):
+    config = MagicMock()
+    config.supported_databases = {db.db_name: db for db in (dbs or [])}
+    config.db_selected = next((d.db_name for d in (dbs or []) if d.db_selected), None)
+    config.dir_database = "/tmp/fpdb-db"
+    return config
+
+
+@pytest.fixture(scope="module")
+def _qapp():
+    from PySide6.QtWidgets import QApplication
+
+    return QApplication.instance() or QApplication([])
+
+
+# --- GuiDatabase panel -----------------------------------------------------
+
+
+def test_refresh_lists_configured_databases(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([
+        _fake_db("fpdb", "sqlite", selected=True),
+        _fake_db("pg", "postgresql", ip="dbhost", user="alice"),
+    ])
+    panel = GuiDatabase(config)
+    assert panel.table.rowCount() == 2
+    # Default marker on the selected row.
+    names = {panel.table.item(r, 0).text(): panel.table.item(r, 4).text() for r in range(2)}
+    assert names["fpdb"] == "✓"
+    assert names["pg"] == ""
+
+
+def test_apply_add_calls_config_and_refreshes(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("fpdb", "sqlite")])
+    panel = GuiDatabase(config)
+    panel.apply_add({"db_name": "new", "db_server": "sqlite"})
+    config.add_db_parameters.assert_called_once_with(db_name="new", db_server="sqlite")
+    config.save.assert_called_once()
+
+
+def test_apply_delete_and_set_default(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("fpdb", "sqlite")])
+    panel = GuiDatabase(config)
+    panel.apply_delete("fpdb")
+    config.del_db_parameters.assert_called_once_with("fpdb")
+    panel.apply_set_default("fpdb")
+    config.set_db_parameters.assert_called_once_with(db_name="fpdb", default="True")
+
+
+def test_selected_db_name(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("a"), _fake_db("b")])
+    panel = GuiDatabase(config)
+    panel.table.setCurrentCell(1, 0)
+    assert panel.selected_db_name() == "b"
+
+
+# --- DatabaseEditDialog ----------------------------------------------------
+
+
+def test_dialog_lists_all_backends(_qapp):
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    dialog = DatabaseEditDialog(_fake_config())
+    servers = {dialog.backendCombo.itemData(i) for i in range(dialog.backendCombo.count())}
+    assert servers == {"sqlite", "postgresql", "mysql"}
+
+
+def test_dialog_hides_server_fields_for_sqlite(_qapp):
+    from PySide6.QtWidgets import QWidget
+
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    dialog = DatabaseEditDialog(_fake_config())
+    dialog.show()  # visibility only meaningful once shown
+    idx = dialog.backendCombo.findData("sqlite")
+    dialog.backendCombo.setCurrentIndex(idx)
+    assert not dialog.hostEdit.isVisible()
+    idx = dialog.backendCombo.findData("postgresql")
+    dialog.backendCombo.setCurrentIndex(idx)
+    assert dialog.hostEdit.isVisible()
+    dialog.close()
+    assert isinstance(dialog, QWidget)
+
+
+def test_dialog_values_for_server_backend(_qapp):
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    dialog = DatabaseEditDialog(_fake_config())
+    dialog.nameEdit.setText("mydb")
+    dialog.backendCombo.setCurrentIndex(dialog.backendCombo.findData("postgresql"))
+    dialog.hostEdit.setText("h")
+    dialog.portEdit.setText("5432")
+    dialog.userEdit.setText("u")
+    dialog.passwordEdit.setText("p")
+    vals = dialog.values()
+    assert vals == {
+        "db_name": "mydb", "db_server": "postgresql",
+        "db_ip": "h", "db_port": "5432", "db_user": "u", "db_pass": "p",
+    }
+
+
+def test_dialog_test_connection_routes_to_helper(_qapp):
+    from fpdb_3_legacy import GuiDatabase as gui_db_module
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    dialog = DatabaseEditDialog(_fake_config())
+    dialog.nameEdit.setText("fpdb.db3")
+    dialog.backendCombo.setCurrentIndex(dialog.backendCombo.findData("sqlite"))
+
+    with patch.object(gui_db_module.db_backends, "test_connection") as mock_test:
+        mock_test.return_value = gui_db_module.db_backends.ConnectionResult(ok=True, message="ok")
+        dialog._on_test()
+
+    mock_test.assert_called_once()
+    assert mock_test.call_args.kwargs["database"] == "fpdb.db3"
+    assert "✓" in dialog.testResult.text()
+
+
+def test_dialog_test_requires_name(_qapp):
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    dialog = DatabaseEditDialog(_fake_config())
+    dialog.nameEdit.setText("")
+    result = dialog.test_connection()
+    assert result.ok is False
+    assert "name is required" in result.message
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a real, backend-aware way to configure the fpdb database **from the GUI**, instead of hand-editing raw XML in the generic tree editor (`GuiPrefs`). The DB engine (`Database.py`) already supported SQLite / PostgreSQL / MySQL — this PR adds the missing **config + UX layer**.

## Phase 0 — backend-agnostic helpers (`db_backends.py`)

- **`available_backends()`** — probes which drivers are importable (`sqlite3` always; `psycopg` / `MySQLdb` if installed).
- **`test_connection(server, …)`** — opens and immediately closes a real connection with the given parameters and returns a friendly `(ok, message)`. SQLite tests are **non-destructive** (an empty file created by the test is removed). Backend ids kept in sync with `Database` (sqlite=4, mysql=2, pg=3).

## Phase 1 — GUI (`GuiDatabase.py`)

- **`GuiDatabase`** panel: table of configured databases with **Add / Edit / Delete / Set-as-default**.
- **`DatabaseEditDialog`**: backend combo (unusable backends **disabled** when the driver is missing), fields shown per backend (SQLite: name; PG/MySQL: host/port/user/password), and a **"Test connection"** button wired to Phase 0.
- Persistence via `Configuration.add_db_parameters` / `set_db_parameters` / `del_db_parameters` + `save()`.

## Configuration fixes/additions

- **Bug fix**: a `dp_`/`db_` typo stopped `set_db_parameters`/`add_db_parameters` from updating the in-memory `supported_databases` cache.
- **New**: `del_db_parameters()` — removes a database (XML node + cache) and reassigns the selection if the removed one was selected.

## Verification

~30 new tests (`test_db_backends.py`, `test_config_db_parameters.py`, `test_gui_database.py`): driver-mocked + real SQLite, config round-trip (add/edit/delete/select + persistence across reload), GUI panel + dialog offscreen. Verified end-to-end with a **real Config**: lists the configured SQLite DB, greys out MySQL when its driver is absent, and a **real SQLite connection test succeeds**.

## Not in this PR (deliberate scope)

- Wiring the panel into the main window menu/notebook — the Gui* panels are self-contained QWidgets assembled by the app launcher (not in `fpdb_3_legacy`); this panel is ready to drop in.
- Phase 2 (switch active DB with restart prompt, create-schema flow) and Phase 3 (extra validation) — planned as follow-ups.
- Password remains stored in plaintext in `HUD_config.xml` (unchanged from current behaviour).
