### PR TITLE
fix(hud): inherit dragged positions on new tables; close recycled CoinPoker HUDs

### DIFF
--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -776,10 +776,31 @@ class AuxSeats(AuxWindow):
             if isinstance(i, int):
                 self.hud.layout.location[self.adj[i]] = new_position  # update the hud-level dict,
                 # so other aux can be told
+                self._propagate_to_shared_layout(self.adj[i], new_position)
             elif i == "common":
                 self.hud.layout.common = new_position
+                self._propagate_to_shared_layout("common", new_position)
             else:
                 log.warning("Ignoring unexpected HUD seat identifier while saving position: %r", i)
+
+    def _propagate_to_shared_layout(self, seat: Any, position: tuple[int, int]) -> None:
+        """Mirror a dragged position onto the site's shared layout set.
+
+        A HUD deep-copies its layout when it is created, so a drag that only
+        updates this HUD's copy is lost on the next table: a table opened later
+        with the same layout would fall back to the un-dragged positions. Writing
+        through to the shared layout_set makes those new tables inherit the drag
+        (permanent persistence still happens via the "Save Layout" menu).
+        """
+        layout_set = getattr(self.hud, "layout_set", None)
+        shared = getattr(layout_set, "layout", {}).get(self.hud.max) if layout_set is not None else None
+        if shared is None:
+            return
+        with contextlib.suppress(Exception):
+            if seat == "common":
+                shared.common = position
+            else:
+                shared.location[seat] = position
 
     def adj_seats(self) -> list[int]:
         """Determine how to adjust seating arrangements.

--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -796,11 +796,26 @@ class AuxSeats(AuxWindow):
         shared = getattr(layout_set, "layout", {}).get(self.hud.max) if layout_set is not None else None
         if shared is None:
             return
+        # ``position`` is in the current table's pixel space, but the shared layout
+        # keeps its own reference width/height and create_scale_position() re-scales
+        # from those when the next HUD is built. Convert back into the shared
+        # layout's space so the drop point round-trips instead of being scaled a
+        # second time by stale dimensions.
+        ref = self._to_shared_layout_space(position, shared)
         with contextlib.suppress(Exception):
             if seat == "common":
-                shared.common = position
+                shared.common = ref
             else:
-                shared.location[seat] = position
+                shared.location[seat] = ref
+
+    def _to_shared_layout_space(self, position: tuple[int, int], shared: Any) -> tuple[int, int]:
+        table_w = getattr(self.hud.table, "width", 0) or 0
+        table_h = getattr(self.hud.table, "height", 0) or 0
+        shared_w = getattr(shared, "width", 0) or 0
+        shared_h = getattr(shared, "height", 0) or 0
+        if not (table_w and table_h and shared_w and shared_h):
+            return position  # dimensions unknown: store as-is
+        return (int(position[0] * shared_w / table_w), int(position[1] * shared_h / table_h))
 
     def adj_seats(self) -> list[int]:
         """Determine how to adjust seating arrangements.

--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -30,10 +30,24 @@ if sys.platform == "win32":
     GetSystemMetrics = ctypes.windll.user32.GetSystemMetrics
     IsWindow = ctypes.windll.user32.IsWindow
     MoveWindow = ctypes.windll.user32.MoveWindow
+    GetWindowThreadProcessId = ctypes.windll.user32.GetWindowThreadProcessId
 
     # Windows API constants
     SM_CXSIZEFRAME = 32
     SM_CYCAPTION = 4
+
+
+def _window_pid(hwnd: int | None) -> int | None:
+    """Return the process id owning ``hwnd`` on Windows, or None."""
+    if sys.platform != "win32" or not hwnd:
+        return None
+    try:
+        pid = ctypes.c_ulong()
+        GetWindowThreadProcessId(int(hwnd), ctypes.byref(pid))
+        return pid.value or None
+    except Exception:  # noqa: BLE001 - defensive: never break the geometry poll
+        return None
+
 
 # Global variables for window borders
 b_width = 3
@@ -201,6 +215,30 @@ class Table(Table_Window):
         except Exception as e:
             log.warning("Could not list open windows: %s", e)
 
