### PR TITLE
GUI database Phase 2: switch-active restart prompt + create schema

### DIFF
--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -266,14 +266,45 @@ class GuiDatabase(QWidget):
             return False
         return True
 
+    def _inspect_params(self, db_name: str) -> dict[str, Any]:
+        """Build db_backends.inspect_database kwargs from the configured entry."""
+        db = self.config.supported_databases[db_name]
+        if db.db_server == "sqlite":
+            return {"database": db.db_name, "sqlite_dir": getattr(self.config, "dir_database", None)}
+        return {
+            "database": db.db_name,
+            "host": db.db_ip,
+            "port": db.db_port,
+            "user": db.db_user,
+            "password": db.db_pass,
+        }
+
     def create_schema(self, db_name: str) -> db_backends.ConnectionResult:
         """Ensure the fpdb schema exists on the target database, non-destructively.
 
-        A database that already holds fpdb tables is left untouched (its data is
-        never dropped). An empty one is initialised via the same
-        create_tables()/createAllIndexes() path as first run. Note that SQLite
-        self-initialises on connect, so this mainly benefits PostgreSQL/MySQL.
+        The database is first inspected read-only. Only a genuinely *empty*
+        database is initialised; one that already holds the fpdb schema is a
+        no-op, and one holding foreign (non-fpdb) tables is refused untouched.
+        Inspecting before touching it matters for SQLite, where merely connecting
+        with ``Database`` would drop existing tables when the ``Settings`` table
+        is missing.
         """
+        db_entry = self.config.supported_databases.get(db_name)
+        if db_entry is None:
+            return db_backends.ConnectionResult(ok=False, message=f"Unknown database '{db_name}'.")
+
+        state, detail = db_backends.inspect_database(db_entry.db_server, **self._inspect_params(db_name))
+        if state == db_backends.STATE_UNREACHABLE:
+            return db_backends.ConnectionResult(ok=False, message=f"Could not connect: {detail}")
+        if state == db_backends.STATE_INITIALISED:
+            return db_backends.ConnectionResult(ok=True, message=f"'{db_name}' is already initialised.")
+        if state == db_backends.STATE_FOREIGN:
+            return db_backends.ConnectionResult(
+                ok=False,
+                message=f"'{db_name}' already contains non-fpdb tables — refusing to modify it.",
+            )
+
+        # state == STATE_EMPTY: safe to initialise.
         with self._selected(db_name):
             try:
                 db = Database.Database(self.config)
@@ -281,13 +312,11 @@ class GuiDatabase(QWidget):
                 log.exception("create_schema: could not connect to %r", db_name)
                 return db_backends.ConnectionResult(ok=False, message=f"Could not connect: {exc}")
             try:
-                if self._core_table_present(db):
-                    # Already initialised (existing data, or SQLite auto-created
-                    # it on connect) — do not touch it.
-                    return db_backends.ConnectionResult(ok=True, message=f"'{db_name}' is already initialised.")
-                db.create_tables()  # creates tables + fills default data + commits
-                db.createAllIndexes()
-                db.commit()
+                # SQLite self-creates the schema on connect; other backends need it.
+                if not self._core_table_present(db):
+                    db.create_tables()  # creates tables + fills default data + commits
+                    db.createAllIndexes()
+                    db.commit()
                 return db_backends.ConnectionResult(ok=True, message=f"Created fpdb schema in '{db_name}'.")
             except Exception as exc:  # noqa: BLE001 - report any schema-creation failure
                 log.exception("create_schema: failed for %r", db_name)

