### PR TITLE
fix(coinpoker): show the HUD on Windows (table window detection + multi-table by argv)

### DIFF
--- a/fpdb/infrastructure/platform/coinpoker_process.py
+++ b/fpdb/infrastructure/platform/coinpoker_process.py
@@ -1,0 +1,29 @@
+"""Shared CoinPoker table-id extraction from a Unity process command line.
+
+CoinPoker renders each open table in its own Unity process and passes the table
+identifier on that process's command line, e.g.::
+
+    ... roomName=NL 0.01-0.02 EV-INRIT-(A) 930357 ...
+    ... -logFile /Users/.../Library/Logs/CoinPoker/table_930357.log
+
+The on-screen window is owned by the same PID, so ``window -> PID -> argv ->
+table id`` is a deterministic mapping that needs no window title, pixel OCR, or
+elevated privilege. Only fetching the argv is platform-specific (``ps`` on
+macOS, ``psutil`` on Windows); this parser is shared.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ``-logFile .../table_<id>.log`` is the least ambiguous anchor; the trailing
+# number of ``roomName=`` / ``pipeName=`` is the fallback. ``\d{4,}`` keeps the
+# 2-digit stake components (e.g. "0.01-0.02") from being mistaken for the id.
+_LOGFILE_RE = re.compile(r"table_(\d+)\.log")
+_ROOMNAME_RE = re.compile(r"(?:room|pipe)Name=.*?(\d{4,})(?:\s|$)")
+
+
+def extract_table_id(argv: str) -> str | None:
+    """Extract a CoinPoker table id from a command line (pure, for testing)."""
+    match = _LOGFILE_RE.search(argv) or _ROOMNAME_RE.search(argv)
+    return match.group(1) if match else None

--- a/fpdb/infrastructure/platform/macos_process.py
+++ b/fpdb/infrastructure/platform/macos_process.py
@@ -20,9 +20,11 @@ can fall back to OCR or the existing heuristics.
 from __future__ import annotations
 
 import logging
-import re
 import subprocess
 import time
+
+# extract_table_id is re-exported for callers and tests that import it here.
+from .coinpoker_process import extract_table_id
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +32,6 @@ logger = logging.getLogger(__name__)
 # every HUD poll.
 _TTL = 5.0
 _cache: dict[int, tuple[float, str | None]] = {}
-
-# ``-logFile .../table_<id>.log`` is the least ambiguous anchor; the trailing
-# number of ``roomName=`` / ``pipeName=`` is the fallback.
-_LOGFILE_RE = re.compile(r"table_(\d+)\.log")
-_ROOMNAME_RE = re.compile(r"(?:room|pipe)Name=.*?(\d{4,})(?:\s|$)")
 
 
 def _argv_for_pid(pid: int) -> str:
@@ -66,18 +63,9 @@ def table_id_for_pid(pid: int, *, force: bool = False) -> str | None:
 
     table_id: str | None = None
     try:
-        argv = _argv_for_pid(pid)
-        match = _LOGFILE_RE.search(argv) or _ROOMNAME_RE.search(argv)
-        if match:
-            table_id = match.group(1)
+        table_id = extract_table_id(_argv_for_pid(pid))
     except Exception as exc:  # pragma: no cover - platform dependent
         logger.debug("Could not read argv for pid %s: %s", pid, exc)
 
     _cache[pid] = (now, table_id)
     return table_id
-
-
-def extract_table_id(argv: str) -> str | None:
-    """Extract a CoinPoker table id from a command line (pure, for testing)."""
-    match = _LOGFILE_RE.search(argv) or _ROOMNAME_RE.search(argv)
-    return match.group(1) if match else None

--- a/fpdb/infrastructure/platform/protocol.py
+++ b/fpdb/infrastructure/platform/protocol.py
@@ -75,6 +75,10 @@ class TableInfo:
         geometry: Window position and size
         process_name: Name of the owning process (e.g., "PokerStars")
         process_id: Platform-specific process identifier
+        window_class: Native window class name, when the platform exposes it
+            (Win32 GetClassName). Used to disambiguate clients that give every
+            window the same title -- e.g. CoinPoker, whose Unity table window
+            and Chromium lobby are both titled "CoinPoker". None elsewhere.
     """
 
     window_id: int | str
