### PR TITLE
fix(coinpoker): stamp captured hands with capture time, not the 1970 epoch

### DIFF
--- a/fpdb_3_legacy/coinpoker_live_capture.py
+++ b/fpdb_3_legacy/coinpoker_live_capture.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import datetime
 import re
 import sys
 from collections.abc import Iterable, Iterator
@@ -292,12 +293,25 @@ class HandPump:
         self.imported: set[str] = set()
         self.failed: set[str] = set()
 
+    @staticmethod
+    def _stamp_capture_time(hand_data: dict) -> None:
+        """Give an unstamped hand the capture time (UTC-naive) instead of 1970.
+
+        The CoinPoker stream carries no per-hand clock, so an unstamped hand would
+        default to 1970-01-01 and fall outside the GUI's date filters (empty
+        graphs / hand viewer). This is a live feed, so "now" is the hand time, and
+        UTC-naive matches how every other site stores startTime.
+        """
+        if not hand_data.get("timestamp"):
+            hand_data["timestamp"] = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
     def process(self, events: list[tuple]) -> int:
         new = 0
         for hand_data in build_hands(events, self.table_category):
             hid = hand_data["hand_id"]
             if hid in self.imported or hid in self.failed:
                 continue
+            self._stamp_capture_time(hand_data)
             try:
                 hand = build_fpdb_hand(hand_data, config=self.config)
             except CaptureNotImportableError:
@@ -371,8 +385,6 @@ def _ensure_capture_file(db) -> int:
     try:
         file_id = db.get_id(name)
         if not file_id:
-            import datetime
-
             now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
             file_id = db.storeFile([name, "CoinPoker", now, now, 0, 0, 0, 0, 0, 0, 0, False])
             db.commit()

--- a/test/test_coinpoker_live_capture.py
+++ b/test/test_coinpoker_live_capture.py
@@ -131,6 +131,29 @@ def test_hand_pump_imports_complete_hands_and_dedupes() -> None:
     assert pump.prune(events) == []  # imported hands' events pruned
 
 
+def test_pump_stamps_capture_time_instead_of_epoch(monkeypatch) -> None:
+    # The stream carries no per-hand clock; an unstamped hand would default to
+    # 1970 and vanish from the GUI's date-filtered graphs. The pump must stamp it.
+    import datetime
+
+    from fpdb_3_legacy.http_capture_hand_builder import CaptureNotImportableError
+
+    seen: dict = {}
+
+    def spy(hand_data, config):  # noqa: ANN001, ANN202 - test double
+        seen["timestamp"] = hand_data.get("timestamp")
+        raise CaptureNotImportableError  # stop after capturing the stamped value
+
+    monkeypatch.setattr("fpdb_3_legacy.coinpoker_live_capture.build_fpdb_hand", spy)
+    config = HttpCaptureHandConfig(site_ids={"CoinPoker": COINPOKER_SITE_ID, "default": COINPOKER_SITE_ID})
+    pump = HandPump(db=None, config=config, table_category="PLO4", dry_run=True)
+
+    pump.process(_events())
+
+    assert isinstance(seen["timestamp"], datetime.datetime)
+    assert seen["timestamp"].year >= 2020  # capture time, not the 1970 epoch
+
+
 def test_live_capture_instance_lock_rejects_second_process(tmp_path) -> None:
     lock_path = str(tmp_path / "coinpoker-capture.lock")
     first = _acquire_instance_lock(lock_path)


### PR DESCRIPTION
## Problème

Les mains CoinPoker capturées s'importaient correctement (héros, joueurs, profits en base) mais **n'apparaissaient ni dans le graphe ni dans le visualiseur de mains** de la GUI.

## Cause

Le hand builder laissait `timestamp: None`, que `_parse_capture_start_time` convertit en **`1970-01-01`**. Or le SQL du graphe **et** du visualiseur filtre par plage de dates :

```sql
AND h.startTime > '<startdate_test>'
AND h.startTime < '<enddate_test>'
```

Les mains datées de 1970 tombent hors de toute plage raisonnable (autour d'aujourd'hui) → aucune donnée affichée.

## Correctif

Le flux CoinPoker ne porte pas d'horloge par main. Comme c'est un feed **live**, le pump d'import stampe désormais chaque main avec l'**heure de capture** (UTC-naïve, comme les autres sites stockent `startTime`). Les mains tombent sur la date du jour et s'affichent.

## Validation

Requête du graphe reproduite en conditions réelles après correctif + réparation des données existantes : **46 mains, profit cumulé +20** renvoyés pour la plage 2026.

## Tests

13 tests (`test_coinpoker_live_capture.py`), dont un nouveau vérifiant que le pump stampe l'heure de capture et non 1970. Lint `ruff` clean.

## Note

Les mains importées **avant** ce correctif gardent leur `startTime` 1970 et nécessitent une mise à jour ponctuelle en base pour redevenir visibles (fait séparément côté utilisateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)