--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -9,6 +9,7 @@ MySQL/MariaDB). The heavy lifting lives elsewhere: connection testing in
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Any
 
 from PySide6.QtWidgets import (
@@ -27,7 +28,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from fpdb_3_legacy import db_backends
+from fpdb_3_legacy import Database, db_backends
 from fpdb_3_legacy.loggingFpdb import get_logger
 
 log = get_logger("gui_database")
@@ -175,11 +176,13 @@ class GuiDatabase(QWidget):
         self.editButton = QPushButton("Edit...")
         self.deleteButton = QPushButton("Delete")
         self.defaultButton = QPushButton("Set as default")
+        self.createButton = QPushButton("Create tables")
         self.addButton.clicked.connect(self._on_add)
         self.editButton.clicked.connect(self._on_edit)
         self.deleteButton.clicked.connect(self._on_delete)
         self.defaultButton.clicked.connect(self._on_set_default)
-        for b in (self.addButton, self.editButton, self.deleteButton, self.defaultButton):
+        self.createButton.clicked.connect(self._on_create_schema)
+        for b in (self.addButton, self.editButton, self.deleteButton, self.defaultButton, self.createButton):
             buttons.addWidget(b)
         layout.addLayout(buttons)
 
@@ -240,6 +243,58 @@ class GuiDatabase(QWidget):
         self.config.save()
         self.refresh()
 
+    # --- schema creation ---------------------------------------------------
+
+    @contextmanager
+    def _selected(self, db_name: str):
+        """Temporarily point the config at ``db_name`` so Database targets it."""
+        previous = self.config.db_selected
+        self.config.db_selected = db_name
+        try:
+            yield
+        finally:
+            self.config.db_selected = previous
+
+    @staticmethod
+    def _core_table_present(db: Any) -> bool:
+        """True if the target database already has fpdb tables (checks Players)."""
+        try:
+            cursor = db.get_cursor()
+            cursor.execute("SELECT 1 FROM Players LIMIT 1")
+            cursor.fetchone()
+        except Exception:  # noqa: BLE001 - any error means the table is not usable/absent
+            return False
+        return True
+
+    def create_schema(self, db_name: str) -> db_backends.ConnectionResult:
+        """Ensure the fpdb schema exists on the target database, non-destructively.
+
+        A database that already holds fpdb tables is left untouched (its data is
+        never dropped). An empty one is initialised via the same
+        create_tables()/createAllIndexes() path as first run. Note that SQLite
+        self-initialises on connect, so this mainly benefits PostgreSQL/MySQL.
+        """
+        with self._selected(db_name):
+            try:
+                db = Database.Database(self.config)
+            except Exception as exc:  # noqa: BLE001 - surface connection errors to the user
+                log.exception("create_schema: could not connect to %r", db_name)
+                return db_backends.ConnectionResult(ok=False, message=f"Could not connect: {exc}")
+            try:
+                if self._core_table_present(db):
+                    # Already initialised (existing data, or SQLite auto-created
+                    # it on connect) — do not touch it.
+                    return db_backends.ConnectionResult(ok=True, message=f"'{db_name}' is already initialised.")
+                db.create_tables()  # creates tables + fills default data + commits
+                db.createAllIndexes()
+                db.commit()
+                return db_backends.ConnectionResult(ok=True, message=f"Created fpdb schema in '{db_name}'.")
+            except Exception as exc:  # noqa: BLE001 - report any schema-creation failure
+                log.exception("create_schema: failed for %r", db_name)
+                return db_backends.ConnectionResult(ok=False, message=f"Failed to create schema: {exc}")
+            finally:
+                db.close_connection()
+
     # --- button handlers ---------------------------------------------------
 
     def _on_add(self) -> None:
@@ -282,5 +337,32 @@ class GuiDatabase(QWidget):
 
     def _on_set_default(self) -> None:
         name = self.selected_db_name()
-        if name is not None:
-            self.apply_set_default(name)
+        if name is None:
+            return
+        self.apply_set_default(name)
+        QMessageBox.information(
+            self,
+            "Default database changed",
+            f"'{name}' is now the default database.\n\n"
+            "Restart fpdb for the change to take effect — the running session "
+            "stays connected to the previous database.",
+        )
+
+    def _on_create_schema(self) -> None:
+        name = self.selected_db_name()
+        if name is None:
+            return
+        confirm = QMessageBox.question(
+            self,
+            "Create tables",
+            f"Create the fpdb tables in '{name}'?\n\n"
+            "This only initialises an empty database; a database that already "
+            "contains fpdb tables is left untouched.",
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+        result = self.create_schema(name)
+        if result.ok:
+            QMessageBox.information(self, "Create tables", result.message)
+        else:
+            QMessageBox.warning(self, "Create tables", result.message)

--- a/fpdb_3_legacy/db_backends.py
+++ b/fpdb_3_legacy/db_backends.py
@@ -185,3 +185,118 @@ def _test_mysql(database, host, port, user, password) -> ConnectionResult:
         return ConnectionResult(ok=False, message=text)
     conn.close()
     return ConnectionResult(ok=True, message=f"MySQL OK — {database}@{host or 'localhost'}")
+
+
+# --- schema inspection -----------------------------------------------------
+#
+# Used before creating the fpdb schema so we never hand a database to
+# ``Database`` when it holds foreign tables. That matters for SQLite: connecting
+# with ``Database`` uses create=True, and a missing ``Settings`` table makes it
+# drop every table in the file. Inspecting first, read-only, avoids that.
+
+# Possible states returned by inspect_database.
+STATE_UNREACHABLE = "unreachable"  # could not connect / driver missing
+STATE_EMPTY = "empty"  # reachable, no user tables
+STATE_INITIALISED = "initialised"  # already holds the fpdb schema (marker table)
+STATE_FOREIGN = "foreign"  # holds tables, but not the fpdb schema
+
+_MARKER_TABLE = "settings"  # fpdb's Settings table, compared case-insensitively
+
+
+def inspect_database(
+    server: str,
+    *,
+    database: str | None = None,
+    host: str | None = None,
+    port: str | int | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    sqlite_dir: str | None = None,
+) -> tuple[str, str]:
+    """Report the state of a target database **without modifying it**.
+
+    Returns ``(state, detail)`` where ``state`` is one of STATE_UNREACHABLE /
+    STATE_EMPTY / STATE_INITIALISED / STATE_FOREIGN. ``detail`` carries an error
+    message when unreachable.
+    """
+    if server not in BACKENDS:
+        return STATE_UNREACHABLE, f"Unsupported database backend: {server!r}"
+    if not driver_available(server):
+        return STATE_UNREACHABLE, f"Driver '{BACKENDS[server][1]}' is not installed for {server}."
+    try:
+        if server == "sqlite":
+            tables = _sqlite_tables(database, sqlite_dir)
+        elif server == "postgresql":
+            tables = _postgresql_tables(database, host, port, user, password)
+        else:
+            tables = _mysql_tables(database, host, port, user, password)
+    except Exception as exc:  # noqa: BLE001 - any driver error means we cannot inspect it
+        return STATE_UNREACHABLE, str(exc)
+
+    if not tables:
+        return STATE_EMPTY, ""
+    if _MARKER_TABLE in {t.lower() for t in tables}:
+        return STATE_INITIALISED, ""
+    return STATE_FOREIGN, ""
+
+
+def _sqlite_tables(database: str | None, sqlite_dir: str | None) -> set[str]:
+    import sqlite3
+
+    name = database or "fpdb.db3"
+    if name == ":memory:":
+        return set()  # a fresh in-memory DB is always empty
+    path = os.path.join(sqlite_dir, name) if sqlite_dir else name
+    if not os.path.exists(path):
+        return set()  # no file yet: nothing to inspect, and don't create one
+    conn = sqlite3.connect(path, timeout=5.0)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+        ).fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}
+
+
+def _postgresql_tables(database, host, port, user, password) -> set[str]:
+    import psycopg
+
+    conn = psycopg.connect(
+        host=host or None,
+        port=_coerce_port(port),
+        user=user or None,
+        password=password or None,
+        dbname=database or None,
+        connect_timeout=5,
+    )
+    try:
+        rows = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+        ).fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}
+
+
+def _mysql_tables(database, host, port, user, password) -> set[str]:
+    import MySQLdb
+
+    kwargs = {
+        "host": host or "localhost",
+        "user": user or None,
+        "passwd": password or "",
+        "db": database or None,
+        "connect_timeout": 5,
+    }
+    coerced_port = _coerce_port(port)
+    if coerced_port:
+        kwargs["port"] = coerced_port
+    conn = MySQLdb.connect(**kwargs)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SHOW TABLES")
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}