@@ -82,6 +86,7 @@ class TableInfo:
     geometry: TableGeometry
     process_name: str | None = None
     process_id: int | None = None
+    window_class: str | None = None
 
     def matches_search(self, search_string: str) -> bool:
         """Check if this table matches a search string

--- a/fpdb/infrastructure/platform/windows.py
+++ b/fpdb/infrastructure/platform/windows.py
@@ -42,6 +42,7 @@ class WindowsTableDetector:
             self._EnumWindows = ctypes_api.windll.user32.EnumWindows
             self._GetWindowText = ctypes_api.windll.user32.GetWindowTextW
             self._GetWindowTextLength = ctypes_api.windll.user32.GetWindowTextLengthW
+            self._GetClassName = ctypes_api.windll.user32.GetClassNameW
             self._IsWindowVisible = ctypes_api.windll.user32.IsWindowVisible
             self._GetWindowRect = ctypes_api.windll.user32.GetWindowRect
             self._SetForegroundWindow = ctypes_api.windll.user32.SetForegroundWindow
@@ -94,10 +95,13 @@ class WindowsTableDetector:
                 if pattern is None or pattern.search(title):
                     geometry = self.get_window_geometry(hwnd)
                     if geometry:
+                        cls_buff = self._ctypes.create_unicode_buffer(256)
+                        self._GetClassName(hwnd, cls_buff, 256)
                         table_info = TableInfo(
                             window_id=hwnd,
                             title=title,
                             geometry=geometry,
+                            window_class=cls_buff.value or None,
                         )
                         tables.append(table_info)
             return True

--- a/fpdb/infrastructure/platform/windows.py
+++ b/fpdb/infrastructure/platform/windows.py
@@ -43,6 +43,7 @@ class WindowsTableDetector:
             self._GetWindowText = ctypes_api.windll.user32.GetWindowTextW
             self._GetWindowTextLength = ctypes_api.windll.user32.GetWindowTextLengthW
             self._GetClassName = ctypes_api.windll.user32.GetClassNameW
+            self._GetWindowThreadProcessId = ctypes_api.windll.user32.GetWindowThreadProcessId
             self._IsWindowVisible = ctypes_api.windll.user32.IsWindowVisible
             self._GetWindowRect = ctypes_api.windll.user32.GetWindowRect
             self._SetForegroundWindow = ctypes_api.windll.user32.SetForegroundWindow
@@ -97,10 +98,13 @@ class WindowsTableDetector:
                     if geometry:
                         cls_buff = self._ctypes.create_unicode_buffer(256)
                         self._GetClassName(hwnd, cls_buff, 256)
+                        pid = self._wintypes.DWORD()
+                        self._GetWindowThreadProcessId(hwnd, self._ctypes.byref(pid))
                         table_info = TableInfo(
                             window_id=hwnd,
                             title=title,
                             geometry=geometry,
+                            process_id=pid.value or None,
                             window_class=cls_buff.value or None,
                         )
                         tables.append(table_info)

--- a/fpdb/infrastructure/platform/windows_process.py
+++ b/fpdb/infrastructure/platform/windows_process.py
@@ -1,0 +1,60 @@
+"""Resolve a Windows CoinPoker table window to its table id via process argv.
+
+Windows counterpart of ``macos_process``: CoinPoker renders each open table in
+its own Unity process (``...\\CoinPoker Game\\CoinPoker.exe``) whose command line
+carries the table id (``roomName=... <id>`` / ``-logFile ...\\table_<id>.log``).
+A window resolves to that process via ``GetWindowThreadProcessId``, so
+``window -> PID -> argv -> table id`` tells multiple open tables apart with no
+window title, pixel OCR, or elevated privilege. The argv is read with ``psutil``
+(already a dependency) rather than shelling out.
+
+Returns ``None`` (never raises) when the table id cannot be resolved, so callers
+can fall back to the window-class heuristic.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from .coinpoker_process import extract_table_id
+
+logger = logging.getLogger(__name__)
+
+# argv is stable for a table's lifetime; cache per PID to avoid re-reading it on
+# every HUD poll.
+_TTL = 5.0
+_cache: dict[int, tuple[float, str | None]] = {}
+
+
+def _argv_for_pid(pid: int) -> str:
+    import psutil
+
+    return " ".join(psutil.Process(pid).cmdline())
+
+
+def table_id_for_pid(pid: int, *, force: bool = False) -> str | None:
+    """Return the CoinPoker table id owned by ``pid``, or ``None``.
+
+    Cached per PID for a few seconds.
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+
+    now = time.monotonic()
+    hit = _cache.get(pid)
+    if hit and not force and now - hit[0] < _TTL:
+        return hit[1]
+
+    table_id: str | None = None
+    try:
+        table_id = extract_table_id(_argv_for_pid(pid))
+    except Exception as exc:  # pragma: no cover - platform/psutil dependent
+        logger.debug("Could not read argv for pid %s: %s", pid, exc)
+
+    _cache[pid] = (now, table_id)
+    return table_id

--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -99,6 +99,62 @@ class Table(Table_Window):
             return True
         return window_class == COINPOKER_TABLE_CLASS
 
+    def _match_coinpoker_by_argv(self, tables):
+        """Return the CoinPoker window owning the requested table id, or None.
+
+        Each CoinPoker table is a separate Unity process whose command line
+        carries the table id (window -> PID -> argv -> id), so this tells several
+        open tables apart -- the window-class heuristic alone cannot. Returns
+        None when argv is unavailable (psutil missing / access denied), so the
+        caller falls back to the class heuristic for the single-table case.
+        """
+        try:
+            from fpdb.infrastructure.platform.windows_process import table_id_for_pid
+        except ImportError:
+            return None
+        target = "".join(ch for ch in str(self.search_string) if ch.isdigit())
+        if not target:
+            return None
+        for table_info in tables:
+            pid = getattr(table_info, "process_id", None)
+            if not pid:
+                continue
+            try:
+                if table_id_for_pid(pid) == target:
+                    return table_info
+            except Exception as exc:  # pragma: no cover - psutil/platform dependent
+                log.debug("argv lookup failed for pid %s: %s", pid, exc)
+        return None
+
+    def _select_window(self, tables, search_str):
+        """Pick the table window from candidates, or None if none qualifies."""
+        is_coinpoker = getattr(self, "site", "") == "CoinPoker"
+        if is_coinpoker:
+            # Prefer the exact table by process argv (multi-table safe); the
+            # class heuristic below is the single-table fallback.
+            argv_match = self._match_coinpoker_by_argv(tables)
+            if argv_match is not None:
+                return argv_match
+
+        for table_info in tables:
+            try:
+                title = table_info.title
+                if not title:
+                    continue
+                if self.check_bad_words(title):
+                    log.debug("Window rejected due to bad words: %s", title)
+                    continue
+                if search_str == "Winamax" and not self._matches_winamax_tournament(title):
+                    log.debug("Winamax window rejected for current tournament/table: %s", title)
+                    continue
+                if is_coinpoker and not self._is_coinpoker_table(table_info):
+                    log.debug("CoinPoker window rejected (not the Unity table window): %s", title)
+                    continue
+                return table_info
+            except Exception as e:  # intentional broad catch: OS window enumeration boundary, log and keep scanning
+                log.exception("Unexpected error processing window: %s", e)
+        return None
+
     def find_table_parameters(self) -> None:
         """Find a poker client window with the given table name.
 
