### PR TITLE
MySQL out of the box (PyMySQL) + Create database action

### DIFF
--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -1555,8 +1555,15 @@ class Database:
         self.hand_inc = 1
 
         if backend == Database.MYSQL_INNODB:
-            #####not working mysql connector on py3.9####
-            import MySQLdb
+            # Prefer mysqlclient (MySQLdb); fall back to the pure-Python pymysql
+            # shim so MySQL works without the system libraries mysqlclient needs.
+            try:
+                import MySQLdb
+            except ImportError:
+                import pymysql
+
+                pymysql.install_as_MySQLdb()
+                import MySQLdb
 
             # Note: SQLAlchemy 2.0 removed pool.manage
             # MySQLdb has its own connection pooling, so we don't need it

--- a/fpdb_3_legacy/GuiDatabase.py
+++ b/fpdb_3_legacy/GuiDatabase.py
@@ -202,17 +202,19 @@ class GuiDatabase(QWidget):
         self.editButton = QPushButton("Edit...")
         self.deleteButton = QPushButton("Delete")
         self.defaultButton = QPushButton("Set as default")
+        self.createDbButton = QPushButton("Create database")
         self.createButton = QPushButton("Create tables")
         self.migrateButton = QPushButton("Migrate to...")
         self.addButton.clicked.connect(self._on_add)
         self.editButton.clicked.connect(self._on_edit)
         self.deleteButton.clicked.connect(self._on_delete)
         self.defaultButton.clicked.connect(self._on_set_default)
+        self.createDbButton.clicked.connect(self._on_create_database)
         self.createButton.clicked.connect(self._on_create_schema)
         self.migrateButton.clicked.connect(self._on_migrate)
         for b in (
-            self.addButton, self.editButton, self.deleteButton,
-            self.defaultButton, self.createButton, self.migrateButton,
+            self.addButton, self.editButton, self.deleteButton, self.defaultButton,
+            self.createDbButton, self.createButton, self.migrateButton,
         ):
             buttons.addWidget(b)
         layout.addLayout(buttons)
@@ -355,6 +357,20 @@ class GuiDatabase(QWidget):
             finally:
                 db.close_connection()
 
