### PR TITLE
fix(coinpoker): detect game variant per hand (PLO4/5/6, NLHE, short-deck) + real timestamps

### DIFF
--- a/fpdb_3_legacy/GuiCoinPokerCapture.py
+++ b/fpdb_3_legacy/GuiCoinPokerCapture.py
@@ -86,9 +86,16 @@ class GuiCoinPokerCapture(QWidget):
         self.iface_combo = QComboBox()
         controls.addWidget(self.iface_combo, 1)
 
-        controls.addWidget(QLabel("Game:"))
+        game_label = QLabel("Default game:")
         self.game_combo = QComboBox()
         self.game_combo.addItems(_GAMES)
+        # The variant is detected per hand from the number of cards dealt to the
+        # hero, so this only applies to hands where the hero's cards are not
+        # captured (e.g. observing a table).
+        game_tip = "Fallback game type. Each hand's variant is auto-detected from your hole cards; this is only used when they aren't captured (e.g. observing)."
+        game_label.setToolTip(game_tip)
+        self.game_combo.setToolTip(game_tip)
+        controls.addWidget(game_label)
         controls.addWidget(self.game_combo)
 
         self.dry_run = QCheckBox("Dry run (no DB insert)")
@@ -305,12 +312,7 @@ class GuiCoinPokerCapture(QWidget):
 
         from fpdb_3_legacy.coinpoker_live_capture import BPF_FILTER
 
-        tcpdump = "/usr/sbin/tcpdump -i {iface} -l -n -S -x {filt} > {fifo} 2>> {log} &".format(
-            iface=shlex.quote(iface),
-            filt=shlex.quote(BPF_FILTER),
-            fifo=shlex.quote(fifo),
-            log=log,
-        )
+        tcpdump = f"/usr/sbin/tcpdump -i {shlex.quote(iface)} -l -n -S -x {shlex.quote(BPF_FILTER)} > {shlex.quote(fifo)} 2>> {log} &"
         applescript = 'do shell script "{}" with administrator privileges'.format(
             tcpdump.replace("\\", "\\\\").replace('"', '\\"'),
         )

--- a/fpdb_3_legacy/GuiCoinPokerCapture.py
+++ b/fpdb_3_legacy/GuiCoinPokerCapture.py
@@ -38,7 +38,7 @@ from fpdb_3_legacy.loggingFpdb import get_logger
 log = get_logger("coinpoker_capture_gui")
 
 _MODULE = "fpdb_3_legacy.coinpoker_live_capture"
-_GAMES = ["PLO4", "PLO5", "PLO6", "NLHE"]
+_GAMES = ["PLO4", "PLO5", "PLO6", "NLHE", "Shortdeck"]
 
 
 def _repo_root() -> Path:

--- a/fpdb_3_legacy/coinpoker_hand_builder.py
+++ b/fpdb_3_legacy/coinpoker_hand_builder.py
@@ -9,6 +9,7 @@ holecards / collections). Currently targets ring Hold'em and Omaha (PLO).
 
 from __future__ import annotations
 
+import datetime
 import re
 from collections import defaultdict
 from decimal import Decimal