@@ -107,49 +163,24 @@ class Table(Table_Window):
         log.debug("Starting window detection for search string: %s", self.search_string)
 
         search_str = self._detection_search_string()
-        is_coinpoker = getattr(self, "site", "") == "CoinPoker"
-
-        # Use platform abstraction layer to find tables
         tables = self._detector.find_tables(search_str)
         log.debug("Found %d matching windows", len(tables))
 
-        for table_info in tables:
-            try:
-                title = table_info.title
-                if not title:
-                    continue
+        match = self._select_window(tables, search_str)
+        if match is not None:
+            self.number = match.window_id
+            self.title = match.title
+            self._table_geometry = match.geometry
+            log.debug("Found table - HWND: %s, Title: %s", self.number, self.title)
+            return
 
-                # Check bad words
-                if self.check_bad_words(title):
-                    log.debug("Window rejected due to bad words: %s", title)
-                    continue
-
-                if search_str == "Winamax" and not self._matches_winamax_tournament(title):
-                    log.debug("Winamax window rejected for current tournament/table: %s", title)
-                    continue
-
-                if is_coinpoker and not self._is_coinpoker_table(table_info):
-                    log.debug("CoinPoker window rejected (not the Unity table window): %s", title)
-                    continue
-
-                # Found matching table
-                self.number = table_info.window_id
-                self.title = title
-                self._table_geometry = table_info.geometry
-                log.debug("Found table - HWND: %s, Title: %s", self.number, self.title)
-                break
-
-            except Exception as e:  # intentional broad catch: OS window enumeration boundary, log and keep scanning
-                log.exception("Unexpected error processing window: %s", e)
-
-        if self.number is None:
-            log.warning("Window '%s' not found.", self.search_string)
-            try:
-                all_tables = self._detector.find_tables("")
-                titles = [t.title for t in all_tables if t.title]
-                log.warning("Currently open windows: %s", titles)
-            except Exception as e:
-                log.warning("Could not list open windows: %s", e)
+        log.warning("Window '%s' not found.", self.search_string)
+        try:
+            all_tables = self._detector.find_tables("")
+            titles = [t.title for t in all_tables if t.title]
+            log.warning("Currently open windows: %s", titles)
+        except Exception as e:
+            log.warning("Could not list open windows: %s", e)
 
     def get_geometry(self):
         """Get the window geometry using platform abstraction."""

