### PR TITLE
fix: unblock Python 3.10 test collection and the macos ruff ratchet

### DIFF
--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -241,53 +241,78 @@ class MacOSTableDetector:
             search_string,
         )
 
-        # Fallback to AppleScript when Quartz produced no usable match: either no
-        # window matched, or none of the windows exposed a title at all (missing
-        # Screen Recording permission / Electron client).
+        # Fallback to AppleScript / argv when Quartz produced no usable match:
+        # either no window matched, or none exposed a title at all (missing Screen
+        # Recording permission / Electron client).
         has_only_empty_titles = len(tables) > 0 and all(t.title == "" for t in tables)
         if len(tables) == 0 or has_only_empty_titles:
-            # CoinPoker renders each table in its own Unity process whose window
-            # carries no useful title and no accessibility text, so the tables are
-            # indistinguishable to every macOS window API. The owning process's
-            # argv, however, contains the table id (window -> kCGWindowOwnerPID ->
-            # argv -> table id). This is deterministic and needs no Screen
-            # Recording, so try it before the AppleScript fallback.
-            if search_string and target_table_windows:
-                pid_match = self._match_target_window_by_pid(search_string, target_table_windows)
-                if pid_match is not None:
-                    logger.debug(
-                        "DIAGNOSTIC: argv matched %s window %s (pid %s) for search %r",
-                        pid_match.process_name,
-                        pid_match.window_id,
-                        pid_match.process_id,
-                        search_string,
-                    )
-                    return [pid_match]
-
-            if total_windows > 0 and titled_windows == 0:
-                # No Quartz title for any window almost always means Screen
-                # Recording is off. Emit the precise, actionable diagnosis once.
-                self._check_permissions_once()
-            else:
-                logger.debug("DIAGNOSTIC: No Quartz window matched the search string. Trying AppleScript fallback...")
-            applescript_tables = self.find_tables_applescript(search_string)
-            if applescript_tables:
-                logger.debug(f"DIAGNOSTIC: AppleScript fallback found {len(applescript_tables)} matching tables")
-                return applescript_tables
-            if len(blank_target_windows) == 1:
-                fallback = blank_target_windows[0]
-                logger.warning(
-                    "Using the only visible %s window as a fallback for table search %r "
-                    "because macOS did not expose a window title and AppleScript did not "
-                    "return a match. Grant Screen Recording/Accessibility permissions for "
-                    "reliable multi-table detection.",
-                    fallback.process_name,
-                    search_string,
-                )
-                return [fallback]
+            fallback = self._find_tables_without_titles(
+                search_string,
+                target_table_windows,
+                blank_target_windows,
+                total_windows,
+                titled_windows,
+            )
+            if fallback is not None:
+                return fallback
 
         logger.debug(f"DIAGNOSTIC: Found {len(tables)} matching tables via Quartz")
         return tables
+
+    def _find_tables_without_titles(
+        self,
+        search_string: str,
+        target_table_windows: list[TableInfo],
+        blank_target_windows: list[TableInfo],
+        total_windows: int,
+        titled_windows: int,
+    ) -> list[TableInfo] | None:
+        """Resolve tables when Quartz exposed no usable title, else return None.
+
+        Tried in order: the owning process's argv (deterministic, no Screen
+        Recording), then AppleScript, then the sole blank target window.
+        """
+        # CoinPoker renders each table in its own Unity process whose window
+        # carries no useful title and no accessibility text, so the tables are
+        # indistinguishable to every macOS window API. The owning process's argv,
+        # however, contains the table id (window -> kCGWindowOwnerPID -> argv ->
+        # table id). This is deterministic, so try it before AppleScript.
+        if search_string and target_table_windows:
+            pid_match = self._match_target_window_by_pid(search_string, target_table_windows)
+            if pid_match is not None:
+                logger.debug(
+                    "DIAGNOSTIC: argv matched %s window %s (pid %s) for search %r",
+                    pid_match.process_name,
+                    pid_match.window_id,
+                    pid_match.process_id,
+                    search_string,
+                )
+                return [pid_match]
+
+        if total_windows > 0 and titled_windows == 0:
+            # No Quartz title for any window almost always means Screen Recording
+            # is off. Emit the precise, actionable diagnosis once.
+            self._check_permissions_once()
+        else:
+            logger.debug("DIAGNOSTIC: No Quartz window matched the search string. Trying AppleScript fallback...")
+        applescript_tables = self.find_tables_applescript(search_string)
+        if applescript_tables:
+            logger.debug(f"DIAGNOSTIC: AppleScript fallback found {len(applescript_tables)} matching tables")
+            return applescript_tables
+
+        if len(blank_target_windows) == 1:
+            fallback = blank_target_windows[0]
+            logger.warning(
+                "Using the only visible %s window as a fallback for table search %r "
+                "because macOS did not expose a window title and AppleScript did not "
+                "return a match. Grant Screen Recording/Accessibility permissions for "
+                "reliable multi-table detection.",
+                fallback.process_name,
+                search_string,
+            )
+            return [fallback]
+
+        return None
 
     def _is_target_process(self, process_name: str | None) -> bool:
         if not process_name:

