### PR TITLE
fix(hud): detect single-table CoinPoker close and reset stale parent handle

### DIFF
--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 Now uses the Platform Abstraction Layer (Feature 1.5) for table detection.
 """
 
-import contextlib
 import re
 import sys
 
@@ -34,6 +33,30 @@ if sys.platform == "win32":
     # Windows API constants
     SM_CXSIZEFRAME = 32
     SM_CYCAPTION = 4
+
+
+_argv_readable: bool | None = None
+
+
+def _argv_reading_works() -> bool:
+    """True if psutil can read a process's command line in this environment.
+
+    Tests our own process once and caches the result: whether argv is readable is
+    a property of the environment (psutil installed / permitted), not of any table,
+    so a single-table close can still be detected without another table open.
+    """
+    global _argv_readable
+    if _argv_readable is None:
+        try:
+            import os
+
+            import psutil
+
+            psutil.Process(os.getpid()).cmdline()
+            _argv_readable = True
+        except Exception:  # noqa: BLE001 - any failure means argv is not usable here
+            _argv_readable = False
+    return _argv_readable
 
 
 def _window_pid(hwnd: int | None) -> int | None:
@@ -216,20 +239,6 @@ class Table(Table_Window):
         except Exception as e:
             log.warning("Could not list open windows: %s", e)
 
-    def _coinpoker_argv_usable(self, tables) -> bool:
-        """True if a table id could be read from any open CoinPoker window (psutil works)."""
-        try:
-            from fpdb.infrastructure.platform.windows_process import table_id_for_pid
-        except ImportError:
-            return False
-        for table_info in tables:
-            pid = getattr(table_info, "process_id", None)
-            if pid:
-                with contextlib.suppress(Exception):
-                    if table_id_for_pid(pid):
-                        return True
-        return False
-
     def _coinpoker_live_geometry(self):
         """Geometry for THIS CoinPoker table, re-resolving its window every poll.
 
@@ -238,22 +247,29 @@ class Table(Table_Window):
         recycled or recreated. Tracking a fixed HWND is therefore unreliable.
         Instead, re-resolve the window by this table's id each poll: if no open
         CoinPoker window's process argv carries our id, the table has closed