+    def _coinpoker_window_reassigned(self) -> bool:
+        """True only if our CoinPoker window now serves a *different* table id.
+
+        Fail-safe: returns False whenever the site isn't CoinPoker, or the table
+        id can't be read (no PID / psutil unavailable / no id in argv), so it can
+        only ever add a close signal, never cause a premature kill.
+        """
+        if getattr(self, "site", "") != "CoinPoker":
+            return False
+        expected = "".join(ch for ch in str(getattr(self, "search_string", "")) if ch.isdigit())
+        if not expected:
+            return False
+        pid = _window_pid(self.number)
+        if not pid:
+            return False
+        try:
+            from fpdb.infrastructure.platform.windows_process import table_id_for_pid
+
+            current = table_id_for_pid(pid)
+        except Exception as exc:  # noqa: BLE001 - never break the geometry poll
+            log.debug("CoinPoker argv re-check failed for pid %s: %s", pid, exc)
+            return False
+        return bool(current) and current != expected
+
     def get_geometry(self):
         """Get the window geometry using platform abstraction."""
         if self._table_geometry is not None:
@@ -217,6 +255,13 @@ class Table(Table_Window):
             # Check if window is still valid
             if not self._detector.is_window_visible(self.number):
                 log.error("The window %s is not valid or visible", self.number)
+                return None
+
+            # CoinPoker recycles a table's Unity window for the next table, so the
+            # HWND can stay "visible" after this table closed while now rendering a
+            # different table. Treat that as destroyed (the HUD must move on).
+            if self._coinpoker_window_reassigned():
+                log.info("CoinPoker window %s now serves a different table; treating as closed", self.number)
                 return None
 
             # Get geometry using platform abstraction

--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -30,8 +30,6 @@ if sys.platform == "win32":
     GetSystemMetrics = ctypes.windll.user32.GetSystemMetrics
     IsWindow = ctypes.windll.user32.IsWindow
     MoveWindow = ctypes.windll.user32.MoveWindow
-    GetWindowThreadProcessId = ctypes.windll.user32.GetWindowThreadProcessId
-
     # Windows API constants
     SM_CXSIZEFRAME = 32
     SM_CYCAPTION = 4
@@ -42,8 +40,10 @@ def _window_pid(hwnd: int | None) -> int | None:
     if sys.platform != "win32" or not hwnd:
         return None
     try:
+        import ctypes  # local import: ctypes.windll is Windows-only
+
         pid = ctypes.c_ulong()
-        GetWindowThreadProcessId(int(hwnd), ctypes.byref(pid))
+        ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(pid))
         return pid.value or None
     except Exception:  # noqa: BLE001 - defensive: never break the geometry poll
         return None

--- a/test/test_hud_positioning.py
+++ b/test/test_hud_positioning.py
@@ -457,5 +457,31 @@ class TestClampToScreen(unittest.TestCase):
         assert x >= 1920
 
 
+def test_drag_propagates_to_shared_layout_so_new_tables_inherit() -> None:
+    # A HUD deep-copies its layout at creation, so a drag that only touched this
+    # HUD's copy was lost on the next table. The drag must write through to the
+    # shared layout_set that later tables copy from.
+    from types import SimpleNamespace
+
+    shared = SimpleNamespace(location=[None] * 11, common=(0, 0))
+    hud = SimpleNamespace(max=6, layout_set=SimpleNamespace(layout={6: shared}))
+    aux = object.__new__(Aux_Base.AuxSeats)
+    aux.hud = hud
+
+    aux._propagate_to_shared_layout(3, (100, 200))
+    aux._propagate_to_shared_layout("common", (50, 60))
+
+    assert shared.location[3] == (100, 200)
+    assert shared.common == (50, 60)
+
+
+def test_propagate_is_a_noop_without_a_shared_layout() -> None:
+    from types import SimpleNamespace
+
+    aux = object.__new__(Aux_Base.AuxSeats)
+    aux.hud = SimpleNamespace(max=6, layout_set=None)
+    aux._propagate_to_shared_layout(2, (1, 2))  # must not raise
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_hud_positioning.py
+++ b/test/test_hud_positioning.py
@@ -463,8 +463,11 @@ def test_drag_propagates_to_shared_layout_so_new_tables_inherit() -> None:
     # shared layout_set that later tables copy from.
     from types import SimpleNamespace
 
-    shared = SimpleNamespace(location=[None] * 11, common=(0, 0))
-    hud = SimpleNamespace(max=6, layout_set=SimpleNamespace(layout={6: shared}))
+    # Same dimensions: no scaling, positions stored as dropped.
+    shared = SimpleNamespace(location=[None] * 11, common=(0, 0), width=800, height=600)
+    hud = SimpleNamespace(
+        max=6, layout_set=SimpleNamespace(layout={6: shared}), table=SimpleNamespace(width=800, height=600)
+    )
     aux = object.__new__(Aux_Base.AuxSeats)
     aux.hud = hud
 