+    def create_database(self, db_name: str, admin_user: str, admin_password: str) -> db_backends.ConnectionResult:
+        """Create the server-side database for ``db_name`` using admin credentials."""
+        entry = self.config.supported_databases.get(db_name)
+        if entry is None:
+            return db_backends.ConnectionResult(ok=False, message=f"Unknown database '{db_name}'.")
+        return db_backends.create_database(
+            entry.db_server,
+            database=entry.db_name,
+            host=entry.db_ip,
+            port=entry.db_port,
+            admin_user=admin_user,
+            admin_password=admin_password,
+        )
+
     def migrate_to(self, source_name: str, dest_name: str) -> db_migrate.MigrationReport:
         """Copy all data from ``source_name`` into ``dest_name`` (replacing it).
 
@@ -457,6 +473,49 @@ class GuiDatabase(QWidget):
             QMessageBox.information(self, "Create tables", result.message)
         else:
             QMessageBox.warning(self, "Create tables", result.message)
+
+    def _on_create_database(self) -> None:
+        name = self.selected_db_name()
+        if name is None:
+            return
+        entry = self.config.supported_databases.get(name)
+        if entry is None:
+            return
+        if entry.db_server == "sqlite":
+            QMessageBox.information(
+                self,
+                "Create database",
+                "SQLite databases are created automatically. Use 'Create tables' to initialise the schema.",
+            )
+            return
+        host = entry.db_ip or "localhost"
+        default_admin = entry.db_user or ("postgres" if entry.db_server == "postgresql" else "root")
+        admin_user, ok = QInputDialog.getText(
+            self,
+            "Create database",
+            f"Administrator account allowed to create '{entry.db_name}' on {host}:",
+            QLineEdit.EchoMode.Normal,
+            default_admin,
+        )
+        if not ok:
+            return
+        admin_password, ok = QInputDialog.getText(
+            self,
+            "Create database",
+            f"Password for '{admin_user}':",
+            QLineEdit.EchoMode.Password,
+        )
+        if not ok:
+            return
+        result = self.create_database(name, admin_user, admin_password)
+        if result.ok:
+            QMessageBox.information(
+                self,
+                "Create database",
+                f"{result.message}\n\nUse 'Create tables' next to initialise the fpdb schema.",
+            )
+        else:
+            QMessageBox.warning(self, "Create database", result.message)
 
     def _on_migrate(self) -> None:
         source = self.selected_db_name()

--- a/fpdb_3_legacy/db_backends.py
+++ b/fpdb_3_legacy/db_backends.py
@@ -322,3 +322,81 @@ def _mysql_tables(database, host, port, user, password) -> set[str]:
     finally:
         conn.close()
     return {row[0] for row in rows}
+
+
+# --- database creation (CREATE DATABASE) -----------------------------------
+#
+# fpdb's "Create tables" only builds the schema inside an existing database.
+# For a fresh PostgreSQL/MySQL server the database itself must be created first,
+# which needs an administrator account (the fpdb user usually cannot). These
+# helpers connect to the server's maintenance database with admin credentials
+# and issue CREATE DATABASE. SQLite needs nothing (the file is created on use).
+
+
+def create_database(
+    server: str,
+    *,
+    database: str,
+    host: str | None = None,
+    port: str | int | None = None,
+    admin_user: str | None = None,
+    admin_password: str | None = None,
+) -> ConnectionResult:
+    """Create the server-side database ``database`` using admin credentials."""
+    if server not in BACKENDS:
+        return ConnectionResult(ok=False, message=f"Unsupported database backend: {server!r}")
+    if server == "sqlite":
+        return ConnectionResult(ok=True, message="SQLite databases are created automatically on first use.")
+    if not driver_available(server):
+        return ConnectionResult(ok=False, message=f"Driver for {server} is not installed.")
+    if not database:
+        return ConnectionResult(ok=False, message="A database name is required.")
+    try:
+        if server == "postgresql":
+            return _create_postgresql_database(database, host, port, admin_user, admin_password)
+        return _create_mysql_database(database, host, port, admin_user, admin_password)
+    except Exception as exc:  # noqa: BLE001 - surface any driver/permission error
+        return ConnectionResult(ok=False, message=str(exc))
+
+
+def _create_postgresql_database(database, host, port, user, password) -> ConnectionResult:
+    import psycopg
+
+    # CREATE DATABASE cannot run in a transaction, so use autocommit, and it
+    # cannot take a bind parameter for the name, so quote the identifier safely.
+    conn = psycopg.connect(
+        host=host or None,
+        port=_coerce_port(port),
+        user=user or None,
+        password=password or None,
+        dbname="postgres",  # maintenance database
+        autocommit=True,
+        connect_timeout=5,
+    )
+    try:
+        exists = conn.execute("SELECT 1 FROM pg_database WHERE datname = %s", (database,)).fetchone()
+        if exists:
+            return ConnectionResult(ok=True, message=f"Database '{database}' already exists.")
+        conn.execute(f'CREATE DATABASE "{database.replace(chr(34), chr(34) * 2)}"')
+    finally:
+        conn.close()
+    return ConnectionResult(ok=True, message=f"Created database '{database}'.")
+
+
+def _create_mysql_database(database, host, port, user, password) -> ConnectionResult:
+    mysqldb = import_mysqldb()
+
+    conn = mysqldb.connect(
+        host=host or "localhost",
+        user=user or None,
+        passwd=password or "",
+        port=_coerce_port(port) or 3306,
+        connect_timeout=5,
+    )
+    try:
+        cursor = conn.cursor()
+        cursor.execute(f"CREATE DATABASE IF NOT EXISTS `{database.replace('`', '``')}`")
+        conn.commit()
+    finally:
+        conn.close()
+    return ConnectionResult(ok=True, message=f"Created database '{database}' (or it already existed).")

--- a/fpdb_3_legacy/db_backends.py
+++ b/fpdb_3_legacy/db_backends.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import importlib.util
 import os
 from dataclasses import dataclass
+from types import ModuleType
 
 # db_server -> (human label, driver module name, needs host/port/user/pass fields)
 BACKENDS: dict[str, tuple[str, str, bool]] = {
@@ -36,13 +37,34 @@ def backend_id(server: str) -> int:
         raise ValueError(msg) from None
 
 
+# Acceptable driver modules per backend. MySQL accepts the pure-Python pymysql
+# as a drop-in fallback (via install_as_MySQLdb), so it works without the system
+# libraries that mysqlclient needs.
+_DRIVER_MODULES: dict[str, tuple[str, ...]] = {
+    "sqlite": ("sqlite3",),
+    "postgresql": ("psycopg",),
+    "mysql": ("MySQLdb", "pymysql"),
+}
+
+
 def driver_available(server: str) -> bool:
-    """Return True if the Python driver for ``server`` is importable."""
-    try:
-        module_name = BACKENDS[server][1]
-    except KeyError:
+    """Return True if a Python driver for ``server`` is importable."""
+    modules = _DRIVER_MODULES.get(server)
+    if not modules:
         return False
-    return importlib.util.find_spec(module_name) is not None
+    return any(importlib.util.find_spec(module) is not None for module in modules)
+
+
+def import_mysqldb() -> ModuleType:
+    """Import MySQLdb, falling back to pymysql's MySQLdb-compatible shim."""
+    try:
+        import MySQLdb  # noqa: PLC0415 - optional driver imported on demand
+    except ImportError:
+        import pymysql  # noqa: PLC0415 - pure-Python fallback
+
+        pymysql.install_as_MySQLdb()
+        import MySQLdb  # noqa: PLC0415
+    return MySQLdb
 
 
 def available_backends() -> dict[str, bool]:
@@ -159,7 +181,7 @@ def _test_postgresql(database, host, port, user, password) -> ConnectionResult:
 
 
 def _test_mysql(database, host, port, user, password) -> ConnectionResult:
-    import MySQLdb
+    MySQLdb = import_mysqldb()
 
     kwargs = {
         "host": host or "localhost",
@@ -280,7 +302,7 @@ def _postgresql_tables(database, host, port, user, password) -> set[str]:
 
 
 def _mysql_tables(database, host, port, user, password) -> set[str]:
-    import MySQLdb
+    MySQLdb = import_mysqldb()
 
     kwargs = {
         "host": host or "localhost",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "mplfinance>=0.12.10b0",
     "xlrd==2.0.1",
     "playwright>=1.40.0",
+    "pymysql>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/test/test_db_backends.py
+++ b/test/test_db_backends.py
@@ -37,6 +37,24 @@ def test_available_backends_reflects_missing_driver():
     assert backends == {"sqlite": False, "postgresql": False, "mysql": False}
 
 
+def test_mysql_available_via_pymysql():
+    """MySQL must be offered when only the pure-Python pymysql driver is present."""
+    with patch.object(
+        db_backends.importlib.util,
+        "find_spec",
+        side_effect=lambda name: object() if name == "pymysql" else None,
+    ):
+        assert db_backends.driver_available("mysql") is True  # pymysql fallback
+        assert db_backends.driver_available("postgresql") is False  # psycopg absent
+
+
+def test_import_mysqldb_returns_usable_driver():
+    """import_mysqldb returns a MySQLdb-compatible module (pymysql shim if needed)."""
+    driver = db_backends.import_mysqldb()
+    assert hasattr(driver, "connect")
+    assert hasattr(driver, "Error")
+
+
 # --- SQLite (real driver, real filesystem) ---------------------------------
 
 

--- a/test/test_db_backends.py
+++ b/test/test_db_backends.py
@@ -221,5 +221,73 @@ def test_inspect_missing_driver_is_unreachable():
     assert "not installed" in detail
 
 
+# --- create_database (CREATE DATABASE) -------------------------------------
+
+
+def test_create_database_sqlite_is_noop():
+    result = db_backends.create_database("sqlite", database="fpdb.db3")
+    assert result.ok is True
+    assert "automatically" in result.message
+
+
+def test_create_database_requires_a_name():
+    with patch.object(db_backends, "driver_available", return_value=True):
+        result = db_backends.create_database("postgresql", database="")
+    assert result.ok is False
+    assert "name is required" in result.message
+
+
+def test_create_database_reports_missing_driver():
+    with patch.object(db_backends, "driver_available", return_value=False):
+        result = db_backends.create_database("postgresql", database="fpdb")
+    assert result.ok is False
+    assert "Driver" in result.message
+
+
+def test_create_database_postgresql_creates_when_absent():
+    fake_psycopg = MagicMock()
+    conn = fake_psycopg.connect.return_value
+    conn.execute.return_value.fetchone.return_value = None  # database not present
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"psycopg": fake_psycopg},
+    ):
+        result = db_backends.create_database(
+            "postgresql", database="fpdb", host="h", admin_user="admin", admin_password="p",
+        )
+    assert result.ok is True
+    assert "Created" in result.message
+    statements = [str(c.args[0]) for c in conn.execute.call_args_list if c.args]
+    assert any("CREATE DATABASE" in s for s in statements)
+    # Connected to the maintenance database, not the target one.
+    assert fake_psycopg.connect.call_args.kwargs["dbname"] == "postgres"
+
+
+def test_create_database_postgresql_skips_when_present():
+    fake_psycopg = MagicMock()
+    conn = fake_psycopg.connect.return_value
+    conn.execute.return_value.fetchone.return_value = (1,)  # already exists
+    with patch.object(db_backends, "driver_available", return_value=True), patch.dict(
+        sys.modules, {"psycopg": fake_psycopg},
+    ):
+        result = db_backends.create_database("postgresql", database="fpdb", admin_user="a", admin_password="p")
+    assert result.ok is True
+    assert "already exists" in result.message
+    statements = [str(c.args[0]) for c in conn.execute.call_args_list if c.args]
+    assert not any("CREATE DATABASE" in s for s in statements)
+
+
+def test_create_database_mysql_issues_create_if_not_exists():
+    fake_mysqldb = MagicMock()
+    with patch.object(db_backends, "driver_available", return_value=True), patch.object(
+        db_backends, "import_mysqldb", return_value=fake_mysqldb,
+    ):
+        result = db_backends.create_database(
+            "mysql", database="fpdb", host="h", admin_user="root", admin_password="p",
+        )
+    assert result.ok is True
+    cursor = fake_mysqldb.connect.return_value.cursor.return_value
+    assert "CREATE DATABASE IF NOT EXISTS" in cursor.execute.call_args.args[0]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -108,6 +108,32 @@ def test_selected_db_name(_qapp):
     assert panel.selected_db_name() == "b"
 
 