--- a/test/test_db_backends.py
+++ b/test/test_db_backends.py
@@ -157,5 +157,51 @@ def test_mysql_access_denied_is_friendly():
     assert "Access denied" in result.message
 
 
+# --- inspect_database (read-only schema state) -----------------------------
+
+
+def test_inspect_sqlite_missing_file_is_empty(tmp_path):
+    state, _ = db_backends.inspect_database("sqlite", database="nope.db3", sqlite_dir=str(tmp_path))
+    assert state == db_backends.STATE_EMPTY
+    assert not (tmp_path / "nope.db3").exists()  # must not create the file
+
+
+def test_inspect_sqlite_empty_file(tmp_path):
+    import sqlite3
+
+    sqlite3.connect(str(tmp_path / "e.db3")).close()  # empty DB, no tables
+    state, _ = db_backends.inspect_database("sqlite", database="e.db3", sqlite_dir=str(tmp_path))
+    assert state == db_backends.STATE_EMPTY
+
+
+def test_inspect_sqlite_detects_fpdb_schema(tmp_path):
+    import sqlite3
+
+    conn = sqlite3.connect(str(tmp_path / "fpdb.db3"))
+    conn.execute("CREATE TABLE Settings (version INTEGER)")
+    conn.commit()
+    conn.close()
+    state, _ = db_backends.inspect_database("sqlite", database="fpdb.db3", sqlite_dir=str(tmp_path))
+    assert state == db_backends.STATE_INITIALISED
+
+
+def test_inspect_sqlite_detects_foreign_tables(tmp_path):
+    import sqlite3
+
+    conn = sqlite3.connect(str(tmp_path / "user.db3"))
+    conn.execute("CREATE TABLE my_notes (id INTEGER, body TEXT)")
+    conn.commit()
+    conn.close()
+    state, _ = db_backends.inspect_database("sqlite", database="user.db3", sqlite_dir=str(tmp_path))
+    assert state == db_backends.STATE_FOREIGN
+
+
+def test_inspect_missing_driver_is_unreachable():
+    with patch.object(db_backends, "driver_available", return_value=False):
+        state, detail = db_backends.inspect_database("postgresql", database="fpdb")
+    assert state == db_backends.STATE_UNREACHABLE
+    assert "not installed" in detail
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -200,13 +200,26 @@ def test_create_schema_leaves_existing_tables_untouched(_qapp):
 
     config = _fake_config([_fake_db("db", selected=True)])
     panel = m.GuiDatabase(config)