-        (return None). Fall back to the tracked HWND's visibility only when the id
-        can't be read (psutil unavailable), so a missing dep never forces a kill.
+        (return None) -- this holds even when ours was the only table, because the
+        "closed" decision is gated on argv being *functional* (see
+        _argv_reading_works), not on another table being open. Fall back to the
+        tracked HWND's visibility only when argv can't be read at all, so a missing
+        dependency never forces a kill.
         """
         tables = self._detector.find_tables("CoinPoker")
         match = self._match_coinpoker_by_argv(tables)
         if match is not None:
-            self.number = match.window_id  # the window may have been recreated
+            if match.window_id != self.number:
+                # The window was recreated with a new HWND; drop the cached parent
+                # handle so topify() re-parents HUD windows to the new window.
+                self.number = match.window_id
+                self.gdkhandle = None
             return self._detector.get_window_geometry(self.number)
-        if self._coinpoker_argv_usable(tables):
+        if _argv_reading_works():
             log.warning(
                 "CoinPoker table %s: no open window carries this table id among %d CoinPoker window(s); closing HUD",
                 self.search_string,
                 len(tables),
             )
             return None
-        # argv unavailable (psutil): keep the old HWND-visibility behaviour.
+        # argv unreadable (psutil unavailable): keep the old HWND-visibility path.
         if self._detector.is_window_visible(self.number):
             return self._detector.get_window_geometry(self.number)
         return None

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -35,6 +35,7 @@ def _make_table() -> WinTables.Table:
     t.search_string = "930357"  # the table number, absent from any window title
     t.number = None
     t.title = ""
+    t.gdkhandle = None
     t._table_geometry = None
     t._detector = Mock()
     return t
@@ -47,38 +48,46 @@ def _windows(*ids_by_pid: tuple[int, str]) -> list[TableInfo]:
     ]
 
 
-def test_live_geometry_reresolves_and_closes_when_table_id_is_gone() -> None:
-    # The window stays "visible" after the table closes, so detection must be by
-    # table id: our id present -> alive (and HWND re-bound); absent -> closed.
+def test_live_geometry_reresolves_and_rebinds_hwnd() -> None:
+    # The window stays "visible" after the table closes, so detection is by table
+    # id: our id present -> alive, HWND re-bound, and the cached parent handle reset.
     t = _make_table()
-    t.search_string = "930357"
     t.number = 111
+    t.gdkhandle = "STALE"
     t._detector.get_window_geometry.return_value = _GEOM
-
-    # Two CoinPoker tables open; ours (930357) lives on pid 957 / window 1057.
     t._detector.find_tables.return_value = _windows((956, "166755"), (957, "930357"))
     pid_to_id = {956: "166755", 957: "930357"}
-    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
-        assert t._coinpoker_live_geometry() is _GEOM
-        assert t.number == 1057  # re-bound to the window actually serving our id
 
-    # Our table closed: only the other table remains -> no window carries our id.
-    t._detector.find_tables.return_value = _windows((956, "166755"))
-    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect={956: "166755"}.get):
+    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=True):
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
+            assert t._coinpoker_live_geometry() is _GEOM
+    assert t.number == 1057  # re-bound to the window actually serving our id
+    assert t.gdkhandle is None  # stale parent handle dropped so topify re-parents
+
+
+def test_single_table_close_is_detected_even_with_no_other_table() -> None:
+    # The whole point: ours was the only table. No window carries our id and argv
+    # is functional -> the table is gone, even though nothing else is open.
+    t = _make_table()
+    t.number = 111
+    t._detector.find_tables.return_value = []  # our window vanished; nothing left
+
+    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=True):
         assert t._coinpoker_live_geometry() is None  # closed
 
 
-def test_live_geometry_falls_back_to_visibility_when_argv_unavailable() -> None:
-    # If psutil can't read any table id, don't guess "closed" -- keep the old
-    # HWND-visibility behaviour so a missing dependency never kills a live HUD.
+def test_live_geometry_falls_back_to_visibility_when_argv_unreadable() -> None:
+    # psutil not usable at all -> don't guess "closed"; keep the HWND-visibility
+    # path so a missing dependency never kills a live HUD.
     t = _make_table()
-    t.search_string = "930357"
     t.number = 111
     t._detector.find_tables.return_value = _windows((956, "x"))
     t._detector.is_window_visible.return_value = True
     t._detector.get_window_geometry.return_value = _GEOM
-    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
-        assert t._coinpoker_live_geometry() is _GEOM  # argv unusable -> fall back, stay alive
+
+    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=False):
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+            assert t._coinpoker_live_geometry() is _GEOM  # stay alive
 
 
 def test_coinpoker_picks_unity_table_over_lobby() -> None:


### PR DESCRIPTION
## Contexte

Deux retours Codex sur la PR #166 (détection de fermeture CoinPoker par re-résolution).

## Correctifs

**1. Fermeture d'une table unique non détectée**
La décision « fermé » était conditionnée à ce qu'une **autre** table ouverte expose un id lisible (`_coinpoker_argv_usable(tables)`). Si ta table était la seule (ou qu'il ne restait qu'un lobby/fenêtre zombie), aucun id lisible → repli sur la visibilité du HWND → jamais fermé. Or c'est le cas le plus courant.

→ La décision est maintenant conditionnée à un vrai test de **fonctionnement de psutil** sur **notre propre process** (`_argv_reading_works`, mis en cache, propriété de l'environnement). La fermeture d'une table isolée est donc détectée.

**2. `gdkhandle` périmé après ré-attache du HWND**
Quand la fenêtre est recréée avec un nouveau HWND, on met à jour `self.number` mais `topify()` gardait `self.gdkhandle` de l'ancien HWND → les fenêtres du HUD restaient rattachées à un parent périmé.

→ On réinitialise `self.gdkhandle = None` au changement de HWND, pour que `topify()` reconstruise le handle vers la nouvelle fenêtre.

## Tests

- Fermeture détectée **sans autre table ouverte** (`find_tables` vide + argv fonctionnel → fermé).
- Ré-attache du HWND + reset du `gdkhandle` périmé.
- Repli visibilité quand psutil est indisponible.
- 8 tests wintables verts, `ruff` + `mypy` clean.