### PR TITLE
GUI database Phase 3: validate the edit dialog before saving

### DIFF
--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -139,8 +139,8 @@ class DatabaseEditDialog(QDialog):
             if not vals.get("db_ip"):
                 return False, "A host is required for PostgreSQL/MySQL."
             port = vals.get("db_port", "")
-            if port and not (port.isdigit() and int(port) > 0):
-                return False, "Port must be a positive number."
+            if port and not (port.isdigit() and 1 <= int(port) <= 65535):
+                return False, "Port must be a number between 1 and 65535."
         return True, ""
 
     def accept(self) -> None:

--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -126,6 +126,31 @@ class DatabaseEditDialog(QDialog):
             result["db_pass"] = self.passwordEdit.text()
         return result
 
+    def validate(self) -> tuple[bool, str]:
+        """Check the entered values; returns (ok, message) with the first error."""
+        vals = self.values()
+        name = vals["db_name"]
+        if not name:
+            return False, "A database name is required."
+        # On add, the name is the unique key across configured databases.
+        if self.existing is None and name in getattr(self.config, "supported_databases", {}):
+            return False, f"A database named '{name}' already exists."
+        if vals["db_server"] in _SERVER_BACKENDS:
+            if not vals.get("db_ip"):
+                return False, "A host is required for PostgreSQL/MySQL."
+            port = vals.get("db_port", "")
+            if port and not (port.isdigit() and int(port) > 0):
+                return False, "Port must be a positive number."
+        return True, ""
+
+    def accept(self) -> None:
+        """Validate before closing; keep the dialog open on invalid input."""
+        ok, message = self.validate()
+        if not ok:
+            QMessageBox.warning(self, "Invalid database settings", message)
+            return
+        super().accept()
+
     def _on_test(self) -> None:
         result = self.test_connection()
         color = "green" if result.ok else "red"

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -180,6 +180,91 @@ def test_dialog_test_requires_name(_qapp):
     assert "name is required" in result.message
 
 
+# --- Phase 3: field validation ---------------------------------------------
+
+
+def _dialog_for(server, **fields):
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    config = fields.pop("config", None) or _fake_config()
+    dialog = DatabaseEditDialog(config)
+    dialog.nameEdit.setText(fields.get("name", "db"))
+    dialog.backendCombo.setCurrentIndex(dialog.backendCombo.findData(server))
+    dialog.hostEdit.setText(fields.get("host", ""))
+    dialog.portEdit.setText(fields.get("port", ""))
+    return dialog
+
+
+def test_validate_requires_name(_qapp):
+    dialog = _dialog_for("sqlite", name="")
+    ok, message = dialog.validate()
+    assert ok is False
+    assert "name is required" in message
+
+
+def test_validate_rejects_duplicate_name_on_add(_qapp):
+    config = _fake_config([_fake_db("taken")])
+    dialog = _dialog_for("sqlite", name="taken", config=config)
+    ok, message = dialog.validate()
+    assert ok is False
+    assert "already exists" in message
+
+
+def test_validate_allows_existing_name_on_edit(_qapp):
+    from fpdb_3_legacy.GuiDatabase import DatabaseEditDialog
+
+    config = _fake_config([_fake_db("edit_me")])
+    dialog = DatabaseEditDialog(config, existing=config.supported_databases["edit_me"])
+    ok, _ = dialog.validate()
+    assert ok is True  # editing keeps its own name; not a duplicate
+
+
+def test_validate_requires_host_for_server_backends(_qapp):
+    dialog = _dialog_for("postgresql", name="pg", host="")
+    ok, message = dialog.validate()
+    assert ok is False
+    assert "host is required" in message.lower()
+
+
+def test_validate_rejects_non_numeric_port(_qapp):
+    dialog = _dialog_for("postgresql", name="pg", host="h", port="abc")
+    ok, message = dialog.validate()
+    assert ok is False
+    assert "Port must be" in message
+
+
+def test_validate_accepts_valid_server_config(_qapp):
+    dialog = _dialog_for("postgresql", name="pg", host="h", port="5432")
+    ok, _ = dialog.validate()
+    assert ok is True
+
+
+def test_validate_sqlite_needs_no_host(_qapp):
+    dialog = _dialog_for("sqlite", name="fpdb.db3")
+    ok, _ = dialog.validate()
+    assert ok is True
+
+
+def test_accept_blocks_on_invalid_input(_qapp):
+    from PySide6.QtWidgets import QDialog
+
+    from fpdb_3_legacy import GuiDatabase as m
+
+    dialog = _dialog_for("postgresql", name="pg", host="")  # missing host
+    with patch.object(m.QMessageBox, "warning") as warn:
+        dialog.accept()
+    warn.assert_called_once()
+    assert dialog.result() != QDialog.DialogCode.Accepted  # stays open
+
+
+def test_accept_passes_on_valid_input(_qapp):
+    from PySide6.QtWidgets import QDialog
+
+    dialog = _dialog_for("sqlite", name="fpdb.db3")
+    dialog.accept()
+    assert dialog.result() == QDialog.DialogCode.Accepted
+
+
 # --- Phase 2: switch-active prompt + create schema -------------------------
 
 

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -233,6 +233,20 @@ def test_validate_rejects_non_numeric_port(_qapp):
     assert "Port must be" in message
 
 
+def test_validate_rejects_out_of_range_port(_qapp):
+    dialog = _dialog_for("postgresql", name="pg", host="h", port="70000")
+    ok, message = dialog.validate()
+    assert ok is False
+    assert "65535" in message
+
+
+def test_validate_accepts_boundary_ports(_qapp):
+    for port in ("1", "65535"):
+        dialog = _dialog_for("postgresql", name="pg", host="h", port=port)
+        ok, _ = dialog.validate()
+        assert ok is True, f"port {port} should be valid"
+
+
 def test_validate_accepts_valid_server_config(_qapp):
     dialog = _dialog_for("postgresql", name="pg", host="h", port="5432")
     ok, _ = dialog.validate()


### PR DESCRIPTION
## Summary

Final phase of the GUI database configuration work (after #145 Phase 0/1 and #147 Phase 2). `DatabaseEditDialog` now **validates input before saving** instead of silently persisting bad settings.

## Validation rules

- A database **name is required**, and on **add** it must be **unique**.
- **PostgreSQL/MySQL** entries require a **host**, and the **port** (if given) must be a **positive integer**.
- **SQLite** needs no server fields.

`accept()` runs `validate()` and, on invalid input, shows a warning and **keeps the dialog open**; valid input proceeds as before. Editing an existing entry keeps its own name (not treated as a duplicate).

## Verification

10 new tests: each validation rule (missing/duplicate name, missing host, non-numeric port, valid server config, sqlite-needs-no-host, edit-keeps-name) plus `accept()` blocking on invalid and passing on valid input. **54 DB-related tests pass; `ruff` clean.**

## Feature status

| Phase | Content | Status |
|---|---|---|
| 0 | backend helpers (`test_connection`, `available_backends`, `inspect_database`) | merged |
| 1 | `GuiDatabase` panel (list/add/edit/delete/test) | merged |
| 2 | switch-active restart prompt + non-destructive create-schema | merged |
| 3 | edit-dialog field validation | this PR |

Remaining (out of scope): wiring the panel into the app's main menu/notebook — the `Gui*` panels are assembled by the launcher, outside `fpdb_3_legacy`.