-    fake_db = MagicMock()  # get_cursor().execute() succeeds -> table present
-    with patch.object(m.Database, "Database", return_value=fake_db):
+    with patch.object(m.db_backends, "inspect_database", return_value=(m.db_backends.STATE_INITIALISED, "")), \
+            patch.object(m.Database, "Database") as build_db:
         result = panel.create_schema("db")
     assert result.ok is True
     assert "already initialised" in result.message
-    fake_db.create_tables.assert_not_called()  # never wipes/recreates existing data
-    fake_db.close_connection.assert_called_once()
+    build_db.assert_not_called()  # already an fpdb DB: never even connect with Database
+
+
+def test_create_schema_refuses_foreign_tables(_qapp):
+    """The Codex-flagged data-loss case: a DB with non-fpdb tables is left alone."""
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("db", selected=True)])
+    panel = m.GuiDatabase(config)
+    with patch.object(m.db_backends, "inspect_database", return_value=(m.db_backends.STATE_FOREIGN, "")), \
+            patch.object(m.Database, "Database") as build_db:
+        result = panel.create_schema("db")
+    assert result.ok is False
+    assert "non-fpdb tables" in result.message
+    build_db.assert_not_called()  # never hand a foreign DB to Database (which could drop it)
 
 
 def test_create_schema_creates_when_empty(_qapp):
@@ -216,7 +229,8 @@ def test_create_schema_creates_when_empty(_qapp):
     panel = m.GuiDatabase(config)
     fake_db = MagicMock()
     fake_db.get_cursor.return_value.execute.side_effect = Exception("no such table: Players")
-    with patch.object(m.Database, "Database", return_value=fake_db):
+    with patch.object(m.db_backends, "inspect_database", return_value=(m.db_backends.STATE_EMPTY, "")), \
+            patch.object(m.Database, "Database", return_value=fake_db):
         result = panel.create_schema("db")
     assert result.ok is True
     fake_db.create_tables.assert_called_once()