--- a/fpdb_3_legacy/pt4_adapter/connection.py
+++ b/fpdb_3_legacy/pt4_adapter/connection.py
@@ -1,9 +1,13 @@
 """PT4 PostgreSQL connection utilities."""
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import psycopg
+if TYPE_CHECKING:
+    import psycopg
 
 
 @dataclass
@@ -17,7 +21,7 @@ class Pt4Config:
     database: str = "PT4 DB"  # PT4 default name with space
 
     @classmethod
-    def from_env(cls) -> "Pt4Config":
+    def from_env(cls) -> Pt4Config:
         """Load configuration from environment variables."""
         return cls(
             host=os.environ.get("PT4_HOST", "localhost"),
@@ -30,6 +34,8 @@ class Pt4Config:
 
 def connect_pt4(config: Pt4Config) -> psycopg.Connection:
     """Read-only connection to PT4 PostgreSQL database."""
+    import psycopg  # deferred: only needed to actually connect, not to import the adapter
+
     return psycopg.connect(
         host=config.host,
         port=config.port,

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -17,7 +17,7 @@ import threading
 from collections import Counter
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import BinaryIO
@@ -2913,7 +2913,7 @@ def iter_capture_records(stream: BinaryIO) -> Iterator[NativeCaptureRecord]:
         if len(payload) != size:
             raise ValueError("truncated SwC native capture payload")
         yield NativeCaptureRecord(
-            captured_at=datetime.fromtimestamp(timestamp_us / 1_000_000, tz=UTC),
+            captured_at=datetime.fromtimestamp(timestamp_us / 1_000_000, tz=timezone.utc),
             direction="received" if direction == 0 else "sent",
             peer_port=peer_port,
             payload=payload,

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -2,9 +2,12 @@ import io
 import struct
 import threading
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
+
+# datetime.UTC only exists on Python 3.11+; the project targets >=3.10.
+UTC = timezone.utc
 
 from fpdb_3_legacy.swc_native_capture import (
     NativeAnimationEvent,


### PR DESCRIPTION
## Problème

Trois problèmes préexistants sur `bigbang`, indépendants, cassaient une collecte `pytest` propre et un run `ruff` propre.

## Correctifs

- **`datetime.UTC` (Python 3.11+)** dans `swc_native_capture.py` — le projet cible `>=3.10`. Passage à `timezone.utc` ; le module de test aliase `UTC = timezone.utc` pour conserver ses nombreux appels. → débloque la collecte de `test_swc_native_capture.py`.
- **`import psycopg` en dur** dans `pt4_adapter/connection.py` — importer l'adaptateur (ou son comparateur pur) échouait sans le driver PostgreSQL optionnel. Import différé dans `connect_pt4` (`TYPE_CHECKING` pour l'annotation). → débloque la collecte de `test_pt4_adapter.py`.
- **`PLR0912` (14 > 12 branches)** dans `macos.py:find_tables` — le bloc de repli sans titre (argv → AppleScript → fenêtre unique) est extrait dans `_find_tables_without_titles` ; comportement inchangé.

## Validation

- Collecte de la suite complète propre à nouveau : **4000 tests collectés** (avant : « Interrupted: 2 errors during collection »).
- Les deux fichiers concernés collectent et passent : **90 + 14 tests**.
- Lint `ruff` clean sur tous les fichiers modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)