@@ -23,25 +24,32 @@ _VALUE = {
 _SUIT = {"SPADES": "s", "HEARTS": "h", "DIAMONDS": "d", "CLUBS": "c"}
 _NUM_RANK = {10: "T", 11: "J", 12: "Q", 13: "K", 14: "A"}
 
-# CoinPoker categories -> (fpdb base, category). PLO4 == 4-card Omaha high.
+# CoinPoker game hints (the GUI dropdown) -> (fpdb base, category). Used as a
+# fallback when the variant can't be read from the hand itself. SHORTDECK == 6+
+# Hold'em (fpdb category 6_holdem).
 _CATEGORY = {
     "PLO4": ("hold", "omahahi"),
     "PLO5": ("hold", "5_omahahi"),
     "PLO6": ("hold", "6_omahahi"),
     "NLH": ("hold", "holdem"),
     "NLHE": ("hold", "holdem"),
+    "SHORTDECK": ("hold", "6_holdem"),
 }
 
-# Hole-card count -> (fpdb base, category). CoinPoker's hand events carry no
-# explicit game variant, so the number of cards dealt to the hero identifies it.
-# This is detected per hand, so a PLO5 hand keeps its 5th card even when the
-# session-wide game hint says PLO4.
+# Hole-card count -> (fpdb base, category), for the counts that are unambiguous.
+# CoinPoker's hand events carry no explicit game variant, but the number of cards
+# dealt to the hero identifies the Omaha family, so it is detected per hand: a
+# PLO5 hand keeps its 5th card even when the session hint says PLO4. Two-card
+# games (Hold'em vs short-deck) are handled separately since the count is equal.
 _HOLE_COUNT_CATEGORY = {
-    2: ("hold", "holdem"),
     4: ("hold", "omahahi"),
     5: ("hold", "5_omahahi"),
     6: ("hold", "6_omahahi"),
 }
+
+# Card ranks removed from a short deck (6+ Hold'em uses 6..A only). Seeing any of
+# them proves a full 52-card deck, i.e. regular Hold'em.
+_LOW_RANKS = frozenset({"TWO", "THREE", "FOUR", "FIVE"})
 
 
 def _card(c: dict) -> str:
@@ -134,18 +142,49 @@ def _hero_hole_count(evs: list[tuple]) -> int:
     return 0
 
 
-def _detect_category(evs: list[tuple], table_category: str) -> tuple[str, str]:
-    """Pick (base, category) from the hero's hole-card count, else the GUI hint.
+def _all_dealt_cards(evs: list[tuple]) -> list[dict]:
+    """Every card visible in the hand: the hero's hole cards plus the board."""
+    hole = _first(evs, "game.hole_cards")
+    cards = list(hole.get("holeCards") or []) if isinstance(hole, dict) else []
+    for name, _h, d in evs:
+        if name == "game.dealer_cards" and isinstance(d, dict):
+            for street_cards in (d.get("dealerCards") or {}).values():
+                cards.extend(street_cards or [])
+    return [c for c in cards if isinstance(c, dict)]
 
-    The number of hole cards is the only reliable per-hand signal of the variant
-    (the events carry no game type), so it wins. The session-wide ``table_category``
-    dropdown is a fallback for hands where the hero's cards are absent from the
-    capture (e.g. observing a table).
+
+def _detect_category(evs: list[tuple], table_category: str) -> tuple[str, str]:
+    """Pick (base, category) from the hand itself, else the GUI hint.
+
+    The hero's hole-card count identifies the Omaha family unambiguously (4/5/6),
+    so it wins. Hold'em and short-deck both deal two cards, so the count can't
+    tell them apart: trust the session hint, but a 2-5 rank anywhere proves a full
+    deck and rules out short-deck even under a wrong hint. The ``table_category``
+    dropdown is the fallback when the hero's cards aren't captured (e.g. observing).
     """
     count = _hero_hole_count(evs)
     if count in _HOLE_COUNT_CATEGORY:
         return _HOLE_COUNT_CATEGORY[count]
+    if count == 2:
+        _, hinted = _CATEGORY.get(table_category.upper(), ("hold", "holdem"))
+        low_card_seen = any(c.get("value") in _LOW_RANKS for c in _all_dealt_cards(evs))
+        if hinted == "6_holdem" and not low_card_seen:
+            return ("hold", "6_holdem")
+        return ("hold", "holdem")
     return _CATEGORY.get(table_category.upper(), ("hold", "omahahi"))
+
+
+def _hand_start_time(info: dict) -> datetime.datetime | None:
+    """Convert the event's initTimeStamp (epoch ms) to a UTC-naive datetime.
+
+    Preferring the protocol's own clock over the import wall-clock keeps replayed
+    or backlogged captures on their real dates in the GUI graphs/filters.
+    """
+    raw = info.get("initTimeStamp")
+    try:
+        return datetime.datetime.fromtimestamp(int(raw) / 1000, tz=datetime.timezone.utc).replace(tzinfo=None)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
 
 
 def _build_one(hid: str, evs: list[tuple], table_category: str) -> dict[str, Any] | None:
@@ -290,7 +329,7 @@ def _build_one(hid: str, evs: list[tuple], table_category: str) -> dict[str, Any
         "hand_id": str(hid),
         "hero": hero,
         "table_id": table_id,
-        "timestamp": None,
+        "timestamp": _hand_start_time(info),
         "buttonpos": info.get("dealerSeatId"),
         "game": {"base": base, "category": category, "fpdb_supported": True},
         "gametype": {

--- a/fpdb_3_legacy/coinpoker_hand_builder.py
+++ b/fpdb_3_legacy/coinpoker_hand_builder.py
@@ -32,6 +32,17 @@ _CATEGORY = {
     "NLHE": ("hold", "holdem"),
 }
 
+# Hole-card count -> (fpdb base, category). CoinPoker's hand events carry no
+# explicit game variant, so the number of cards dealt to the hero identifies it.
+# This is detected per hand, so a PLO5 hand keeps its 5th card even when the
+# session-wide game hint says PLO4.
+_HOLE_COUNT_CATEGORY = {
+    2: ("hold", "holdem"),
+    4: ("hold", "omahahi"),
+    5: ("hold", "5_omahahi"),
+    6: ("hold", "6_omahahi"),
+}
+
 
 def _card(c: dict) -> str:
     return _VALUE[c["value"]] + _SUIT[c["suit"]]
@@ -112,12 +123,37 @@ def _collect_players(evs: list[tuple]) -> dict[str, dict]:
 
 
 
+def _hero_hole_count(evs: list[tuple]) -> int:
+    """Number of cards dealt to the hero, or 0 if they weren't captured."""
+    for name in ("game.hole_cards", "game.player_info"):
+        ev = _first(evs, name)
+        if isinstance(ev, dict):
+            cards = ev.get("holeCards") or ev.get("playerCards")
+            if cards:
+                return len(cards)
+    return 0
+
+
+def _detect_category(evs: list[tuple], table_category: str) -> tuple[str, str]:
+    """Pick (base, category) from the hero's hole-card count, else the GUI hint.
+
+    The number of hole cards is the only reliable per-hand signal of the variant
+    (the events carry no game type), so it wins. The session-wide ``table_category``
+    dropdown is a fallback for hands where the hero's cards are absent from the
+    capture (e.g. observing a table).
+    """
+    count = _hero_hole_count(evs)
+    if count in _HOLE_COUNT_CATEGORY:
+        return _HOLE_COUNT_CATEGORY[count]
+    return _CATEGORY.get(table_category.upper(), ("hold", "omahahi"))
+
+
 def _build_one(hid: str, evs: list[tuple], table_category: str) -> dict[str, Any] | None:
     info = _first(evs, "game.pre_hand_start_info")
     if not info:
         return None
 
-    base, category = _CATEGORY.get(table_category.upper(), ("hold", "omahahi"))
+    base, category = _detect_category(evs, table_category)
     sb = Decimal(str(info.get("sbAmount", 0)))
     bb = Decimal(str(info.get("bbAmount", 0)))
     ante = Decimal(str(info.get("anteAmount", 0)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ ignore = [
 "fpdb_3_legacy/backfill_autonotes.py" = ["C901", "PLR0912", "PLR0915"]
 "fpdb_3_legacy/backfill_boards.py" = ["C901", "PLR0912"]
 "fpdb_3_legacy/backfill_showdown.py" = ["C901", "PLR0912", "PLR0915"]
+"fpdb_3_legacy/coinpoker_hand_builder.py" = ["C901", "PLR0912", "PLR0915"]
 "fpdb_3_legacy/fpdb.pyw" = ["C901", "PLR0912", "PLR0915"]
 "fpdb_3_legacy/http_capture_actions.py" = ["C901", "PLR0912", "PLR0915"]
 "fpdb_3_legacy/http_capture_diff.py" = ["C901"]

--- a/test/test_coinpoker_converter.py
+++ b/test/test_coinpoker_converter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from fpdb_3_legacy.coinpoker_hand_builder import _collect_players, build_hands
+from fpdb_3_legacy.coinpoker_hand_builder import _collect_players, _detect_category, build_hands
 from fpdb_3_legacy.coinpoker_protocol import decode_frame, split_frames
 from fpdb_3_legacy.http_capture_hand_builder import (
     CaptureNotImportableError,
@@ -85,6 +85,43 @@ def test_hole_cards_and_board_are_mapped() -> None:
     assert hero["closed"] == ["Js", "8s", "7s", "4d"]
     assert h["community"]["FLOP"] == ["Qc", "9s", "6c"]
     assert h["community"]["TURN"] == ["5s"]
+
+
+def _hole_cards_event(count: int) -> list[tuple]:
+    values = ["ACE", "KING", "QUEEN", "JACK", "TEN", "NINE"]
+    cards = [{"suit": "SPADES", "value": values[i]} for i in range(count)]
+    return [("game.hole_cards", "H", {"holeCards": cards})]
+
+
+def test_variant_detected_from_hero_hole_card_count() -> None:
+    # The number of cards dealt to the hero identifies the Omaha variant; the
+    # session-wide hint is ignored when the hero's cards are present.
+    assert _detect_category(_hole_cards_event(2), "PLO4") == ("hold", "holdem")
+    assert _detect_category(_hole_cards_event(4), "PLO5") == ("hold", "omahahi")
+    assert _detect_category(_hole_cards_event(5), "PLO4") == ("hold", "5_omahahi")
+    assert _detect_category(_hole_cards_event(6), "PLO4") == ("hold", "6_omahahi")
+
+
+def test_variant_falls_back_to_hint_when_hero_cards_absent() -> None:
+    # Observing a table (no hero hole cards captured): trust the GUI hint.
+    assert _detect_category([("game.pre_hand_start_info", "H", {})], "PLO5") == ("hold", "5_omahahi")
+    assert _detect_category([], "NLHE") == ("hold", "holdem")
+
+
+def test_plo5_hand_keeps_its_fifth_card() -> None:
+    # A 5-card hand imported under a stale "PLO4" hint must not be truncated.
+    events = _load_events()
+    patched = []
+    for name, hid, data in events:
+        if name == "game.hole_cards" and isinstance(data, dict) and data.get("holeCards"):
+            cards = list(data["holeCards"])
+            cards.append({"suit": "HEARTS", "value": "TWO"})  # 5th card
+            data = {**data, "holeCards": cards}
+        patched.append((name, hid, data))
+    hand = next(h for h in build_hands(patched, "PLO4") if h["holecards"])
+    assert hand["gametype"]["category"] == "5_omahahi"
+    hero = next(hc for hc in hand["holecards"] if hc["player"] == "Hero")
+    assert len(hero["closed"]) == 5
 
 
 def test_seat_reuse_keeps_one_player_per_seat() -> None:

--- a/test/test_coinpoker_converter.py
+++ b/test/test_coinpoker_converter.py
@@ -106,6 +106,39 @@ def test_variant_falls_back_to_hint_when_hero_cards_absent() -> None:
     # Observing a table (no hero hole cards captured): trust the GUI hint.
     assert _detect_category([("game.pre_hand_start_info", "H", {})], "PLO5") == ("hold", "5_omahahi")
     assert _detect_category([], "NLHE") == ("hold", "holdem")
+    assert _detect_category([], "Shortdeck") == ("hold", "6_holdem")
+
+
+def _two_card_hand(hole: list[tuple[str, str]], board: list[tuple[str, str]]) -> list[tuple]:
+    def cards(pairs):
+        return [{"value": v, "suit": s} for v, s in pairs]
+
+    return [
+        ("game.hole_cards", "H", {"holeCards": cards(hole)}),
+        ("game.dealer_cards", "H", {"dealerCards": {"FLOP": cards(board)}}),
+    ]
+
+
+def test_shortdeck_detected_from_hint_when_no_low_cards() -> None:
+    # Hold'em and short-deck both deal two cards, so the hint decides -- but only
+    # when nothing in the hand contradicts a 36-card deck.
+    hand = _two_card_hand([("ACE", "SPADES"), ("KING", "HEARTS")], [("TEN", "SPADES"), ("NINE", "CLUBS"), ("SEVEN", "HEARTS")])
+    assert _detect_category(hand, "Shortdeck") == ("hold", "6_holdem")
+    assert _detect_category(hand, "NLHE") == ("hold", "holdem")
+
+
+def test_low_card_overrides_a_wrong_shortdeck_hint() -> None:
+    # A 2-5 anywhere proves a full deck: it is regular Hold'em, hint notwithstanding.
+    hand = _two_card_hand([("ACE", "SPADES"), ("KING", "HEARTS")], [("FOUR", "CLUBS"), ("TEN", "SPADES"), ("ACE", "DIAMONDS")])
+    assert _detect_category(hand, "Shortdeck") == ("hold", "holdem")
+
+
+def test_hand_start_time_uses_event_init_timestamp() -> None:
+    # The protocol's own clock (epoch ms) must win over import wall-clock so
+    # replayed captures keep their real dates.
+    hand = _hand("91426500343")
+    assert hand["timestamp"] is not None
+    assert hand["timestamp"].year == 2026  # from the fixture's initTimeStamp, not 1970/now
 
 
 def test_plo5_hand_keeps_its_fifth_card() -> None:


### PR DESCRIPTION
## Problème

Une main PLO5 capturée avec le dropdown "game" sur PLO4 était stockée en Omaha 4-cartes → **5ᵉ carte perdue**. Le dropdown imposait une seule catégorie à toute la session. De plus, le short-deck NL n'était pas géré.

## Correctifs

**Détection de la variante par main** (les événements CoinPoker ne portent aucun type de jeu) :
- **Omaha 4/5/6** : identifié sans ambiguïté par le **nombre de cartes du héros** → `omahahi` / `5_omahahi` / `6_omahahi`. Une main PLO5/PLO6 garde toutes ses cartes même si le dropdown dit PLO4.
- **Hold'em vs Short-deck** (2 cartes chacun, indistinguables au comptage) : on suit le hint (nouvelle option **Shortdeck** → `6_holdem`), mais toute carte **2-5** vue dans la main prouve un deck complet et force `holdem`.
- Le dropdown, relabellisé **"Default game"**, ne sert plus que de repli (héros non capturé, ex. observateur).

**Timestamps réels** (retour de review sur PR #156) :
- Le `startTime` de la main vient désormais du `initTimeStamp` (epoch ms) de l'événement, au lieu de `None`. Le stamp "heure de capture" du pump devient un vrai repli → les captures rejouées gardent leur date réelle dans les graphes/filtres.

## Validation

Vérifié de bout en bout : main 5 cartes sous hint "PLO4" → `5_omahahi`, 5 cartes préservées ; short-deck (sans 2-5) sous hint "Shortdeck" → `6_holdem` ; carte basse → `holdem` ; `initTimeStamp` → date 2026 réelle.

## Tests / lint

Tests étendus (`test_coinpoker_converter.py`) : détection par comptage, repli hint, short-deck + override carte basse, timestamp initTimeStamp. Lint `ruff` clean. `coinpoker_hand_builder.py` ajouté au ratchet de complexité (`_build_one` dépassait déjà les seuils avant ce changement).

## Note
Les mains déjà importées tronquées (5ᵉ carte non stockée) ne sont pas réparables : re-capturer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)