### PR TITLE
fix(coinpoker): don't guess the table window when several tables are open

### DIFF
--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -126,15 +126,37 @@ class Table(Table_Window):
                 log.debug("argv lookup failed for pid %s: %s", pid, exc)
         return None
 
+    def _coinpoker_table_candidates(self, tables):
+        """The CoinPoker table windows (Unity), excluding the lobby and bad-word windows."""
+        return [t for t in tables if t.title and not self.check_bad_words(t.title) and self._is_coinpoker_table(t)]
+
+    def _select_coinpoker_window(self, tables):
+        """Pick this CoinPoker table's window, or None if it can't be told apart.
+
+        The process argv carries the exact table id, so it disambiguates several
+        open tables. When argv is unavailable (psutil missing / access denied) the
+        window class only separates a table from the lobby, not one table from
+        another, so fall back to it only when a single table is open -- otherwise
+        a HUD could attach to the wrong table.
+        """
+        argv_match = self._match_coinpoker_by_argv(tables)
+        if argv_match is not None:
+            return argv_match
+        candidates = self._coinpoker_table_candidates(tables)
+        if len(candidates) == 1:
+            return candidates[0]
+        if candidates:
+            log.warning(
+                "%d CoinPoker tables open but the table id could not be read from any process; "
+                "not guessing which window to attach to.",
+                len(candidates),
+            )
+        return None
+
     def _select_window(self, tables, search_str):
         """Pick the table window from candidates, or None if none qualifies."""
-        is_coinpoker = getattr(self, "site", "") == "CoinPoker"
-        if is_coinpoker:
-            # Prefer the exact table by process argv (multi-table safe); the
-            # class heuristic below is the single-table fallback.
-            argv_match = self._match_coinpoker_by_argv(tables)
-            if argv_match is not None:
-                return argv_match
+        if getattr(self, "site", "") == "CoinPoker":
+            return self._select_coinpoker_window(tables)
 
         for table_info in tables:
             try:
@@ -146,9 +168,6 @@ class Table(Table_Window):
                     continue
                 if search_str == "Winamax" and not self._matches_winamax_tournament(title):
                     log.debug("Winamax window rejected for current tournament/table: %s", title)
-                    continue
-                if is_coinpoker and not self._is_coinpoker_table(table_info):
-                    log.debug("CoinPoker window rejected (not the Unity table window): %s", title)
                     continue
                 return table_info
             except Exception as e:  # intentional broad catch: OS window enumeration boundary, log and keep scanning

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -71,6 +71,21 @@ def test_coinpoker_picks_the_right_table_by_argv_among_several() -> None:
     assert t.number == 222  # the window whose process argv carries 930357
 
 
+def test_multiple_tables_without_argv_are_not_guessed() -> None:
+    # argv can't read the table ids and the class only separates tables from the
+    # lobby, so with >1 table open the HUD must not attach to a guessed window.
+    t1 = TableInfo(window_id=111, title="CoinPoker", geometry=_GEOM, process_id=956, window_class="UnityWndClass")
+    t2 = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, process_id=957, window_class="UnityWndClass")
+    lobby = TableInfo(window_id=333, title="CoinPoker", geometry=_GEOM, process_id=17736, window_class="Chrome_WidgetWin_1")
+    t = _make_table()
+    t._detector.find_tables.return_value = [t1, t2, lobby]
+
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+        t.find_table_parameters()
+
+    assert t.number is None
+
+
 def test_coinpoker_not_found_when_only_lobby_open() -> None:
     lobby = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")
     t = _make_table()


### PR DESCRIPTION
## Contexte

Retour de review sur PR #155 (détection de la fenêtre de table CoinPoker).

## Problème

Quand l'argv du processus ne peut pas être lu (psutil absent / accès refusé / pas de PID), la classe de fenêtre ne distingue que **table vs lobby**, pas une table d'une autre. L'ancien fallback retournait la **première** fenêtre `UnityWndClass` — donc avec plusieurs tables ouvertes, un HUD pouvait s'accrocher à la mauvaise table.

## Correctif

La sélection CoinPoker est isolée dans `_select_coinpoker_window` :
1. Priorité à la table exacte via l'**id d'argv** (désambiguïse plusieurs tables).
2. Repli sur la classe de fenêtre **uniquement s'il y a exactement une table candidate** ; sinon on laisse non-matché plutôt que de deviner (log d'avertissement).

## Tests / lint

Nouveau test : plusieurs tables Unity + argv indisponible → aucune fenêtre choisie. 5 tests `test_wintables_coinpoker.py` verts, lint `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)