+def test_create_database_delegates_entry_fields(_qapp):
+    from fpdb_3_legacy import GuiDatabase as gui_db_module
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("pg", "postgresql", ip="dbhost", port="5432", user="alice")])
+    panel = GuiDatabase(config)
+    with patch.object(gui_db_module.db_backends, "create_database") as create:
+        create.return_value = gui_db_module.db_backends.ConnectionResult(ok=True, message="Created database 'pg'.")
+        result = panel.create_database("pg", "admin", "secret")
+    assert result.ok is True
+    create.assert_called_once_with(
+        "postgresql", database="pg", host="dbhost", port="5432",
+        admin_user="admin", admin_password="secret",
+    )
+
+
+def test_create_database_unknown_name_is_reported(_qapp):
+    from fpdb_3_legacy.GuiDatabase import GuiDatabase
+
+    config = _fake_config([_fake_db("fpdb", "sqlite")])
+    panel = GuiDatabase(config)
+    result = panel.create_database("missing", "admin", "secret")
+    assert result.ok is False
+    assert "Unknown database" in result.message
+
+
 # --- DatabaseEditDialog ----------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -730,6 +730,7 @@ dependencies = [
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "playwright" },
     { name = "psutil" },
+    { name = "pymysql" },
     { name = "pyobjc", marker = "sys_platform == 'darwin'" },
     { name = "pyside6" },
     { name = "pytz" },
@@ -804,6 +805,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'test'", specifier = ">=3.1.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'test-no-gui'", specifier = ">=3.1.0" },
     { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.9.0" },
+    { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pyobjc", marker = "sys_platform == 'darwin'", specifier = "==10.3.1" },
     { name = "pyside6", specifier = ">=6.8.1" },
     { name = "pyside6", marker = "extra == 'linux'", specifier = ">=6.8.1" },
@@ -2441,6 +2443,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two fixes for the Databases panel, both coming from real usage: MySQL was greyed out, and there was no way to create a brand-new PostgreSQL/MySQL database from the GUI.

## MySQL without a build step (PyMySQL)
`mysqlclient` needs native build tools, so MySQL stayed unavailable on a fresh install. Add the pure-Python `pymysql` driver as a dependency and use it as a `MySQLdb` drop-in (`install_as_MySQLdb()`), so MySQL now works out of the box.

- `driver_available("mysql")` accepts either `MySQLdb` or `pymysql`
- `import_mysqldb()` returns the real driver or the pymysql shim
- `Database.py` MySQL connect path falls back to pymysql

## Create database action
A fresh PostgreSQL/MySQL server left users stuck: "Create tables" fails when the database itself does not exist yet.

- `db_backends.create_database()` connects with admin credentials to the maintenance database and issues `CREATE DATABASE`, skipping if it already exists; SQLite is a no-op (file is created on first use)
- New "Create database" button in the panel prompts for an admin account + password, then points the user to "Create tables"

## Tests
- pymysql fallback + `import_mysqldb` usability
- `create_database`: sqlite no-op, missing name/driver, PostgreSQL create/already-exists (mocked), MySQL `CREATE DATABASE IF NOT EXISTS` (mocked)
- GuiDatabase `create_database` delegation + unknown-name handling

63 tests pass; ruff clean.