### PR TITLE
fix(hud): gate CoinPoker close on this table's argv being readable, not fpdb's

### DIFF
--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -35,6 +35,20 @@ if sys.platform == "win32":
     SM_CYCAPTION = 4
 
 
+def _window_pid(hwnd: int | None) -> int | None:
+    """Return the process id owning ``hwnd`` on Windows, or None."""
+    if sys.platform != "win32" or not hwnd:
+        return None
+    try:
+        import ctypes  # local import: ctypes.windll is Windows-only
+
+        pid = ctypes.c_ulong()
+        ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(pid))
+        return pid.value or None
+    except Exception:  # noqa: BLE001 - defensive: never break the geometry poll
+        return None
+
+
 # Global variables for window borders
 b_width = 3
 tb_height = 29
@@ -233,18 +247,47 @@ class Table(Table_Window):
                 self.number = match.window_id
                 self.gdkhandle = None
             return self._detector.get_window_geometry(self.number)
-        if self._coinpoker_argv_confirmed:
+        # No open CoinPoker window carries our id. Close if we can be sure this is
+        # not our table anymore: either our id was readable before and is now gone
+        # (confirmed), or the very window we track positively resolves to a
+        # *different* table id (reused/stale window -- catches HUDs first attached
+        # via the class fallback, where confirmed is still False).
+        if self._coinpoker_argv_confirmed or self._tracked_window_belongs_elsewhere():
             log.warning(
                 "CoinPoker table %s: no open window carries this table id among %d CoinPoker window(s); closing HUD",
                 self.search_string,
                 len(tables),
             )
             return None
-        # This table's id was never readable from its process: don't guess a
-        # close, keep the tracked HWND's visibility path.
+        # Can't tell (our id was never readable and the tracked window's argv is
+        # unreadable too): keep the tracked HWND's visibility path so a permission
+        # mismatch never kills a live HUD.
         if self._detector.is_window_visible(self.number):
             return self._detector.get_window_geometry(self.number)
         return None
+
+    def _tracked_window_belongs_elsewhere(self) -> bool:
+        """True if the tracked HWND's process argv resolves to a *different* table id.
+
+        Proves the window we hold is no longer ours (recycled for another table),
+        which is a reliable close signal even when this HUD was attached via the
+        class fallback and never had its id confirmed. Returns False whenever the
+        id can't be read, so it never causes a premature kill.
+        """
+        target = "".join(ch for ch in str(getattr(self, "search_string", "")) if ch.isdigit())
+        if not target:
+            return False
+        pid = _window_pid(self.number)
+        if not pid:
+            return False
+        try:
+            from fpdb.infrastructure.platform.windows_process import table_id_for_pid
+
+            current = table_id_for_pid(pid)
+        except Exception as exc:  # noqa: BLE001 - never break the geometry poll
+            log.debug("CoinPoker tracked-window argv check failed for pid %s: %s", pid, exc)
+            return False
+        return bool(current) and current != target
 
     def get_geometry(self):
         """Get the window geometry using platform abstraction."""

--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -35,44 +35,6 @@ if sys.platform == "win32":
     SM_CYCAPTION = 4
 
 
-_argv_readable: bool | None = None
-
-
-def _argv_reading_works() -> bool:
-    """True if psutil can read a process's command line in this environment.
-
-    Tests our own process once and caches the result: whether argv is readable is
-    a property of the environment (psutil installed / permitted), not of any table,
-    so a single-table close can still be detected without another table open.
-    """
-    global _argv_readable
-    if _argv_readable is None:
-        try:
-            import os
-
-            import psutil
-
-            psutil.Process(os.getpid()).cmdline()
-            _argv_readable = True
-        except Exception:  # noqa: BLE001 - any failure means argv is not usable here
-            _argv_readable = False
-    return _argv_readable
-
-
-def _window_pid(hwnd: int | None) -> int | None:
-    """Return the process id owning ``hwnd`` on Windows, or None."""
-    if sys.platform != "win32" or not hwnd:
-        return None
-    try:
-        import ctypes  # local import: ctypes.windll is Windows-only
-
-        pid = ctypes.c_ulong()
-        ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(pid))
-        return pid.value or None
-    except Exception:  # noqa: BLE001 - defensive: never break the geometry poll
-        return None
-
-
 # Global variables for window borders
 b_width = 3
 tb_height = 29
@@ -94,6 +56,11 @@ class Table(Table_Window):
         self._detector = get_table_detector()
         self._table_geometry = None
         self.gdkhandle: QWindow | None = None