@@ -473,6 +476,23 @@ def test_drag_propagates_to_shared_layout_so_new_tables_inherit() -> None:
 
     assert shared.location[3] == (100, 200)
     assert shared.common == (50, 60)
+
+
+def test_drag_is_converted_into_the_shared_layout_scale() -> None:
+    # The table is twice the shared layout's reference size, so the dropped pixel
+    # position must be halved before storing, or a new HUD would scale it up twice.
+    from types import SimpleNamespace
+
+    shared = SimpleNamespace(location=[None] * 11, common=(0, 0), width=400, height=300)
+    hud = SimpleNamespace(
+        max=6, layout_set=SimpleNamespace(layout={6: shared}), table=SimpleNamespace(width=800, height=600)
+    )
+    aux = object.__new__(Aux_Base.AuxSeats)
+    aux.hud = hud
+
+    aux._propagate_to_shared_layout(2, (200, 200))
+
+    assert shared.location[2] == (100, 100)  # 200 * 400/800, 200 * 300/600
 
 
 def test_propagate_is_a_noop_without_a_shared_layout() -> None:

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -40,6 +40,29 @@ def _make_table() -> WinTables.Table:
     return t
 
 
+def test_window_reassigned_only_when_argv_shows_a_different_table() -> None:
+    # CoinPoker recycles a table's Unity window; the HUD must treat "my window now
+    # serves another table id" as closed, but never guess when it can't read the id.
+    t = _make_table()
+    t.site = "CoinPoker"
+    t.search_string = "930357"
+    t.number = 111
+
+    with patch("fpdb_3_legacy.WinTables._window_pid", return_value=4672):
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value="928730"):
+            assert t._coinpoker_window_reassigned() is True  # different table -> reassigned
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value="930357"):
+            assert t._coinpoker_window_reassigned() is False  # still our table
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+            assert t._coinpoker_window_reassigned() is False  # can't tell -> keep
+
+    # Fail-safe: no PID, or a non-CoinPoker site, never reports reassigned.
+    with patch("fpdb_3_legacy.WinTables._window_pid", return_value=None):
+        assert t._coinpoker_window_reassigned() is False
+    t.site = "PokerStars"
+    assert t._coinpoker_window_reassigned() is False
+
+
 def test_coinpoker_picks_unity_table_over_lobby() -> None:
     # No argv resolution available -> class heuristic picks the Unity window.
     lobby = TableInfo(window_id=222, title="CoinPoker", geometry=_GEOM, window_class="Chrome_WidgetWin_1")


### PR DESCRIPTION
## Problèmes signalés

1. Les positions de HUD ne sont pas reprises pour de **nouvelles tables** ouvertes avec le même layout.
2. À la **fermeture** d'une table, le HUD de cette table n'est pas tué.

## Analyse

**#1** — Un HUD **deep-copie** son layout à la création (`Hud.layout = deepcopy(layout_set.layout[max])`). Or le drag d'une fenêtre de siège (`Aux_Base.configure_event_cb`) ne mettait à jour que **cette copie locale** (`self.hud.layout.location`), sans toucher au `layout_set` partagé. Une table ouverte ensuite deepcopy le layout partagé **inchangé** → positions par défaut.

**#2** — CoinPoker **recycle** la fenêtre Unity d'une table pour la table suivante. Après fermeture, le HWND pouvait rester « visible » tout en affichant une **autre** table → `IsWindowVisible` ne signalait jamais la fermeture → HUD fantôme.

## Correctifs

- **#1** : `configure_event_cb` écrit aussi la nouvelle position dans le `layout_set` partagé → les tables ouvertes ensuite en héritent (la persistance permanente reste via le menu « Save Layout »).
- **#2** : `WinTables.get_geometry` recoupe l'**id de table dans l'argv du process** de la fenêtre avec celui que suit le HUD, et signale la fermeture s'ils diffèrent. **Fail-safe** : ne signale « fermé » que sur un écart **positif** (jamais quand l'id est illisible) → aucun kill prématuré possible.

## Tests

- Bug #1 : le drag propage au layout partagé ; no-op si pas de layout partagé.
- Bug #2 : réassignation détectée seulement sur id différent ; False sur id identique / illisible / autre site.
- Suites HUD complètes : 46 tests verts (`test_multiblock_hud`, `test_hud_regression_prevention`), + 24 (`test_wintables_coinpoker`, `test_hud_positioning`). Lint `ruff` clean.

## Note
Le bug #2 est corrigé sur l'hypothèse (confirmée par le comportement observé) que CoinPoker recycle ses fenêtres Unity ; le fix étant fail-safe, il ne peut qu'améliorer la détection de fermeture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)