### PR TITLE
test: make ACR hh-path assertion OS-agnostic (fix on Windows)

### DIFF
--- a/test/test_hh_path_detection.py
+++ b/test/test_hh_path_detection.py
@@ -162,7 +162,8 @@ def test_acr_detect_hh_path_reads_json_config(acr_json_tree):
     result = cfg.detect_hh_path("ACR Poker")
     assert result is not None
     assert result.endswith("edinapoker")
-    assert "AmericasCardroom/handHistory" in result
+    # str(Path) uses the OS separator, so build the expected fragment the same way.
+    assert os.path.join("AmericasCardroom", "handHistory") in result
 
 
 def test_acr_detect_hh_path_falls_back_to_base_if_no_account_folder(acr_json_tree):


### PR DESCRIPTION
## Problème

`test_hh_path_detection.py::test_acr_detect_hh_path_reads_json_config` échouait **sous Windows** (préexistant) :

```
assert "AmericasCardroom/handHistory" in result
E  AssertionError: ... 'C:\...\AmericasCardroom\handHistory\edinapoker'
```

`result` vient de `detect_hh_path` = `str(Path(...))`, qui utilise le séparateur de l'OS (**backslash** sous Windows). L'assertion cherchait un fragment en **slash** → échec sur Windows, OK sur Unix.

## Correctif

Construire le fragment attendu avec `os.path.join("AmericasCardroom", "handHistory")` pour qu'il colle au séparateur de l'OS. **Test uniquement** ; le code de détection est inchangé.

## Validation

Les 10 tests de `test_hh_path_detection.py` passent sous Windows ; lint `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)