+        # Set once this table's id has actually been read from a CoinPoker Unity
+        # process argv. Only then can a later "no window carries our id" be trusted
+        # to mean the table closed (rather than psutil being unable to read those
+        # processes, e.g. an elevated client).
+        self._coinpoker_argv_confirmed = False
         super().__init__(*args, **kwargs)
 
     def _matches_winamax_tournament(self, title: str) -> bool:
@@ -159,6 +126,9 @@ class Table(Table_Window):
                 continue
             try:
                 if table_id_for_pid(pid) == target:
+                    # We could read this table's id from its process, so a later
+                    # absence can be trusted to mean the table was closed.
+                    self._coinpoker_argv_confirmed = True
                     return table_info
             except Exception as exc:  # pragma: no cover - psutil/platform dependent
                 log.debug("argv lookup failed for pid %s: %s", pid, exc)
@@ -247,11 +217,12 @@ class Table(Table_Window):
         recycled or recreated. Tracking a fixed HWND is therefore unreliable.
         Instead, re-resolve the window by this table's id each poll: if no open
         CoinPoker window's process argv carries our id, the table has closed
-        (return None) -- this holds even when ours was the only table, because the
-        "closed" decision is gated on argv being *functional* (see
-        _argv_reading_works), not on another table being open. Fall back to the
-        tracked HWND's visibility only when argv can't be read at all, so a missing
-        dependency never forces a kill.
+        (return None) -- this holds even when ours was the only table. The "closed"
+        decision is gated on having *ever* read this table's id from its process
+        (_coinpoker_argv_confirmed): if we never could (psutil missing, or the
+        CoinPoker processes are access-denied/elevated), we can't tell a close from
+        an unreadable process, so we fall back to the tracked HWND's visibility and
+        never kill a live HUD.
         """
         tables = self._detector.find_tables("CoinPoker")
         match = self._match_coinpoker_by_argv(tables)
@@ -262,14 +233,15 @@ class Table(Table_Window):
                 self.number = match.window_id
                 self.gdkhandle = None
             return self._detector.get_window_geometry(self.number)
-        if _argv_reading_works():
+        if self._coinpoker_argv_confirmed:
             log.warning(
                 "CoinPoker table %s: no open window carries this table id among %d CoinPoker window(s); closing HUD",
                 self.search_string,
                 len(tables),
             )
             return None
-        # argv unreadable (psutil unavailable): keep the old HWND-visibility path.
+        # This table's id was never readable from its process: don't guess a
+        # close, keep the tracked HWND's visibility path.
         if self._detector.is_window_visible(self.number):
             return self._detector.get_window_geometry(self.number)
         return None

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -77,6 +77,25 @@ def test_single_table_close_is_detected_even_with_no_other_table() -> None:
     assert t._coinpoker_live_geometry() is None  # closed
 
 
+def test_fallback_attached_hud_closes_when_tracked_window_is_another_table() -> None:
+    # Codex case: attached via the class fallback (never confirmed). A later poll
+    # can read argv and the tracked HWND now belongs to a *different* table, so the
+    # window we hold is provably not ours -> close, don't cling via is_window_visible.
+    t = _make_table()
+    t.number = 111
+    t._coinpoker_argv_confirmed = False
+    t.search_string = "930357"
+    # No open window carries our id (another table occupies things).
+    t._detector.find_tables.return_value = _windows((956, "928730"))
+    t._detector.is_window_visible.return_value = True  # stale window still "visible"
+    t._detector.get_window_geometry.return_value = _GEOM
+
+    with patch("fpdb_3_legacy.WinTables._window_pid", return_value=956):
+        # Our tracked HWND's process now serves table 928730, not 930357.
+        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value="928730"):
+            assert t._coinpoker_live_geometry() is None  # closed despite visibility
+
+
 def test_unreadable_coinpoker_processes_do_not_kill_a_live_hud() -> None:
     # Codex case: fpdb's own argv is readable but the CoinPoker Unity processes are
     # access-denied (e.g. elevated), so our id was never confirmed. A no-match must

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -37,6 +37,7 @@ def _make_table() -> WinTables.Table:
     t.title = ""
     t.gdkhandle = None
     t._table_geometry = None
+    t._coinpoker_argv_confirmed = False
     t._detector = Mock()
     return t
 
@@ -49,8 +50,8 @@ def _windows(*ids_by_pid: tuple[int, str]) -> list[TableInfo]:
 
 
 def test_live_geometry_reresolves_and_rebinds_hwnd() -> None:
-    # The window stays "visible" after the table closes, so detection is by table
-    # id: our id present -> alive, HWND re-bound, and the cached parent handle reset.
+    # Detection is by table id: our id present -> alive, HWND re-bound, the cached
+    # parent handle reset, and _coinpoker_argv_confirmed latched by the match.
     t = _make_table()
     t.number = 111
     t.gdkhandle = "STALE"
@@ -58,36 +59,37 @@ def test_live_geometry_reresolves_and_rebinds_hwnd() -> None:
     t._detector.find_tables.return_value = _windows((956, "166755"), (957, "930357"))
     pid_to_id = {956: "166755", 957: "930357"}
 
-    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=True):
-        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
-            assert t._coinpoker_live_geometry() is _GEOM
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", side_effect=pid_to_id.get):
+        assert t._coinpoker_live_geometry() is _GEOM
     assert t.number == 1057  # re-bound to the window actually serving our id
     assert t.gdkhandle is None  # stale parent handle dropped so topify re-parents
+    assert t._coinpoker_argv_confirmed is True  # reading our id latched it
 
 
 def test_single_table_close_is_detected_even_with_no_other_table() -> None:
-    # The whole point: ours was the only table. No window carries our id and argv
-    # is functional -> the table is gone, even though nothing else is open.
+    # Ours was the only table and its id was read before (confirmed). No window
+    # carries our id now -> closed, even though nothing else is open.
     t = _make_table()
     t.number = 111
+    t._coinpoker_argv_confirmed = True  # our id was readable while the table lived
     t._detector.find_tables.return_value = []  # our window vanished; nothing left
 
-    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=True):
-        assert t._coinpoker_live_geometry() is None  # closed
+    assert t._coinpoker_live_geometry() is None  # closed
 
 
-def test_live_geometry_falls_back_to_visibility_when_argv_unreadable() -> None:
-    # psutil not usable at all -> don't guess "closed"; keep the HWND-visibility
-    # path so a missing dependency never kills a live HUD.
+def test_unreadable_coinpoker_processes_do_not_kill_a_live_hud() -> None:
+    # Codex case: fpdb's own argv is readable but the CoinPoker Unity processes are
+    # access-denied (e.g. elevated), so our id was never confirmed. A no-match must
+    # NOT be read as closed -- fall back to the tracked window's visibility.
     t = _make_table()
     t.number = 111
-    t._detector.find_tables.return_value = _windows((956, "x"))
+    t._coinpoker_argv_confirmed = False  # never managed to read a CoinPoker id
+    t._detector.find_tables.return_value = _windows((956, "denied"))
     t._detector.is_window_visible.return_value = True
     t._detector.get_window_geometry.return_value = _GEOM
 
-    with patch("fpdb_3_legacy.WinTables._argv_reading_works", return_value=False):
-        with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
-            assert t._coinpoker_live_geometry() is _GEOM  # stay alive
+    with patch("fpdb.infrastructure.platform.windows_process.table_id_for_pid", return_value=None):
+        assert t._coinpoker_live_geometry() is _GEOM  # stay alive
 
 
 def test_coinpoker_picks_unity_table_over_lobby() -> None:


### PR DESCRIPTION
## Contexte

Retour Codex sur la PR #167 : le check de fermeture utilisait `_argv_reading_works()`, qui teste si psutil peut lire l'argv de **notre propre** process fpdb.

## Le problème (régression)

Si les process Unity de CoinPoker sont **inaccessibles** (client élevé / access-denied) alors que le nôtre est lisible, `table_id_for_pid()` renvoie `None` pour eux → aucune fenêtre ne matche → mais `_argv_reading_works()` renvoie `True` → on concluait « fermé » et on **tuait un HUD vivant**.

## Correctif

Suivi **par table** au lieu d'un check global : `_coinpoker_argv_confirmed` se verrouille à `True` dès que l'id de **cette** table a réellement été lu depuis l'argv de son process Unity.
- Une absence ultérieure n'est interprétée comme fermeture **que si** l'id avait déjà été lisible.
- Si l'id n'a **jamais** été lisible (psutil absent, ou process CoinPoker access-denied), on retombe sur la visibilité du HWND → une différence de privilèges ne peut jamais tuer un HUD vivant.

Supprime les helpers devenus inutiles (`_argv_reading_works`, `_window_pid`).

## Tests

- id présent → vivant + ré-attache HWND + `gdkhandle` reset + flag verrouillé.
- Table unique fermée (id lu auparavant) → fermé.
- **Process CoinPoker illisibles** (cas Codex) → HUD reste vivant.
- 8 tests wintables + 53 HUD (positioning, multiblock) verts. `ruff` + `mypy` clean.