--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -39,6 +39,11 @@ if sys.platform == "win32":
 b_width = 3
 tb_height = 29
 
+# CoinPoker renders each table in a Unity window whose title is just "CoinPoker"
+# (no table number), while the lobby is a Chromium window with the *same* title.
+# The table is told apart by its native window class, not the title.
+COINPOKER_TABLE_CLASS = "UnityWndClass"
+
 
 class Table(Table_Window):
     """Windows-specific table window implementation.
@@ -66,6 +71,34 @@ class Table(Table_Window):
         # optional leading zeros when matching table "3" against "#03".
         return bool(re.search(rf"(?:#|Table\s*)0*{re.escape(table)}\b", title, re.IGNORECASE))
 
+    def _detection_search_string(self) -> str:
+        """Broaden the title search for clients whose title omits the table id.
+
+        Winamax's title does not always match the precise getTableTitleRe regex,
+        and CoinPoker titles every window just "CoinPoker"; in both cases we
+        search on the client name and filter the matches afterwards.
+        """
+        search_str = self.search_string
+        if "Winamax" in search_str:
+            log.debug("Winamax detected, adjusted search string to: Winamax")
+            return "Winamax"
+        if getattr(self, "site", "") == "CoinPoker":
+            log.debug("CoinPoker detected, adjusted search string to: CoinPoker")
+            return "CoinPoker"
+        return search_str
+
+    def _is_coinpoker_table(self, table_info) -> bool:
+        """True for the CoinPoker Unity table window, False for its Chromium lobby.
+
+        Both are titled "CoinPoker"; only the native window class tells them
+        apart. If the detector could not report a class (non-Windows, or an
+        older detector), accept the window rather than hide the HUD.
+        """
+        window_class = getattr(table_info, "window_class", None)
+        if window_class is None:
+            return True
+        return window_class == COINPOKER_TABLE_CLASS
+
     def find_table_parameters(self) -> None:
         """Find a poker client window with the given table name.
 
