### PR TITLE
style: sort imports to satisfy ruff I001

### DIFF
--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 ########################################################################
 #    Standard Library modules
 import codecs
-import json
 import inspect
+import json
 import locale
 import os
 import platform

--- a/fpdb_3_legacy/parser_registry.py
+++ b/fpdb_3_legacy/parser_registry.py
@@ -15,6 +15,7 @@ from fpdb_3_legacy.BossToFpdb import Boss
 from fpdb_3_legacy.BovadaSummary import BovadaSummary
 from fpdb_3_legacy.BovadaToFpdb import Bovada
 from fpdb_3_legacy.CakeToFpdb import Cake
+from fpdb_3_legacy.CoinPokerToFpdb import CoinPoker
 from fpdb_3_legacy.EnetToFpdb import Enet
 from fpdb_3_legacy.EntractionToFpdb import Entraction
 from fpdb_3_legacy.EverestToFpdb import Everest
@@ -38,7 +39,6 @@ from fpdb_3_legacy.PokerStarsSummary import PokerStarsSummary
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 from fpdb_3_legacy.PokerTrackerSummary import PokerTrackerSummary
 from fpdb_3_legacy.PokerTrackerToFpdb import PokerTracker
-from fpdb_3_legacy.CoinPokerToFpdb import CoinPoker
 from fpdb_3_legacy.SealsWithClubsToFpdb import SealsWithClubs
 from fpdb_3_legacy.TourneySummary import TourneySummary
 from fpdb_3_legacy.UnibetSummary import UnibetSummary

--- a/test/test_flop_mucked_stud_render.py
+++ b/test/test_flop_mucked_stud_render.py
@@ -16,7 +16,6 @@ from PySide6.QtWidgets import QLabel
 from fpdb_3_legacy import Card
 from fpdb_3_legacy.Mucked import Flop_Mucked
 
-
 CARD_W, CARD_H = 30, 42
 
 

--- a/test/test_hh_path_detection.py
+++ b/test/test_hh_path_detection.py
@@ -135,8 +135,8 @@ def acr_json_tree(tmp_path, monkeypatch):
     # Patch _read_acr_json_path to use our tmp storage instead of ~/Library/...
     def patched_read(acr_key, kind, screen_name):
         prefix = "hhDirPath" if kind == "hh" else "tsDirPath"
-        from pathlib import Path
         import json as _json
+        from pathlib import Path
 
         json_path = storage / f"{prefix}_{acr_key}.json"
         if not json_path.is_file():


### PR DESCRIPTION
## Contexte

Dette préexistante sur `bigbang` : 4 blocs d'imports signalés `I001` (isort) par ruff, faisant échouer un `ruff check .` propre.

## Correctif

Réordonnancement alphabétique pur, **aucun changement de comportement** :
- `Configuration.py` : ordre `json`/`inspect`
- `parser_registry.py` : `CoinPokerToFpdb` remis à sa place alphabétique
- `test_flop_mucked_stud_render.py`, `test_hh_path_detection.py`

`ruff check .` est désormais clean pour `I001` sur tout le repo.

## Note (hors scope, préexistant)

`test_hh_path_detection.py::test_acr_detect_hh_path_reads_json_config` échoue sous Windows sur un problème de **séparateurs de chemin** (`/` vs `\`), présent aussi avant ce commit et sans rapport avec le tri d'imports. Non traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)