### PR TITLE
Fix Windows CI: make win32console import optional in GuiAutoImport

### DIFF
--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -51,7 +51,12 @@ if __name__ == "__main__":
 log = get_logger("gui_auto_import")
 
 if os.name == "nt":
-    import win32console
+    try:
+        import win32console
+    except ImportError:
+        # pywin32 is optional (e.g. not installed in CI); console detection for
+        # the HUD launch degrades gracefully when it is unavailable.
+        win32console = None
 
 
 def to_raw(string) -> str:
@@ -503,7 +508,7 @@ class GuiAutoImport(QWidget):
 
         elif os.name == "nt":  # Windows installation source
             path = to_raw(self._hud_base_path())
-            use_pythonw = win32console.GetConsoleWindow() == 0
+            use_pythonw = win32console is not None and win32console.GetConsoleWindow() == 0
             # Use the current interpreter (e.g. the uv/venv python) so the
             # HUD subprocess shares the same environment and installed
             # packages (zmq, PyQt, ...). Falling back to a bare
@@ -547,7 +552,9 @@ class GuiAutoImport(QWidget):
             "universal_newlines": True,
         }
         # Capture stdout/err for windows « exe »
-        if self.config.install_method == "exe" or (os.name == "nt" and win32console.GetConsoleWindow() == 0):
+        if self.config.install_method == "exe" or (
+            os.name == "nt" and win32console is not None and win32console.GetConsoleWindow() == 0
+        ):
             popen_kwargs.update(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if env is not None:


### PR DESCRIPTION
## Problem

The Windows CI run fails with 11 errors, all from `test_guiautoimport_headless.py`:

```
fpdb_3_legacy\GuiAutoImport.py:54: in <module>
    import win32console
E   ModuleNotFoundError: No module named 'win32console'
```

`GuiAutoImport` imported `win32console` unconditionally under `if os.name == "nt"`. When **pywin32 is not installed** — as on the Windows CI runner — that import raises `ModuleNotFoundError` at *module load*, so every test that imports `GuiAutoImport` fails (not just the win32 code paths).

## Fix

- Wrap the import in `try/except ImportError` and set `win32console = None` on failure.
- Guard the two `win32console.GetConsoleWindow()` usages with `win32console is not None`.

The module now imports without pywin32, and the HUD console-detection (only used when actually launching the HUD on Windows) degrades gracefully. Non-Windows behaviour is unchanged (the `win32console` name is only referenced inside `os.name == "nt"` guarded, short-circuited code).

## Verification

- `test_guiautoimport_headless.py`: 11 passed locally (macOS).
- Compile OK, `ruff` unchanged (pre-existing I001 only).
- Simulated the missing-pywin32 path: the `try/except` yields `win32console = None` as expected.
