### PR TITLE
fix: resolve mypy errors that failed the CI quality gate

### DIFF
--- a/fpdb_3_legacy/HandHistoryConverter.py
+++ b/fpdb_3_legacy/HandHistoryConverter.py
@@ -306,7 +306,7 @@ HandHistoryConverter: '{sitename}'
         """Parse a shared game header for converters that enable ``copyGameHeader``."""
         raise NotImplementedError
 
-    def raise_summary_partial(self, hand: object, marker: str) -> None:
+    def raise_summary_partial(self, hand: Hand.Hand, marker: str) -> None:
         """Reject a hand whose summary sections do not number exactly one.
 
         Two unrelated situations land here, and reporting both as "not cleanly

--- a/fpdb_3_legacy/IdentifySite.py
+++ b/fpdb_3_legacy/IdentifySite.py
@@ -291,6 +291,10 @@ class IdentifySite:
             if best_score is None or score > best_score:
                 best_site, best_score = site, score
 
+        if best_site is None or best_score is None:
+            # wpn_sites is non-empty (guarded above), so the loop always fills
+            # these; the check keeps the types non-optional for the rest.
+            return fallback_site
         matched_by_path, is_enabled, _ = best_score
         # Nothing matched by path and nothing is enabled: keep the fallback
         # rather than silently renaming to an arbitrary skin.


### PR DESCRIPTION
## Contexte

Le job **CI quality** (mypy) échouait sur 4 erreurs préexistantes dans 2 fichiers, indépendantes de toute feature.

## Correctifs

- **`HandHistoryConverter.raise_summary_partial`** typait son paramètre `hand` en `object` puis lisait `hand.handText` → `object has no attribute handText`. Annoté en `Hand.Hand` (module déjà importé) ; tous les appelants passent un `hand` de ce type ou non typé.
- **`IdentifySite._select_winning_skin_site`** initialise `best_site`/`best_score` à `None` puis les remplit dans une boucle sur `wpn_sites` (non vide, gardé plus haut). mypy ne peut pas l'inférer → ajout d'un garde `None` explicite (aussi défensif) avant le dépaquetage et le déréférencement.

## Validation

`mypy` sur les 2 fichiers **et** les 6 appelants de `raise_summary_partial` → **Success: no issues found in 7 source files**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)