@@ -73,16 +106,8 @@ class Table(Table_Window):
         """
         log.debug("Starting window detection for search string: %s", self.search_string)
 
-        # Winamax special handling: the exact window-title format of the Winamax
-        # client does not always match the precise regex from getTableTitleRe, so
-        # we broaden the search to any "Winamax" window and then filter it below
-        # with _matches_winamax_tournament. (The previous code did
-        # search_string.split(" ")[0], which kept the leading "^" regex anchor and
-        # produced "^Winamax" — a pattern no window title ever contains.)
-        search_str = self.search_string
-        if "Winamax" in search_str:
-            search_str = "Winamax"
-            log.debug("Winamax detected, adjusted search string to: %s", search_str)
+        search_str = self._detection_search_string()
+        is_coinpoker = getattr(self, "site", "") == "CoinPoker"
 
         # Use platform abstraction layer to find tables
         tables = self._detector.find_tables(search_str)
@@ -101,6 +126,10 @@ class Table(Table_Window):
 
                 if search_str == "Winamax" and not self._matches_winamax_tournament(title):
                     log.debug("Winamax window rejected for current tournament/table: %s", title)
+                    continue
+
+                if is_coinpoker and not self._is_coinpoker_table(table_info):
+                    log.debug("CoinPoker window rejected (not the Unity table window): %s", title)
                     continue
 
                 # Found matching table

--- a/test/test_coinpoker_process.py
+++ b/test/test_coinpoker_process.py
@@ -1,0 +1,55 @@
+"""CoinPoker table-id resolution from process argv (shared parser + Windows).
+
+The pure ``extract_table_id`` parser is shared by macOS and Windows; the Windows
+``table_id_for_pid`` reads argv via psutil, mocked here so the test is portable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fpdb.infrastructure.platform.coinpoker_process import extract_table_id
+
+# A real Windows CoinPoker Unity command line (quotes dropped by argv splitting).
+_WIN_ARGV = (
+    r'C:\Program Files\CoinPoker\resources\unity-resources-win-x64\CoinPoker Game\CoinPoker.exe '
+    "serverIp=poker-nlb.coinpoker.ai:7003 roomName=NL 0.01-0.02 EV-INRIT-(A) 930357 "
+    "isSuspectedFraud=false tableSize=6 lobbyId=1 pipeName=NL 0.01-0.02 EV-INRIT-(A) 930357 "
+    r"-logFile C:\Users\jd\AppData\Roaming\CoinPoker\logs\table_930357.log"
+)
+
+
+def test_extract_prefers_logfile_anchor() -> None:
+    assert extract_table_id(_WIN_ARGV) == "930357"
+
+
+def test_extract_from_roomname_without_logfile() -> None:
+    argv = "CoinPoker serverIp=x:7003 roomName=NL 0.01-0.02 EV-INRIT-(A) 166755 tableSize=6"
+    assert extract_table_id(argv) == "166755"
+
+
+def test_stake_digits_not_mistaken_for_id() -> None:
+    assert extract_table_id("CoinPoker roomName=PLO 0.01-0.02 (A) 922564") == "922564"
+
+
+def test_no_id_returns_none() -> None:
+    assert extract_table_id("CoinPoker --type=renderer --user-data-dir=x") is None
+    assert extract_table_id("") is None
+
+
+def test_windows_table_id_for_pid_reads_argv_via_psutil() -> None:
+    from fpdb.infrastructure.platform import windows_process
+
+    windows_process._cache.clear()
+    with patch.object(windows_process, "_argv_for_pid", return_value=_WIN_ARGV):
+        assert windows_process.table_id_for_pid(956) == "930357"
+
+
+def test_windows_table_id_for_pid_handles_bad_pid_and_errors() -> None:
+    from fpdb.infrastructure.platform import windows_process
+
+    windows_process._cache.clear()
+    assert windows_process.table_id_for_pid(0) is None
+    assert windows_process.table_id_for_pid("nope") is None
+    with patch.object(windows_process, "_argv_for_pid", side_effect=OSError("no such process")):
+        assert windows_process.table_id_for_pid(4242) is None

--- a/test/test_platform_abstraction.py
+++ b/test/test_platform_abstraction.py
@@ -22,6 +22,10 @@ def test_geometry_and_table_matching_contracts() -> None:
     assert not geometry.intersects(TableGeometry(x=110, y=100, width=20, height=20))
     table = TableInfo(window_id=1, title="Winamax Table Alpha", geometry=geometry)
     assert table.matches_search("winamax")
