### PR TITLE
fix(hud): detect CoinPoker table close by re-resolving the window each poll

### DIFF
--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 Now uses the Platform Abstraction Layer (Feature 1.5) for table detection.
 """
 
+import contextlib
 import re
 import sys
 
@@ -215,29 +216,47 @@ class Table(Table_Window):
         except Exception as e:
             log.warning("Could not list open windows: %s", e)
 
-    def _coinpoker_window_reassigned(self) -> bool:
-        """True only if our CoinPoker window now serves a *different* table id.
-
-        Fail-safe: returns False whenever the site isn't CoinPoker, or the table
-        id can't be read (no PID / psutil unavailable / no id in argv), so it can
-        only ever add a close signal, never cause a premature kill.
-        """
-        if getattr(self, "site", "") != "CoinPoker":
-            return False
-        expected = "".join(ch for ch in str(getattr(self, "search_string", "")) if ch.isdigit())
-        if not expected:
-            return False
-        pid = _window_pid(self.number)
-        if not pid:
-            return False
+    def _coinpoker_argv_usable(self, tables) -> bool:
+        """True if a table id could be read from any open CoinPoker window (psutil works)."""
         try:
             from fpdb.infrastructure.platform.windows_process import table_id_for_pid
-
-            current = table_id_for_pid(pid)
-        except Exception as exc:  # noqa: BLE001 - never break the geometry poll
-            log.debug("CoinPoker argv re-check failed for pid %s: %s", pid, exc)
+        except ImportError:
             return False
-        return bool(current) and current != expected
+        for table_info in tables:
+            pid = getattr(table_info, "process_id", None)
+            if pid:
+                with contextlib.suppress(Exception):
+                    if table_id_for_pid(pid):
+                        return True
+        return False
+
+    def _coinpoker_live_geometry(self):
+        """Geometry for THIS CoinPoker table, re-resolving its window every poll.
+
+        CoinPoker's Unity table window stays *visible* after the table is closed
+        (so is_window_visible() never reports the close) and its HWND can also be
+        recycled or recreated. Tracking a fixed HWND is therefore unreliable.
+        Instead, re-resolve the window by this table's id each poll: if no open
+        CoinPoker window's process argv carries our id, the table has closed
+        (return None). Fall back to the tracked HWND's visibility only when the id
+        can't be read (psutil unavailable), so a missing dep never forces a kill.
+        """
+        tables = self._detector.find_tables("CoinPoker")
+        match = self._match_coinpoker_by_argv(tables)
+        if match is not None:
+            self.number = match.window_id  # the window may have been recreated
+            return self._detector.get_window_geometry(self.number)
+        if self._coinpoker_argv_usable(tables):
+            log.warning(
+                "CoinPoker table %s: no open window carries this table id among %d CoinPoker window(s); closing HUD",
+                self.search_string,
+                len(tables),
+            )
+            return None
+        # argv unavailable (psutil): keep the old HWND-visibility behaviour.
+        if self._detector.is_window_visible(self.number):
+            return self._detector.get_window_geometry(self.number)
+        return None
 
     def get_geometry(self):
         """Get the window geometry using platform abstraction."""
@@ -251,17 +270,15 @@ class Table(Table_Window):
             table_geom = self._table_geometry
             self._table_geometry = None
             log.debug("Using geometry captured during table detection for window: %s", self.number)
+        elif getattr(self, "site", "") == "CoinPoker":
+            # CoinPoker needs id-based re-resolution, not fixed-HWND visibility.
+            table_geom = self._coinpoker_live_geometry()
+            if table_geom is None:
+                return None
         else:
             # Check if window is still valid
             if not self._detector.is_window_visible(self.number):
                 log.error("The window %s is not valid or visible", self.number)
-                return None
-
-            # CoinPoker recycles a table's Unity window for the next table, so the
-            # HWND can stay "visible" after this table closed while now rendering a
-            # different table. Treat that as destroyed (the HUD must move on).
-            if self._coinpoker_window_reassigned():
-                log.info("CoinPoker window %s now serves a different table; treating as closed", self.number)
                 return None
 
             # Get geometry using platform abstraction

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -40,27 +40,45 @@ def _make_table() -> WinTables.Table:
     return t
 
 
-def test_window_reassigned_only_when_argv_shows_a_different_table() -> None:
-    # CoinPoker recycles a table's Unity window; the HUD must treat "my window now
-    # serves another table id" as closed, but never guess when it can't read the id.
+def _windows(*ids_by_pid: tuple[int, str]) -> list[TableInfo]:
+    return [
+        TableInfo(window_id=100 + pid, title="CoinPoker", geometry=_GEOM, process_id=pid, window_class="UnityWndClass")
+        for pid, _tid in ids_by_pid
+    ]
+
+
+def test_live_geometry_reresolves_and_closes_when_table_id_is_gone() -> None:
+    # The window stays "visible" after the table closes, so detection must be by
+    # table id: our id present -> alive (and HWND re-bound); absent -> closed.
     t = _make_table()
-    t.site = "CoinPoker"
     t.search_string = "930357"
     t.number = 111
+    t._detector.get_window_geometry.return_value = _GEOM
 
-    with patch("fpdb_3_legacy.WinTables._window_pid", return_value=4672):
-        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value="928730"):
-            assert t._coinpoker_window_reassigned() is True  # different table -> reassigned
-        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value="930357"):
-            assert t._coinpoker_window_reassigned() is False  # still our table
-        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
-            assert t._coinpoker_window_reassigned() is False  # can't tell -> keep
+    # Two CoinPoker tables open; ours (930357) lives on pid 957 / window 1057.
+    t._detector.find_tables.return_value = _windows((956, "166755"), (957, "930357"))
+    pid_to_id = {956: "166755", 957: "930357"}
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
+        assert t._coinpoker_live_geometry() is _GEOM
+        assert t.number == 1057  # re-bound to the window actually serving our id
 
-    # Fail-safe: no PID, or a non-CoinPoker site, never reports reassigned.
-    with patch("fpdb_3_legacy.WinTables._window_pid", return_value=None):
-        assert t._coinpoker_window_reassigned() is False
-    t.site = "PokerStars"
-    assert t._coinpoker_window_reassigned() is False
+    # Our table closed: only the other table remains -> no window carries our id.
+    t._detector.find_tables.return_value = _windows((956, "166755"))
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect={956: "166755"}.get):
+        assert t._coinpoker_live_geometry() is None  # closed
+
+
+def test_live_geometry_falls_back_to_visibility_when_argv_unavailable() -> None:
+    # If psutil can't read any table id, don't guess "closed" -- keep the old
+    # HWND-visibility behaviour so a missing dependency never kills a live HUD.
+    t = _make_table()
+    t.search_string = "930357"
+    t.number = 111
+    t._detector.find_tables.return_value = _windows((956, "x"))
+    t._detector.is_window_visible.return_value = True
+    t._detector.get_window_geometry.return_value = _GEOM
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+        assert t._coinpoker_live_geometry() is _GEOM  # argv unusable -> fall back, stay alive
 
 
 def test_coinpoker_picks_unity_table_over_lobby() -> None:


### PR DESCRIPTION
## Problème

La détection de fermeture des tables CoinPoker ne fonctionne toujours pas sous Windows → le HUD n'est pas tué.

## Analyse

Les loggers fpdb sont par défaut au niveau **ERROR**. L'**absence** de l'ERROR « The window … is not valid or visible » dans les runs récents prouve que `IsWindowVisible()` renvoie **toujours vrai** après la fermeture : la fenêtre Unity de CoinPoker **reste visible** (et peut garder le même HWND). Suivre un HWND fixe est donc inadapté — ni la visibilité, ni le check « HWND réassigné » (PR #165) ne se déclenchent.

## Correctif

Détection par **identité de table**, pas par HWND fixe : à **chaque poll de géométrie**, re-résoudre quelle fenêtre CoinPoker ouverte porte (via l'argv de son process) **cet** id de table.
- Une fenêtre porte notre id → vivant (et on ré-attache le HWND si la fenêtre a été recréée).
- Aucune fenêtre ne le porte alors que l'argv est lisible → table fermée → HUD tué.
- Aucun id lisible du tout (psutil indisponible) → repli sur l'ancien check de visibilité du HWND → une dépendance manquante ne peut jamais tuer un HUD vivant.

Le chemin « closing HUD » logge en **WARNING** (visible même avec la config logger ERROR-only).

## Tests

- Re-résolution : id présent → géométrie + ré-attache du HWND ; id absent → fermé.
- Repli visibilité quand l'argv est illisible.
- Suites HUD : 53 tests verts (positioning, multiblock) + 7 (wintables). Lint `ruff`, `mypy` clean.

## Note

Si CoinPoker conservait une fenêtre fantôme portant encore l'ancien id, il faudrait un signal supplémentaire (inactivité) — le log WARNING le confirmera. Envoie `~/.fpdb/log/HUD-log.txt` après un test si ça persiste.