### PR TITLE
fix: unblock bigbang CI (ruff complexity + missing qt/engine guards)

### DIFF
--- a/fpdb_3_legacy/coinpoker_protocol.py
+++ b/fpdb_3_legacy/coinpoker_protocol.py
@@ -56,46 +56,54 @@ def split_frames(buf: bytes) -> list[tuple[int, bytes]]:
     return frames
 
 
+# Fixed-width scalar TLV types -> struct format (0x02 is a bare byte).
+_SCALAR_FMT = {0x03: ">H", 0x04: ">I", 0x05: ">Q"}
+# Length-prefixed string TLV types -> format of the length prefix.
+_STRLEN_FMT = {0x08: ">H", 0x0A: ">I"}
+
+
+def _read_map(b: bytes, off: int) -> tuple[dict[str, Any], int]:
+    count = struct.unpack_from(">H", b, off)[0]
+    off += 2
+    out: dict[str, Any] = {}
+    for _ in range(count):
+        klen = struct.unpack_from(">H", b, off)[0]
+        off += 2
+        key = b[off : off + klen].decode("latin1")
+        off += klen
+        vtyp = b[off]
+        off += 1
+        out[key], off = _read_value(b, off, vtyp)
+    return out, off
+
+
+def _read_array(b: bytes, off: int) -> tuple[list[Any], int]:
+    count = struct.unpack_from(">H", b, off)[0]
+    off += 2
+    etyp = b[off]
+    off += 1
+    arr = []
+    for _ in range(count):
+        val, off = _read_value(b, off, etyp)
+        arr.append(val)
+    return arr, off
+
+
 def _read_value(b: bytes, off: int, typ: int) -> tuple[Any, int]:
     if typ == 0x12:  # map
-        count = struct.unpack_from(">H", b, off)[0]
-        off += 2
-        out: dict[str, Any] = {}
-        for _ in range(count):
-            klen = struct.unpack_from(">H", b, off)[0]
-            off += 2
-            key = b[off : off + klen].decode("latin1")
-            off += klen
-            vtyp = b[off]
-            off += 1
-            val, off = _read_value(b, off, vtyp)
-            out[key] = val
-        return out, off
+        return _read_map(b, off)
     if typ == 0x13:  # array
-        count = struct.unpack_from(">H", b, off)[0]
-        off += 2
-        etyp = b[off]
-        off += 1
-        arr = []
-        for _ in range(count):
-            val, off = _read_value(b, off, etyp)
-            arr.append(val)
-        return arr, off
-    if typ == 0x02:
+        return _read_array(b, off)
+    if typ == 0x02:  # single byte
         return b[off], off + 1
-    if typ == 0x03:
-        return struct.unpack_from(">H", b, off)[0], off + 2
-    if typ == 0x04:
-        return struct.unpack_from(">I", b, off)[0], off + 4
-    if typ == 0x05:
-        return struct.unpack_from(">Q", b, off)[0], off + 8
-    if typ == 0x08:
-        ln = struct.unpack_from(">H", b, off)[0]
-        off += 2
-        return b[off : off + ln].decode("latin1"), off + ln
-    if typ == 0x0a:
-        ln = struct.unpack_from(">I", b, off)[0]
-        off += 4
+    if typ in _SCALAR_FMT:
+        fmt = _SCALAR_FMT[typ]
+        return struct.unpack_from(fmt, b, off)[0], off + struct.calcsize(fmt)
+    if typ in _STRLEN_FMT:
+        fmt = _STRLEN_FMT[typ]
+        prefix = struct.calcsize(fmt)
+        ln = struct.unpack_from(fmt, b, off)[0]
+        off += prefix
         return b[off : off + ln].decode("latin1"), off + ln
     raise ValueError(f"unknown TLV type 0x{typ:02x} at offset {off}")
 

--- a/test/test_flop_mucked_stud_render.py
+++ b/test/test_flop_mucked_stud_render.py
@@ -10,8 +10,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QLabel
+
+# Uses the pytest-qt `qapp` fixture; group with the other Qt UI tests so it is
+# deselected in the default (non-qt) run instead of erroring on a missing fixture.
+pytestmark = pytest.mark.qt
 
 from fpdb_3_legacy import Card
 from fpdb_3_legacy.Mucked import Flop_Mucked

--- a/test/test_mucked_stud_grid.py
+++ b/test/test_mucked_stud_grid.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QVBoxLayout
+
+# Uses the pytest-qt `qapp` fixture; group with the other Qt UI tests so it is
+# deselected in the default (non-qt) run instead of erroring on a missing fixture.
+pytestmark = pytest.mark.qt
 
 from fpdb_3_legacy import Card
 from fpdb_3_legacy.Mucked import Stud_cards

--- a/test/test_pot_eval_excludes_folders.py
+++ b/test/test_pot_eval_excludes_folders.py
@@ -16,9 +16,19 @@ import sys
 from decimal import Decimal
 from unittest.mock import MagicMock
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import fpdb_3_legacy.DerivedStats as _derived_stats
 from fpdb_3_legacy.DerivedStats import DerivedStats
+
+# assembleHandsPots is a no-op without the native poker-eval engine (pypoker-eval),
+# which isn't built in every environment, so these pot-award checks can't run there.
+pytestmark = pytest.mark.skipif(
+    _derived_stats.pokereval is None,
+    reason="requires the native poker-eval engine (pypoker-eval)",
+)
 
 # Unibet hand 1615946806, Pot Limit Omaha. jejesat folds on the flop holding the
 # best hand at the river; ASC2 wins €0.23 of a €0.25 pot, rake €0.02.


### PR DESCRIPTION
## Contexte

Trois échecs **préexistants** sur `bigbang` rendaient la CI Ubuntu rouge (indépendants de toute feature ; ils apparaissaient sur la CI de la PR #162).

## Correctifs

**1. ruff C901 — `coinpoker_protocol._read_value` (11 > 10)**
Extraction de `_read_map`/`_read_array` et pilotage des types TLV scalaires/chaînes par tables de lookup. Comportement inchangé (les tests du décodeur passent).

**2. Fixture `qapp` introuvable**
`test_flop_mucked_stud_render.py` et `test_mucked_stud_grid.py` utilisent la fixture pytest-qt `qapp` mais n'étaient pas marqués `qt` → le job par défaut (non-qt) les exécutait et échouait sur la fixture manquante. Marqués `qt` comme les autres tests UI (désélectionnés hors job qt, verts dedans).

**3. `test_pot_eval_excludes_folders.py` sans moteur poker-eval**
`assembleHandsPots` est un no-op sans le moteur natif `pypoker-eval` → les assertions échouaient là où il n'est pas compilé. `skipif` quand il est indisponible, comme les autres tests dépendant d'un moteur/OS.

## Validation

- `ruff check fpdb_3_legacy fpdb test tests tools` → **All checks passed**.
- pot_eval → skipped (plus fail) ; mucked → désélectionnés hors qt, **7 passed** sous `-m qt` ; décodeur CoinPoker → 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)