### PR TITLE
Cross-backend data migration (engine + GUI)

### DIFF
--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -28,7 +29,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from fpdb_3_legacy import Database, db_backends
+from fpdb_3_legacy import Database, db_backends, db_migrate
 from fpdb_3_legacy.loggingFpdb import get_logger
 
 log = get_logger("gui_database")
@@ -202,12 +203,17 @@ class GuiDatabase(QWidget):
         self.deleteButton = QPushButton("Delete")
         self.defaultButton = QPushButton("Set as default")
         self.createButton = QPushButton("Create tables")
+        self.migrateButton = QPushButton("Migrate to...")
         self.addButton.clicked.connect(self._on_add)
         self.editButton.clicked.connect(self._on_edit)
         self.deleteButton.clicked.connect(self._on_delete)
         self.defaultButton.clicked.connect(self._on_set_default)
         self.createButton.clicked.connect(self._on_create_schema)
-        for b in (self.addButton, self.editButton, self.deleteButton, self.defaultButton, self.createButton):
+        self.migrateButton.clicked.connect(self._on_migrate)
+        for b in (
+            self.addButton, self.editButton, self.deleteButton,
+            self.defaultButton, self.createButton, self.migrateButton,
+        ):
             buttons.addWidget(b)
         layout.addLayout(buttons)
 
@@ -349,6 +355,37 @@ class GuiDatabase(QWidget):
             finally:
                 db.close_connection()
 
+    def migrate_to(self, source_name: str, dest_name: str) -> db_migrate.MigrationReport:
+        """Copy all data from ``source_name`` into ``dest_name`` (replacing it).
+
+        The destination schema is ensured first (created if empty, refused if it
+        holds non-fpdb tables); then the data is copied preserving primary keys.
+        """
+        schema = self.create_schema(dest_name)
+        if not schema.ok:
+            report = db_migrate.MigrationReport()
+            report.error = schema.message
+            return report
+
+        previous = self.config.db_selected
+        source = dest = None
+        try:
+            self.config.db_selected = source_name
+            source = Database.Database(self.config)
+            self.config.db_selected = dest_name
+            dest = Database.Database(self.config)
+            return db_migrate.migrate(source, dest)
+        except Exception as exc:  # noqa: BLE001 - surface connection errors as a report
+            log.exception("migrate_to: failed %r -> %r", source_name, dest_name)
+            report = db_migrate.MigrationReport()
+            report.error = str(exc)
+            return report
+        finally:
+            self.config.db_selected = previous
+            for db in (source, dest):
+                if db is not None:
+                    db.close_connection()
+
     # --- button handlers ---------------------------------------------------
 
     def _on_add(self) -> None:
@@ -420,3 +457,37 @@ class GuiDatabase(QWidget):
             QMessageBox.information(self, "Create tables", result.message)
         else:
             QMessageBox.warning(self, "Create tables", result.message)