+    # window_class is optional metadata, absent unless the platform reports it.
+    assert table.window_class is None
+    classed = TableInfo(window_id=2, title="CoinPoker", geometry=geometry, window_class="UnityWndClass")
+    assert classed.window_class == "UnityWndClass"
 
 
 def test_factory_detects_supported_platforms() -> None:

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -1,0 +1,75 @@
+"""CoinPoker table-window detection on Windows.
+
+CoinPoker titles every window (the Unity table and the Chromium lobby) just
+"CoinPoker", with no table number, so the title-based match used for other
+sites never finds the table. These tests lock in the special case: broaden the
+search to the client name and keep only the Unity render window.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.qt
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Light Qt stubs so WinTables imports without a real display.
+sys.modules.setdefault("PySide6", Mock())
+sys.modules.setdefault("PySide6.QtCore", Mock())
+sys.modules.setdefault("PySide6.QtGui", Mock())
+sys.modules.setdefault("PySide6.QtWidgets", Mock())
+
+import fpdb_3_legacy.WinTables as WinTables  # noqa: E402
+from fpdb.infrastructure.platform import TableGeometry, TableInfo  # noqa: E402
+
+_GEOM = TableGeometry(x=100, y=100, width=800, height=613)
+
+
+def _make_table() -> WinTables.Table:
+    """A Table with just the attributes find_table_parameters touches."""
+    t = object.__new__(WinTables.Table)
+    t.site = "CoinPoker"
+    t.search_string = "930357"  # the table number, absent from any window title
+    t.number = None
+    t.title = ""
+    t._table_geometry = None
+    t._detector = Mock()
+    return t
+
+
+def test_coinpoker_picks_unity_table_over_lobby() -> None:
+    lobby = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")
+    table = TableInfo(window_id=111, title="CoinPoker", geometry=_GEOM, window_class="UnityWndClass")
+    t = _make_table()
+    t._detector.find_tables.return_value = [lobby, table]
+
+    t.find_table_parameters()
+
+    # Search was broadened to the client name; the Unity window was selected.
+    t._detector.find_tables.assert_called_once_with("CoinPoker")
+    assert t.number == 111
+
+
+def test_coinpoker_not_found_when_only_lobby_open() -> None:
+    lobby = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")
+    t = _make_table()
+    t._detector.find_tables.return_value = [lobby]
+    # The "list open windows" fallback also queries the detector.
+    t._detector.find_tables.side_effect = lambda s: [lobby] if s == "CoinPoker" else []
+
+    t.find_table_parameters()
+
+    assert t.number is None
+
+
+def test_is_coinpoker_table_accepts_when_class_unknown() -> None:
+    # Non-Windows detectors report no class; don't hide the HUD in that case.
+    no_class = TableInfo(window_id=1, title="CoinPoker", geometry=_GEOM)
+    assert WinTables.Table._is_coinpoker_table(None, no_class) is True
+    unity = TableInfo(window_id=2, title="CoinPoker", geometry=_GEOM, window_class="UnityWndClass")
+    assert WinTables.Table._is_coinpoker_table(None, unity) is True
+    lobby = TableInfo(window_id=3, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")
+    assert WinTables.Table._is_coinpoker_table(None, lobby) is False

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -8,7 +8,7 @@ search to the client name and keep only the Unity render window.
 
 import os
 import sys
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -41,16 +41,34 @@ def _make_table() -> WinTables.Table:
 
 
 def test_coinpoker_picks_unity_table_over_lobby() -> None:
+    # No argv resolution available -> class heuristic picks the Unity window.
     lobby = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")
     table = TableInfo(window_id=111, title="CoinPoker", geometry=_GEOM, window_class="UnityWndClass")
     t = _make_table()
     t._detector.find_tables.return_value = [lobby, table]
 
-    t.find_table_parameters()
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+        t.find_table_parameters()
 
     # Search was broadened to the client name; the Unity window was selected.
     t._detector.find_tables.assert_called_once_with("CoinPoker")
     assert t.number == 111
+
+
+def test_coinpoker_picks_the_right_table_by_argv_among_several() -> None:
+    # Two Unity tables open: argv disambiguates by the requested table id.
+    other = TableInfo(window_id=111, title="CoinPoker", geometry=_GEOM, process_id=956, window_class="UnityWndClass")
+    wanted = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, process_id=957, window_class="UnityWndClass")
+    lobby = TableInfo(window_id=333, title="CoinPoker", geometry=_GEOM, process_id=17736, window_class="Chrome_WidgetWin_1")
+    t = _make_table()
+    t.search_string = "930357"  # the table we want
+    t._detector.find_tables.return_value = [other, wanted, lobby]
+
+    pid_to_id = {956: "166755", 957: "930357", 17736: None}
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
+        t.find_table_parameters()
+
+    assert t.number == 222  # the window whose process argv carries 930357
 
 
 def test_coinpoker_not_found_when_only_lobby_open() -> None:


### PR DESCRIPTION
## Problème

Les mains CoinPoker s'importaient mais **le HUD ne s'affichait pas sous Windows**. Le client CoinPoker titre **toutes** ses fenêtres juste `"CoinPoker"`, sans numéro de table, donc la recherche par titre (le numéro de table, ex. `930357`) ne matchait aucune fenêtre → HUD_main sautait la création.

## Diagnostic

- La **table** est une fenêtre **Unity** (`class=UnityWndClass`), le **lobby** une fenêtre **Chromium** (`Chrome_WidgetWin_1`) — même titre `"CoinPoker"`.
- Chaque table tourne dans son **propre processus Unity** dont la ligne de commande porte l'id : `roomName=... <id>` et `-logFile ...\table_<id>.log`.

C'est le même mécanisme que la solution macOS déjà en place (`macos_process.py` : `window → PID → argv → table id`).

## Correctifs (2 commits)

**1. Détection de la fenêtre de table par classe** (`7043c03e`)
- `TableInfo` gagne un `window_class` optionnel, rempli par le détecteur Windows via `GetClassName` (`None` ailleurs → Linux/macOS intacts).
- WinTables élargit la recherche au nom du client pour CoinPoker (comme pour Winamax) et ne garde que la fenêtre `UnityWndClass`, rejetant le lobby.

**2. Résolution exacte par argv, multi-table safe** (`2b5a618a`) — port de l'approche macOS
- `coinpoker_process.py` (nouveau) : parser pur **partagé** `extract_table_id` (macOS + Windows).
- `macos_process.py` : réutilise le parser partagé (comportement inchangé).
- `windows_process.py` (nouveau) : `table_id_for_pid` via **psutil** (déjà en dépendance), caché par PID.
- Le détecteur Windows remplit `TableInfo.process_id` (via `GetWindowThreadProcessId`).
- WinTables : pour CoinPoker, match la fenêtre dont l'argv du process porte l'id demandé (désambiguïse plusieurs tables) ; repli sur l'heuristique de classe si l'argv est indisponible.

## Validation en conditions réelles (Windows + client CoinPoker)

- Fenêtre Unity → argv → table id `928730` ; lobby Chromium → `None` (exclu).
- WinTables sélectionne la bonne fenêtre de table par id.
- **Limitation multi-table levée.**

## Impact multi-plateforme

- `window_class`/`process_id` : optionnels, `None` sur Linux/macOS → aucun changement de comportement.
- Parser partagé : le comportement macOS est inchangé (mêmes regex, re-export de `extract_table_id` pour ses tests).

## Tests

42 tests verts (nouveaux : parser partagé, `windows_process` mocké psutil, matching argv WinTables ; `TableInfo.window_class`), lint `ruff` clean sur tous les fichiers modifiés.

## Note (hors scope, préexistant sur `bigbang`)

`macos.py:find_tables` dépasse `PLR0912` (14>12) et `test_swc_native_capture.py`/`test_pt4_adapter.py` ne collectent pas sous Python 3.10 (`datetime.UTC`, requiert 3.11+). Non lié à cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)