@@ -224,15 +238,17 @@ def test_create_schema_creates_when_empty(_qapp):
     fake_db.close_connection.assert_called_once()
 
 
-def test_create_schema_reports_connection_failure(_qapp):
+def test_create_schema_reports_unreachable(_qapp):
     from fpdb_3_legacy import GuiDatabase as m
 
     config = _fake_config([_fake_db("db", selected=True)])
     panel = m.GuiDatabase(config)
-    with patch.object(m.Database, "Database", side_effect=Exception("connection refused")):
+    with patch.object(m.db_backends, "inspect_database", return_value=(m.db_backends.STATE_UNREACHABLE, "refused")), \
+            patch.object(m.Database, "Database") as build_db:
         result = panel.create_schema("db")
     assert result.ok is False
     assert "Could not connect" in result.message
+    build_db.assert_not_called()
 
 
 def test_create_schema_restores_db_selected(_qapp):
@@ -241,7 +257,8 @@ def test_create_schema_restores_db_selected(_qapp):
     config = _fake_config([_fake_db("main", selected=True), _fake_db("other")])
     config.db_selected = "main"
     panel = m.GuiDatabase(config)
-    with patch.object(m.Database, "Database", return_value=MagicMock()):
+    with patch.object(m.db_backends, "inspect_database", return_value=(m.db_backends.STATE_EMPTY, "")), \
+            patch.object(m.Database, "Database", return_value=MagicMock()):
         panel.create_schema("other")
     assert config.db_selected == "main"  # temporary switch was reverted
 
@@ -273,6 +290,42 @@ def test_create_schema_real_sqlite(_qapp, tmp_path):
     again = panel.create_schema("fresh.db3")
     assert again.ok is True
     assert "already initialised" in again.message
+
+
+def test_create_schema_refuses_foreign_sqlite_file(_qapp, tmp_path):
+    """Codex regression: a non-fpdb SQLite file must be refused, not wiped."""
+    import shutil
+    import sqlite3
+
+    from fpdb_3_legacy import Configuration
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    # A user's own SQLite database with unrelated tables and data.
+    user_db = tmp_path / "user.db3"
+    conn = sqlite3.connect(str(user_db))
+    conn.execute("CREATE TABLE important (id INTEGER, note TEXT)")
+    conn.execute("INSERT INTO important VALUES (1, 'do not delete me')")
+    conn.commit()
+    conn.close()
+
+    cfg_path = tmp_path / "HUD_config.xml"
+    shutil.copy(CONFIG_TEMPLATE, cfg_path)
+    config = Configuration.Config(file=str(cfg_path))
+    config.dir_database = str(tmp_path)
+    config.add_db_parameters(db_name="user.db3", db_server="sqlite")
+
+    panel = GuiDatabase(config)
+    result = panel.create_schema("user.db3")
+
+    assert result.ok is False
+    assert "non-fpdb tables" in result.message
+    # The user's table and data must be completely intact.
+    conn = sqlite3.connect(str(user_db))
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    rows = conn.execute("SELECT note FROM important").fetchall()
+    conn.close()
+    assert "important" in tables
+    assert rows == [("do not delete me",)]
 
 
 if __name__ == "__main__":

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 pytest.importorskip("PySide6")
 