+
+    def _on_migrate(self) -> None:
+        source = self.selected_db_name()
+        if source is None:
+            return
+        others = [name for name in self.config.supported_databases if name != source]
+        if not others:
+            QMessageBox.warning(
+                self, "Migrate database", "There is no other database to migrate into. Add one first.",
+            )
+            return
+        dest, chosen = QInputDialog.getItem(
+            self, "Migrate database", f"Copy all data from '{source}' into:", others, 0, editable=False,
+        )
+        if not chosen or not dest:
+            return
+        confirm = QMessageBox.warning(
+            self,
+            "Migrate database",
+            f"This will REPLACE all data in '{dest}' with the data from '{source}'.\n\n"
+            "The destination's current contents will be lost. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+        report = self.migrate_to(source, dest)
+        if report.ok:
+            QMessageBox.information(
+                self, "Migrate database",
+                f"Copied {report.total_rows} rows across {len(report.tables)} tables into '{dest}'.",
+            )
+        else:
+            QMessageBox.warning(self, "Migrate database", f"Migration failed: {report.error}")

--- a/fpdb_3_legacy/db_migrate.py
+++ b/fpdb_3_legacy/db_migrate.py
@@ -1,0 +1,161 @@
+"""Copy all fpdb data from one database to another, across backends.
+
+Both databases share the fpdb schema, so migration is a straight table-by-table
+row copy that **preserves primary keys** (no id remapping, so foreign keys stay
+valid). During the copy, foreign-key enforcement is relaxed on the destination
+and each destination table is cleared first, so table order does not matter and
+the default lookup rows created by a fresh schema (``fillDefaultData``) do not
+collide. PostgreSQL sequences are reset afterwards.
+
+The destination must already have the fpdb schema (see GuiDatabase's "Create
+tables"). Its existing contents are replaced by the source's — migration is a
+destructive operation on the destination, by design.
+
+The engine talks to the two ``Database`` instances through their cursors and
+``sql.query['placeholder']``, so it is backend-agnostic; only foreign-key
+handling and sequence reset are per-backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("db_migrate")
+
+# Database backend ids (kept in sync with Database.{MYSQL_INNODB,PGSQL,SQLITE}).
+_MYSQL = 2
+_PGSQL = 3
+_SQLITE = 4
+
+_BATCH = 1000
+
+ProgressCallback = Callable[[int, int, str], None]
+
+
+@dataclass
+class MigrationReport:
+    """Outcome of a migration: rows copied per table plus any error."""
+
+    tables: dict[str, int] = field(default_factory=dict)
+    total_rows: int = 0
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def _quote(backend: int, identifier: str) -> str:
+    """Quote a table/column identifier for the given backend."""
+    if backend == _MYSQL:
+        return f"`{identifier}`"
+    return f'"{identifier}"'  # sqlite and postgresql
+
+
+def list_data_tables(db: Any) -> list[str]:
+    """Return the user tables of an fpdb database (excludes internal tables)."""
+    cursor = db.get_cursor()
+    if db.backend == _SQLITE:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+    elif db.backend == _PGSQL:
+        cursor.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+    else:  # mysql
+        cursor.execute("SHOW TABLES")
+    return [row[0] for row in cursor.fetchall()]
+
+
+def _set_fk_enforcement(db: Any, *, enabled: bool) -> None:
+    """Enable/disable foreign-key enforcement on ``db`` (best effort)."""
+    cursor = db.get_cursor()
+    try:
+        if db.backend == _SQLITE:
+            cursor.execute(f"PRAGMA foreign_keys = {'ON' if enabled else 'OFF'}")
+        elif db.backend == _MYSQL:
+            cursor.execute(f"SET FOREIGN_KEY_CHECKS = {1 if enabled else 0}")
+        elif db.backend == _PGSQL:
+            # Requires replication/superuser; ignored if not permitted.
+            cursor.execute(f"SET session_replication_role = '{'origin' if enabled else 'replica'}'")
+    except Exception as exc:  # noqa: BLE001 - relaxing FKs is best-effort
+        log.warning("Could not toggle foreign-key enforcement (%s): %s", "on" if enabled else "off", exc)
+
+
+def _reset_sequences(dest: Any, tables: list[str]) -> None:
+    """Reset PostgreSQL identity sequences to max(id)+1 after preserving ids."""
+    if dest.backend != _PGSQL:
+        return
+    cursor = dest.get_cursor()
+    for table in tables:
+        try:
+            cursor.execute(
+                "SELECT pg_get_serial_sequence(%s, 'id')",
+                (table,),
+            )
+            row = cursor.fetchone()
+            sequence = row[0] if row else None
+            if not sequence:
+                continue
+            cursor.execute(f'SELECT setval(%s, COALESCE((SELECT MAX(id) FROM "{table}"), 0) + 1, false)', (sequence,))
+        except Exception as exc:  # noqa: BLE001 - a table may have no id sequence
+            log.debug("No sequence reset for %s: %s", table, exc)
+
+
+def _copy_table(source: Any, dest: Any, table: str) -> int:
+    """Replace the destination table's rows with the source's, preserving ids."""
+    src_cursor = source.get_cursor()
+    src_cursor.execute(f"SELECT * FROM {_quote(source.backend, table)}")
+    columns = [desc[0] for desc in src_cursor.description]
+
+    dest_cursor = dest.get_cursor()
+    dest_cursor.execute(f"DELETE FROM {_quote(dest.backend, table)}")
+
+    placeholder = dest.sql.query.get("placeholder", "%s")
+    column_list = ", ".join(_quote(dest.backend, col) for col in columns)
+    placeholders = ", ".join([placeholder] * len(columns))
+    insert = f"INSERT INTO {_quote(dest.backend, table)} ({column_list}) VALUES ({placeholders})"
+
+    copied = 0
+    while True:
+        rows = src_cursor.fetchmany(_BATCH)
+        if not rows:
+            break
+        dest_cursor.executemany(insert, rows)
+        copied += len(rows)
+    return copied
+
+
+def migrate(source: Any, dest: Any, *, progress: ProgressCallback | None = None) -> MigrationReport:
+    """Copy every fpdb table from ``source`` into ``dest`` (replacing its data).
+
+    Args:
+        source: connected Database to read from.
+        dest: connected Database (with the fpdb schema) to overwrite.
+        progress: optional callback ``(index, total, table_name)`` per table.
+
+    Returns:
+        MigrationReport with per-table row counts, or an error message.
+    """
+    report = MigrationReport()
+    tables = list_data_tables(source)
+
+    _set_fk_enforcement(dest, enabled=False)
+    try:
+        for index, table in enumerate(tables):
+            if progress is not None:
+                progress(index, len(tables), table)
+            count = _copy_table(source, dest, table)
+            report.tables[table] = count
+            report.total_rows += count
+        dest.commit()
+        _reset_sequences(dest, tables)
+        dest.commit()
+    except Exception as exc:  # noqa: BLE001 - report any failure to the caller
+        log.exception("Migration failed")
+        dest.rollback()
+        report.error = str(exc)
+    finally:
+        _set_fk_enforcement(dest, enabled=True)
+    return report

--- a/fpdb_3_legacy/db_migrate.py
+++ b/fpdb_3_legacy/db_migrate.py
@@ -49,13 +49,6 @@ class MigrationReport:
         return self.error is None
 
 
-def _quote(backend: int, identifier: str) -> str:
-    """Quote a table/column identifier for the given backend."""
-    if backend == _MYSQL:
-        return f"`{identifier}`"
-    return f'"{identifier}"'  # sqlite and postgresql
-
-
 def list_data_tables(db: Any) -> list[str]:
     """Return the user tables of an fpdb database (excludes internal tables)."""
     cursor = db.get_cursor()
@@ -68,19 +61,34 @@ def list_data_tables(db: Any) -> list[str]:
     return [row[0] for row in cursor.fetchall()]
 
 
-def _set_fk_enforcement(db: Any, *, enabled: bool) -> None:
-    """Enable/disable foreign-key enforcement on ``db`` (best effort)."""
+def _disable_fk(db: Any) -> None:
+    """Disable foreign-key enforcement on ``db``.
+
+    Raises on failure. On PostgreSQL this uses ``session_replication_role``,
+    which needs a privileged role; a failure there is fatal (a copy would abort
+    the transaction table by table), so we let it propagate and fail early.
+    """
     cursor = db.get_cursor()
+    if db.backend == _SQLITE:
+        cursor.execute("PRAGMA foreign_keys = OFF")
+    elif db.backend == _MYSQL:
+        cursor.execute("SET FOREIGN_KEY_CHECKS = 0")
+    elif db.backend == _PGSQL:
+        cursor.execute("SET session_replication_role = 'replica'")
+
+
+def _enable_fk(db: Any) -> None:
+    """Re-enable foreign-key enforcement on ``db`` (best effort)."""
     try:
+        cursor = db.get_cursor()
         if db.backend == _SQLITE:
-            cursor.execute(f"PRAGMA foreign_keys = {'ON' if enabled else 'OFF'}")
+            cursor.execute("PRAGMA foreign_keys = ON")
         elif db.backend == _MYSQL:
-            cursor.execute(f"SET FOREIGN_KEY_CHECKS = {1 if enabled else 0}")
+            cursor.execute("SET FOREIGN_KEY_CHECKS = 1")
         elif db.backend == _PGSQL:
-            # Requires replication/superuser; ignored if not permitted.
-            cursor.execute(f"SET session_replication_role = '{'origin' if enabled else 'replica'}'")
-    except Exception as exc:  # noqa: BLE001 - relaxing FKs is best-effort
-        log.warning("Could not toggle foreign-key enforcement (%s): %s", "on" if enabled else "off", exc)
+            cursor.execute("SET session_replication_role = 'origin'")
+    except Exception as exc:  # noqa: BLE001 - re-enabling is best-effort cleanup
+        log.warning("Could not re-enable foreign-key enforcement: %s", exc)
 
 
 def _reset_sequences(dest: Any, tables: list[str]) -> None:
@@ -98,24 +106,29 @@ def _reset_sequences(dest: Any, tables: list[str]) -> None:
             sequence = row[0] if row else None
             if not sequence:
                 continue
-            cursor.execute(f'SELECT setval(%s, COALESCE((SELECT MAX(id) FROM "{table}"), 0) + 1, false)', (sequence,))
+            cursor.execute(f"SELECT setval(%s, COALESCE((SELECT MAX(id) FROM {table}), 0) + 1, false)", (sequence,))
         except Exception as exc:  # noqa: BLE001 - a table may have no id sequence
             log.debug("No sequence reset for %s: %s", table, exc)
 
 
 def _copy_table(source: Any, dest: Any, table: str) -> int:
-    """Replace the destination table's rows with the source's, preserving ids."""
+    """Replace the destination table's rows with the source's, preserving ids.
+
+    Identifiers are used unquoted, matching how fpdb creates its schema and runs
+    its own queries. That keeps them case-consistent across backends (PostgreSQL
+    folds unquoted names to lower case, as it did when the tables were created).
+    """
     src_cursor = source.get_cursor()
-    src_cursor.execute(f"SELECT * FROM {_quote(source.backend, table)}")
+    src_cursor.execute(f"SELECT * FROM {table}")
     columns = [desc[0] for desc in src_cursor.description]
 
     dest_cursor = dest.get_cursor()
-    dest_cursor.execute(f"DELETE FROM {_quote(dest.backend, table)}")
+    dest_cursor.execute(f"DELETE FROM {table}")
 
     placeholder = dest.sql.query.get("placeholder", "%s")
-    column_list = ", ".join(_quote(dest.backend, col) for col in columns)
+    column_list = ", ".join(columns)
     placeholders = ", ".join([placeholder] * len(columns))
-    insert = f"INSERT INTO {_quote(dest.backend, table)} ({column_list}) VALUES ({placeholders})"
+    insert = f"INSERT INTO {table} ({column_list}) VALUES ({placeholders})"
 
     copied = 0
     while True:
@@ -141,7 +154,18 @@ def migrate(source: Any, dest: Any, *, progress: ProgressCallback | None = None)
     report = MigrationReport()
     tables = list_data_tables(source)
 
-    _set_fk_enforcement(dest, enabled=False)
+    # Relax destination foreign keys so table order doesn't matter. On PostgreSQL
+    # this needs a privileged role; if it fails the transaction is aborted, so we
+    # stop early with a clear message rather than cascading table errors.
+    try:
+        _disable_fk(dest)
+    except Exception as exc:  # noqa: BLE001 - fail fast on an unusable destination
+        log.exception("Could not disable destination foreign keys")
+        dest.rollback()
+        _enable_fk(dest)
+        report.error = f"Cannot disable foreign keys on the destination: {exc}"
+        return report
+
     try:
         for index, table in enumerate(tables):
             if progress is not None:
@@ -157,5 +181,5 @@ def migrate(source: Any, dest: Any, *, progress: ProgressCallback | None = None)
         dest.rollback()
         report.error = str(exc)
     finally:
-        _set_fk_enforcement(dest, enabled=True)
+        _enable_fk(dest)
     return report

--- a/test/test_db_migrate.py
+++ b/test/test_db_migrate.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""End-to-end tests for the cross-backend data migration engine (db_migrate).
+
+Uses two real SQLite databases (no server needed): a populated source and a
+freshly-initialised destination. Verifies that every table is copied with
+matching row counts, that edited data is carried over, and that the
+destination's own default rows are replaced rather than duplicated.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy import Configuration, db_migrate
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG_TEMPLATE = os.path.join(REPO_ROOT, "HUD_config.xml")
+
+
+def _build_db(config, db_name):
+    """Connect a Database to the named sqlite entry (schema auto-created)."""
+    from fpdb_3_legacy import Database
+
+    config.db_selected = db_name
+    return Database.Database(config)
+
+
+def _counts(db, tables):
+    counts = {}
+    cursor = db.get_cursor()
+    for table in tables:
+        cursor.execute(f'SELECT COUNT(*) FROM "{table}"')
+        counts[table] = cursor.fetchone()[0]
+    return counts
+
+
+@pytest.fixture
+def config(tmp_path):
+    cfg_path = tmp_path / "HUD_config.xml"
+    shutil.copy(CONFIG_TEMPLATE, cfg_path)
+    cfg = Configuration.Config(file=str(cfg_path))
+    cfg.dir_database = str(tmp_path)
+    cfg.add_db_parameters(db_name="source.db3", db_server="sqlite")
+    cfg.add_db_parameters(db_name="dest.db3", db_server="sqlite")
+    return cfg
+
+
+def test_migrate_sqlite_to_sqlite_copies_every_table(config):
+    source = _build_db(config, "source.db3")
+    # Make the source distinguishable from a default DB: rename a Site.
+    cur = source.get_cursor()
+    cur.execute("SELECT MIN(id) FROM Sites")
+    site_id = cur.fetchone()[0]
+    cur.execute('UPDATE Sites SET name = ? WHERE id = ?', ("MIGRATED_SITE", site_id))
+    source.commit()
+
+    tables = db_migrate.list_data_tables(source)
+    assert "Players" in tables and "Sites" in tables and "Hands" in tables
+    source_counts = _counts(source, tables)
+
+    dest = _build_db(config, "dest.db3")
+
+    report = db_migrate.migrate(source, dest)
+
+    assert report.ok, report.error
+    assert report.total_rows > 0
+    # Every table has the same number of rows as the source.
+    assert _counts(dest, tables) == source_counts
+    # The edited value was carried over (and the destination's default replaced).
+    cur = dest.get_cursor()
+    cur.execute('SELECT name FROM Sites WHERE id = ?', (site_id,))
+    assert cur.fetchone()[0] == "MIGRATED_SITE"
+
+    source.close_connection()
+    dest.close_connection()
+
+
+def test_migrate_is_idempotent(config):
+    """Running the migration twice must not duplicate rows (delete-then-copy)."""
+    source = _build_db(config, "source.db3")
+    tables = db_migrate.list_data_tables(source)
+    source_counts = _counts(source, tables)
+    dest = _build_db(config, "dest.db3")
+
+    first = db_migrate.migrate(source, dest)
+    second = db_migrate.migrate(source, dest)
+
+    assert first.ok and second.ok
+    assert _counts(dest, tables) == source_counts  # unchanged after the second run
+
+    source.close_connection()
+    dest.close_connection()
+
+
+def test_migrate_preserves_ids_of_non_default_rows(config):
+    """A user row inserted into an initially-empty table migrates with its id."""
+    source = _build_db(config, "source.db3")
+    cur = source.get_cursor()
+    cur.execute("INSERT INTO Players (id, name, siteId, hero) VALUES (?, ?, ?, ?)", (4242, "heroic", 2, 1))
+    source.commit()
+
+    dest = _build_db(config, "dest.db3")
+    report = db_migrate.migrate(source, dest)
+    assert report.ok
+
+    cur = dest.get_cursor()
+    cur.execute("SELECT name, siteId FROM Players WHERE id = ?", (4242,))
+    assert cur.fetchone() == ("heroic", 2)  # id preserved, so FKs stay valid
+
+    source.close_connection()
+    dest.close_connection()
+
+
+def test_report_lists_rows_per_table(config):
+    source = _build_db(config, "source.db3")
+    dest = _build_db(config, "dest.db3")
+    report = db_migrate.migrate(source, dest)
+    assert report.ok
+    # Actions is a lookup table populated by fillDefaultData, so it has rows.
+    assert report.tables.get("Actions", 0) > 0
+    assert report.total_rows == sum(report.tables.values())
+    source.close_connection()
+    dest.close_connection()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_db_migrate.py
+++ b/test/test_db_migrate.py
@@ -129,5 +129,28 @@ def test_report_lists_rows_per_table(config):
     dest.close_connection()
 
 
+def test_migrate_fails_fast_when_fk_disable_fails():
+    """On PostgreSQL, an unprivileged FK-disable must stop early, not cascade."""
+    from unittest.mock import MagicMock
+
+    source = MagicMock()
+    source.backend = 4  # sqlite -> list_data_tables uses sqlite_master
+    source.get_cursor.return_value.fetchall.return_value = [("Players",)]
+
+    dest = MagicMock()
+    dest.backend = 3  # postgresql
+    dest.get_cursor.return_value.execute.side_effect = Exception(
+        "permission denied to set parameter session_replication_role",
+    )
+
+    report = db_migrate.migrate(source, dest)
+
+    assert report.ok is False
+    assert "Cannot disable foreign keys" in report.error
+    dest.rollback.assert_called()
+    # It must not have attempted to copy any table into the aborted transaction.
+    assert report.tables == {}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -427,5 +427,87 @@ def test_create_schema_refuses_foreign_sqlite_file(_qapp, tmp_path):
     assert rows == [("do not delete me",)]
 
 
+# --- migration (migrate_to) ------------------------------------------------
+
+
+def test_migrate_to_orchestrates_schema_then_copy(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("src", selected=True), _fake_db("dst")])
+    panel = m.GuiDatabase(config)
+    panel.create_schema = MagicMock(return_value=m.db_backends.ConnectionResult(ok=True, message="ok"))
+    report = m.db_migrate.MigrationReport(tables={"Players": 3}, total_rows=3)
+    with patch.object(m.Database, "Database", return_value=MagicMock()), \
+            patch.object(m.db_migrate, "migrate", return_value=report) as do_migrate:
+        result = panel.migrate_to("src", "dst")
+    panel.create_schema.assert_called_once_with("dst")  # destination schema ensured first
+    do_migrate.assert_called_once()
+    assert result.total_rows == 3
+
+
+def test_migrate_to_aborts_when_dest_schema_refused(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("src", selected=True), _fake_db("dst")])
+    panel = m.GuiDatabase(config)
+    panel.create_schema = MagicMock(
+        return_value=m.db_backends.ConnectionResult(ok=False, message="non-fpdb tables"),
+    )
+    with patch.object(m.db_migrate, "migrate") as do_migrate:
+        result = panel.migrate_to("src", "dst")
+    assert result.ok is False
+    assert "non-fpdb tables" in result.error
+    do_migrate.assert_not_called()  # never migrate into an unsafe destination
+
+
+def test_migrate_to_restores_db_selected(_qapp):
+    from fpdb_3_legacy import GuiDatabase as m
+
+    config = _fake_config([_fake_db("src", selected=True), _fake_db("dst")])
+    config.db_selected = "src"
+    panel = m.GuiDatabase(config)
+    panel.create_schema = MagicMock(return_value=m.db_backends.ConnectionResult(ok=True, message="ok"))
+    with patch.object(m.Database, "Database", return_value=MagicMock()), \
+            patch.object(m.db_migrate, "migrate", return_value=m.db_migrate.MigrationReport()):
+        panel.migrate_to("src", "dst")
+    assert config.db_selected == "src"
+
+
+def test_migrate_to_real_sqlite(_qapp, tmp_path):
+    """End-to-end through the panel: source data lands in the destination."""
+    import shutil
+
+    from fpdb_3_legacy import Configuration
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    cfg_path = tmp_path / "HUD_config.xml"
+    shutil.copy(CONFIG_TEMPLATE, cfg_path)
+    config = Configuration.Config(file=str(cfg_path))
+    config.dir_database = str(tmp_path)
+    config.add_db_parameters(db_name="src.db3", db_server="sqlite")
+    config.add_db_parameters(db_name="dst.db3", db_server="sqlite")
+
+    # Put a recognisable row in the source.
+    from fpdb_3_legacy import Database
+
+    config.db_selected = "src.db3"
+    src = Database.Database(config)
+    cur = src.get_cursor()
+    cur.execute("INSERT INTO Players (id, name, siteId, hero) VALUES (?, ?, ?, ?)", (7, "migrated_hero", 2, 1))
+    src.commit()
+    src.close_connection()
+
+    panel = GuiDatabase(config)
+    report = panel.migrate_to("src.db3", "dst.db3")
+    assert report.ok, report.error
+
+    import sqlite3
+
+    conn = sqlite3.connect(str(tmp_path / "dst.db3"))
+    row = conn.execute("SELECT name FROM Players WHERE id = 7").fetchone()
+    conn.close()
+    assert row == ("migrated_hero",)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds the last piece of the multi-backend database work: **moving fpdb data between backends** (e.g. SQLite → PostgreSQL) from the GUI.

## Engine — `fpdb_3_legacy/db_migrate.py`

Both databases share the fpdb schema, so migration is a table-by-table row copy that **preserves primary keys** (no id remapping — foreign keys stay valid).

- `list_data_tables()` — user tables from the backend catalog (`sqlite_master` / `information_schema` / `SHOW TABLES`).
- `migrate(source, dest)` — relaxes foreign-key enforcement on the destination, clears + refills each table from the source (so the default lookup rows a fresh schema creates don't collide), resets PostgreSQL sequences, and returns a `MigrationReport` (per-table row counts / error). Backend-agnostic via each `Database`'s cursor and `sql.query['placeholder']`; only FK toggling and sequence reset are per-backend.

## GUI — `GuiDatabase`

A **"Migrate to..."** button: pick a destination among the other configured databases, confirm the destructive replace, and run the copy.

`migrate_to(source, dest)` ensures the destination schema first (via `create_schema` — created if empty, **refused if it holds non-fpdb tables**), connects both databases, migrates, and always restores `db_selected`.

## Verification

- Engine (real SQLite → SQLite, no server): every table copied with matching row counts, edited data carried over, idempotent re-runs, and a user row's id preserved.
- GUI: orchestration (schema-then-copy, abort when the destination is refused, `db_selected` restored) with mocks, plus a **real end-to-end run through the panel** confirming a source row lands in the destination.
- 38 DB tests pass; `ruff` clean.

## Notes / follow-ups

- The engine is backend-agnostic by construction; PostgreSQL/MySQL paths (FK toggling, sequence reset) are implemented but only exercised against real servers, which CI does not have. SQLite ↔ SQLite is fully covered.
- Migration **replaces** the destination's data (by design); the GUI confirms strongly before running.