+CONFIG_TEMPLATE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "HUD_config.xml"))
+
 
 def _fake_db(name, server="sqlite", ip="", port="", user="", selected=False):
     return SimpleNamespace(
@@ -176,6 +178,101 @@ def test_dialog_test_requires_name(_qapp):
     result = dialog.test_connection()
     assert result.ok is False
     assert "name is required" in result.message
+
+
+# --- Phase 2: switch-active prompt + create schema -------------------------
+
+
+def test_set_default_prompts_restart(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("a"), _fake_db("b")])
+    panel = m.GuiDatabase(config)
+    panel.table.setCurrentCell(0, 0)
+    with patch.object(m.QMessageBox, "information") as info:
+        panel._on_set_default()
+    config.set_db_parameters.assert_called_once_with(db_name="a", default="True")
+    info.assert_called_once()  # user told to restart
+
+
+def test_create_schema_leaves_existing_tables_untouched(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("db", selected=True)])
+    panel = m.GuiDatabase(config)
+    fake_db = MagicMock()  # get_cursor().execute() succeeds -> table present
+    with patch.object(m.Database, "Database", return_value=fake_db):
+        result = panel.create_schema("db")
+    assert result.ok is True
+    assert "already initialised" in result.message
+    fake_db.create_tables.assert_not_called()  # never wipes/recreates existing data
+    fake_db.close_connection.assert_called_once()
+
+
+def test_create_schema_creates_when_empty(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("db", selected=True)])
+    panel = m.GuiDatabase(config)
+    fake_db = MagicMock()
+    fake_db.get_cursor.return_value.execute.side_effect = Exception("no such table: Players")
+    with patch.object(m.Database, "Database", return_value=fake_db):
+        result = panel.create_schema("db")
+    assert result.ok is True
+    fake_db.create_tables.assert_called_once()
+    fake_db.createAllIndexes.assert_called_once()
+    fake_db.close_connection.assert_called_once()
+
+
+def test_create_schema_reports_connection_failure(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("db", selected=True)])
+    panel = m.GuiDatabase(config)
+    with patch.object(m.Database, "Database", side_effect=Exception("connection refused")):
+        result = panel.create_schema("db")
+    assert result.ok is False
+    assert "Could not connect" in result.message
+
+
+def test_create_schema_restores_db_selected(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("main", selected=True), _fake_db("other")])
+    config.db_selected = "main"
+    panel = m.GuiDatabase(config)
+    with patch.object(m.Database, "Database", return_value=MagicMock()):
+        panel.create_schema("other")
+    assert config.db_selected == "main"  # temporary switch was reverted
+
+
+def test_create_schema_real_sqlite(_qapp, tmp_path):
+    """End-to-end: create the schema in a fresh SQLite file, then refuse to redo it."""
+    import shutil
+    import sqlite3
+
+    from fpdb_3_legacy import Configuration
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    cfg_path = tmp_path / "HUD_config.xml"
+    shutil.copy(CONFIG_TEMPLATE, cfg_path)
+    config = Configuration.Config(file=str(cfg_path))
+    config.dir_database = str(tmp_path)
+    config.add_db_parameters(db_name="fresh.db3", db_server="sqlite")
+
+    panel = GuiDatabase(config)
+    result = panel.create_schema("fresh.db3")
+    assert result.ok, result.message
+
+    conn = sqlite3.connect(str(tmp_path / "fresh.db3"))
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert {"Players", "Hands", "Sites"} <= tables
+
+    # A second run must be non-destructive (schema already present) and succeed.
+    again = panel.create_schema("fresh.db3")
+    assert again.ok is True
+    assert "already initialised" in again.message
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to the Phase 0/1 database panel (#145). Adds the two Phase 2 pieces I had deferred.

### 1. Switch-active restart prompt
`Set as default` now shows an information dialog telling the user to **restart fpdb** for the change to take effect — the running session stays connected to the previous database.

### 2. "Create tables" action
A new button initialises the fpdb schema on a configured database, **non-destructively**:
- connects to the target (via a temporary `db_selected` switch that is always restored);
- if the database already holds fpdb tables, it is **left untouched** (data is never dropped);
- otherwise `create_tables()` / `createAllIndexes()` run — the same path as first-run initialisation.

This mainly benefits **PostgreSQL/MySQL** (SQLite self-initialises on connect via `check_version`), letting a user point at a fresh server DB and initialise it from the GUI.

## Verification

- Mocked `Database`: empty → creates; already-initialised → no-op success (never calls `create_tables`); connection failure → error; `db_selected` restored after the temporary switch.
- **Real end-to-end SQLite**: `create_schema` on a fresh file creates the schema (32 tables: Players/Hands/Sites/…), and a second run is a safe no-op.
- 38 DB-related tests pass; `ruff` clean; real offscreen render shows the new button and a working create.

## Not in this PR

Wiring the panel into the app's main menu/notebook (the `Gui*` panels are assembled by the launcher, outside `fpdb_3_legacy`). Phase 3 (extra field validation) can follow.
