### PR TITLE
fix(db): survive network outages and reduce HUD queries from 41 to 7 per hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,7 +572,7 @@ jobs:
             ~/.cache/pyoxidizer
             ~/Library/Caches/pyoxidizer
             ~/AppData/Local/pyoxidizer
-          key: pyoxidizer-${{ runner.os }}-${{ runner.arch }}-0.24.0-rust-1.83.0-${{ hashFiles('pyoxidizer.bzl', 'pyproject.toml') }}
+          key: pyoxidizer-${{ runner.os }}-${{ runner.arch }}-0.24.0-rust-1.83.0-${{ hashFiles('pyoxidizer.bzl', 'pyoxidizer-requirements.txt', 'pyproject.toml') }}
           restore-keys: |
             pyoxidizer-${{ runner.os }}-${{ runner.arch }}-0.24.0-rust-1.83.0-
       - name: Install PyOxidizer
@@ -595,14 +595,6 @@ jobs:
           echo "$pyoxidizer_dir" >> "$GITHUB_PATH"
       - name: Compile translation catalogs
         run: python tools/compile_translations.py
-      - name: Relax requires-python for embedded Python 3.10
-        shell: bash
-        run: |
-          python -c "
-          import pathlib
-          p = pathlib.Path('pyproject.toml')
-          p.write_text(p.read_text().replace('>=3.11,<4.0', '>=3.10,<4.0'))
-          "
       - name: Build with PyOxidizer
         shell: bash
         run: |

--- a/HUD_DB_PERFORMANCE_PLAN.md
+++ b/HUD_DB_PERFORMANCE_PLAN.md
@@ -1,0 +1,135 @@
+# HUD database performance — done, and what is left
+
+Status: 2026-08-01. Branch `fix/db-vpn-reconnect`.
+Open item: **run `tools/explain_hud_queries.py` against the real PostgreSQL
+database.** Everything else below is landed and measured.
+
+## Why round trips, not query time
+
+The HUD reads its database on the Qt thread that repaints it, once per open
+table per hand dealt. When the database is remote — the case this work started
+from, a home PostgreSQL reached over a VPN — every statement costs one network
+latency whatever the server does with it. A query that runs in 200µs locally
+still costs 40ms from a hotel. So the number that decides how the HUD feels is
+how many statements it sends, which no CPU-time benchmark reports.
+
+`fpdb_3_legacy/db_profile.py` counts them and attributes each one to the work
+that asked for it. Off unless `FPDB_DB_PROFILE=1`.
+
+```bash
+FPDB_DB_PROFILE=1 fpdb                                    # profile a real session
+python tools/measure_hud_round_trips.py --tables 12       # reproduce the numbers below
+```
+
+## What landed
+
+Measured with `tools/measure_hud_round_trips.py`, twelve tables at one stake,
+steady state (the first batch pays cache misses and costs more):
+
+| | statements per hand dealt | at 40ms RTT |
+|---|---:|---:|
+| before | 41 | 1.64s |
+| after read caches (`446defb8`) | 17 | 0.68s |
+| after batching (`3a14d517`) | **7** | **0.28s** |
+
+Three statements dominated, each issued once per open table per hand:
+
+- `get_hand_1day_ago` — a 24-hour boundary hand id that moves once a day. Now
+  re-read at most every five minutes. It is a sliding boundary, so it is
+  always a little stale by construction.
+- `get_gameinfo_from_hid` — a hand's gametype, settled when the hand is written
+  and never changed. Now cached by hand id. A **miss** is deliberately not
+  cached: it means the hand is not committed yet, and caching it would keep
+  denying the hand after the import lands.
+- `get_stats_from_hand_aggregated` — the one doing real work. Now answered for
+  every refreshing table in a single query (`get_stats_from_hands`).
+
+Both caches are dropped by `resetCache`, which `recreate_tables` goes through:
+that restarts hand ids from 1, so an entry kept across it would be served for a
+different hand.
+
+The batched query is the per-hand one **rewritten**, not a second copy — the
+aggregate is 300 lines of stat columns and two copies would drift into the HUD
+reporting different numbers depending on which path served a table. Each
+rewrite is checked; any that no longer applies drops back to asking per hand.
+`tests/test_hud_stats_batching.py` compares the two paths stat by stat over the
+imported corpus.
+
+## Open: run EXPLAIN against the real database
+
+Counting round trips says nothing about what each one costs once it arrives.
+Only a database with real volume and real planner statistics can say that, so
+this has to run against the PostgreSQL instance the HUD actually uses.
+
+```bash
+python tools/explain_hud_queries.py --plans
+```
+
+It runs `EXPLAIN (ANALYZE, BUFFERS)` over the HUD's statements with parameters
+taken from real rows, inside a transaction it rolls back, and flags:
+
+- sequential scans over `HudCache`, `HandsPlayers`, `Hands`, `Players`
+- row estimates off by more than 10x — what makes the planner choose a nested
+  loop over a hash join and lose an order of magnitude
+- blocks read from disk rather than served from cache
+
+### The hypothesis to test first
+
+The aggregate reaches `HudCache` like this:
+
+```sql
+INNER JOIN HudCache hc ON (hc.playerId = hp.playerId)
+...
+AND hc.gametypeId+0 in (SELECT ...)
+```
+
+and the compound index is:
+
+```sql
+CREATE UNIQUE INDEX HudCache_Compound_idx
+    ON HudCache(gametypeId, playerId, seats, position, tourneyTypeId, styleKey)
+```
+
+Two things follow. The join is on `playerId`, which is not the leading column,
+so the compound index cannot serve it and the join falls back to the plain
+`HudCache(playerId)` index. And `gametypeId+0` is an old MySQL idiom for
+*discouraging* the optimiser from using an index — on PostgreSQL it buys
+nothing and stops any index on `gametypeId` being used at all, turning what
+could be an index condition into a filter applied after the fact.
+
+**Do not remove the `+0` blind.** It may have earned its place on MySQL, and
+how much it costs depends entirely on how large `HudCache` has grown. Decide
+from the plan:
+
+- If `HudCache` is scanned sequentially, or the filter on `gametypeId` discards
+  most of what the join produced, dropping `+0` on the PostgreSQL variant of
+  the query is the first thing to try. `sql_queries_hud_aggregated_stats.py`
+  can branch on `db_server`, as several other queries already do.
+- If the plan already uses `HudCache(playerId)` and discards little, `+0` is
+  not the problem and the next candidate is an index leading with `playerId`
+  and covering `styleKey`/`seats`.
+- If row estimates are far out, `ANALYZE HudCache` (or raising its statistics
+  target) may be all that is needed.
+
+Re-run `tools/measure_hud_round_trips.py` after any change: it is the same
+harness that produced the table above.
+
+## Not pursued
+
+- **Moving the HUD's reads off the Qt thread.** It would mean splitting
+  `read_stdin`, `_update_existing_hud`, `_refresh_secondary_hud` and
+  `_create_new_hud` into fetch and apply phases, on the hottest path in the
+  HUD, with no way to exercise it against a live client. The circuit breaker in
+  `HUD_main` (`0ac7eb58`) removes the freeze this was meant to address without
+  that risk.
+- **A local staging database that syncs to the remote one.** The write path
+  already has a durable queue — the hand-history files themselves — so a
+  staging database would duplicate it. The read path cannot be fixed by a
+  cache: serving an unknown villain offline needs all of `HudCache`, which is a
+  replica, not a cache, and a replica while you are also writing locally is a
+  merge problem on integer surrogate keys. Running PostgreSQL locally and
+  replicating *to* the remote machine is the better shape for the travelling
+  case.
+- **A global `statement_timeout`.** It would abort bulk imports, `VACUUM` and
+  index rebuilds. TCP keepalives (`a1fca458`, `f9c74a3d`) address the failure
+  mode this was proposed for.

--- a/HUD_DB_PERFORMANCE_PLAN.md
+++ b/HUD_DB_PERFORMANCE_PLAN.md
@@ -1,8 +1,9 @@
 # HUD database performance — done, and what is left
 
 Status: 2026-08-01. Branch `fix/db-vpn-reconnect`.
-Open item: **run `tools/explain_hud_queries.py` against the real PostgreSQL
-database.** Everything else below is landed and measured.
+Open item: **resolve the aggregate's gametype set in the application** — see
+"What EXPLAIN actually said" below, which corrects the hypothesis this document
+first carried.
 
 ## Why round trips, not query time
 
@@ -55,64 +56,120 @@ rewrite is checked; any that no longer applies drops back to asking per hand.
 `tests/test_hud_stats_batching.py` compares the two paths stat by stat over the
 imported corpus.
 
-## Open: run EXPLAIN against the real database
+## What EXPLAIN actually said
 
-Counting round trips says nothing about what each one costs once it arrives.
-Only a database with real volume and real planner statistics can say that, so
-this has to run against the PostgreSQL instance the HUD actually uses.
+Run locally against PostgreSQL 16 in a container, with `HudCache` grown to
+1.07M rows / 1.5GB and each seated player carrying ~365 rows, which is the size
+at which the question stops being hypothetical. See "Reproducing the fixture"
+below.
+
+**The hypothesis this document first carried was wrong.** It said the aggregate's
+`hc.gametypeId+0` — an old MySQL idiom for discouraging index use — was
+stopping PostgreSQL using an index, and that removing it was the thing to try.
+Measured, that changes nothing:
+
+| variant | median | rows discarded per player |
+|---|---:|---:|
+| current (`gametypeId+0`, subquery) | 1.42ms | 378 |
+| without `+0` | 1.09ms | 378 |
+| without `+0`, plus index `(playerId, gametypeId)` | 1.06ms | 378 |
+| with `+0`, plus index `(playerId, gametypeId)` | 1.03ms | 378 |
+
+`Rows Removed by Filter: 378` is identical in all four. There is no sequential
+scan either: the join already uses `hudcache_playerid_idx`. The `+0` is a red
+herring on PostgreSQL — **do not spend a risky change on it.**
+
+The real blocker is that the "gametypes similar to this one" set is an
+uncorrelatable subquery, so PostgreSQL evaluates it into a hashed SubPlan and
+applies it as a **filter after fetching each row from the heap**. No index on
+`gametypeId`, compound or otherwise, can be used for something the planner only
+knows at run time.
+
+That set depends only on the gametype and the blind multiplier, so the
+application can resolve it once and pass the ids as an array. Then it becomes
+an index condition:
+
+```
+Index Cond: ((playerid = p.id) AND (gametypeid = ANY ('{3,4,7,...,60}'::smallint[])))
+```
+
+| | median | HudCache buffers | rows discarded |
+|---|---:|---:|---:|
+| current | 1.07ms | 2414 | 378 |
+| gametype set passed as an array | 0.78ms | **502** | **0** |
+
+4.8x less of `HudCache` touched, nothing fetched only to be thrown away. And it
+uses the **existing** `HudCache_Compound_idx` — no new index needed, because
+with the gametype ids known the leading column is finally usable.
+
+### What to do with that
+
+- Resolve the set in `database_hud_stats`, cache it per
+  `(gametypeId, agg_bb_mult)` — it changes only when a new gametype appears —
+  and pass it as an array. Both the per-hand and the batched path go through
+  the same query, so this is one change.
+- Keep it PostgreSQL-shaped: `sql_queries_hud_aggregated_stats.py` can branch on
+  `db_server` as other queries already do, leaving MySQL's `+0` alone.
+- `tests/test_hud_stats_batching.py` already compares stat dicts between two
+  query paths; the same harness answers whether this one is equivalent.
+
+### Keep the magnitude in perspective
+
+0.3ms per query on a warm cache, and after batching there is now one aggregate
+per hand rather than twelve — so this is worth far less than the round-trip
+work above, and nothing like it on a fast local link. It matters where I/O
+does: a database larger than RAM, or a cold cache, where 4.8x fewer buffers is
+4.8x less to read. Confirm on the real database before deciding it is worth the
+change:
 
 ```bash
 python tools/explain_hud_queries.py --plans
 ```
 
-It runs `EXPLAIN (ANALYZE, BUFFERS)` over the HUD's statements with parameters
-taken from real rows, inside a transaction it rolls back, and flags:
-
-- sequential scans over `HudCache`, `HandsPlayers`, `Hands`, `Players`
-- row estimates off by more than 10x — what makes the planner choose a nested
-  loop over a hash join and lose an order of magnitude
-- blocks read from disk rather than served from cache
-
-### The hypothesis to test first
-
-The aggregate reaches `HudCache` like this:
-
-```sql
-INNER JOIN HudCache hc ON (hc.playerId = hp.playerId)
-...
-AND hc.gametypeId+0 in (SELECT ...)
-```
-
-and the compound index is:
-
-```sql
-CREATE UNIQUE INDEX HudCache_Compound_idx
-    ON HudCache(gametypeId, playerId, seats, position, tourneyTypeId, styleKey)
-```
-
-Two things follow. The join is on `playerId`, which is not the leading column,
-so the compound index cannot serve it and the join falls back to the plain
-`HudCache(playerId)` index. And `gametypeId+0` is an old MySQL idiom for
-*discouraging* the optimiser from using an index — on PostgreSQL it buys
-nothing and stops any index on `gametypeId` being used at all, turning what
-could be an index condition into a filter applied after the fact.
-
-**Do not remove the `+0` blind.** It may have earned its place on MySQL, and
-how much it costs depends entirely on how large `HudCache` has grown. Decide
-from the plan:
-
-- If `HudCache` is scanned sequentially, or the filter on `gametypeId` discards
-  most of what the join produced, dropping `+0` on the PostgreSQL variant of
-  the query is the first thing to try. `sql_queries_hud_aggregated_stats.py`
-  can branch on `db_server`, as several other queries already do.
-- If the plan already uses `HudCache(playerId)` and discards little, `+0` is
-  not the problem and the next candidate is an index leading with `playerId`
-  and covering `styleKey`/`seats`.
-- If row estimates are far out, `ANALYZE HudCache` (or raising its statistics
-  target) may be all that is needed.
-
 Re-run `tools/measure_hud_round_trips.py` after any change: it is the same
 harness that produced the table above.
+
+## Reproducing the fixture
+
+```bash
+docker run -d --name fpdb-explain -e POSTGRES_PASSWORD=fpdb -e POSTGRES_USER=fpdb \
+    -e POSTGRES_DB=fpdb -p 55432:5432 postgres:16
+```
+
+Point a config at `127.0.0.1:55432` with `db-server=postgresql` / `db-backend=3`,
+run `Database.recreate_tables()`, bulk-import
+`regression-test-files/cash/Stars/Flop`, then grow the cache — a plan over the
+955 rows the import produces says only that PostgreSQL prefers a sequential
+scan on a tiny table, which is true and useless:
+
+```sql
+-- 40k opponents with ~25 cache rows each, cloned from imported rows so every
+-- NOT NULL column and foreign key is satisfied without enumerating 200 columns
+INSERT INTO Players (name, siteId, hero)
+SELECT 'synth_' || g, 1, FALSE FROM generate_series(1, 40000) g;
+
+INSERT INTO HudCache (<every column except id>)
+SELECT <playerid := p.id, gametypeid := gt.id, rest from src>
+FROM (SELECT * FROM HudCache ORDER BY id LIMIT 25) src
+CROSS JOIN LATERAL (SELECT id FROM Players WHERE name LIKE 'synth_%' ORDER BY id LIMIT 40000) p
+CROSS JOIN LATERAL (SELECT id FROM Gametypes ORDER BY random() LIMIT 1) gt;
+
+-- and give the players who are actually seated a real history, which is what
+-- makes the gametype filter discard work rather than be free
+INSERT INTO HudCache (playerid, gametypeid, seats, position, tourneytypeid,
+                      stylekey, n, street0vpichance, street0vpi,
+                      street0aggrchance, street0aggr)
+SELECT hp.playerid, gt.id, s.seats, pos.p, NULL, '0000000', 50, 50, 20, 50, 15
+FROM (SELECT DISTINCT playerid FROM HandsPlayers) hp
+CROSS JOIN (SELECT id FROM Gametypes ORDER BY id LIMIT 20) gt
+CROSS JOIN (SELECT unnest(ARRAY[6,9,10]) AS seats) s
+CROSS JOIN (SELECT unnest(ARRAY['B','S','D','C','M','E']) AS p) pos;
+
+ANALYZE HudCache;
+```
+
+`TourneyTypes` is empty in a cash-only fixture, so `tourneytypeid` must be NULL
+or the foreign key rejects the insert.
 
 ## Not pursued
 

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -54,6 +54,12 @@ from fpdb_3_legacy.database_schema import DB_VERSION, DatabaseSchemaMixin
 # columns; re-exported because four test modules import it from Database.
 from fpdb_3_legacy.database_schema import HANDS_PLAYERS_KEYS as HANDS_PLAYERS_KEYS
 from fpdb_3_legacy.database_tournaments import DatabaseTournamentsMixin
+from fpdb_3_legacy.db_reconnect import (
+    MYSQL_NETWORK_KWARGS,
+    PG_NETWORK_KWARGS,
+    RECONNECT_COOLDOWN,
+    reconnect_on_connection_loss,
+)
 from fpdb_3_legacy.Exceptions import (
     FpdbError,
     FpdbMySQLAccessDenied,
@@ -277,6 +283,13 @@ class Database(
         self.resetCache()
         self.resetBulkCache()
         self._in_transaction = 0
+        # Reconnection state (see db_reconnect). The guard collapses nested
+        # decorated calls onto a single retry; the deadline throttles reconnect
+        # attempts so a database that stays unreachable costs one connect
+        # timeout per cooldown window instead of one per query.
+        self._reconnect_guard = False
+        self._reconnect_blocked_until = 0.0
+        self._connection_down_logged = False
 
         if "day_start" in gen:
             self.day_start = float(gen["day_start"])
@@ -489,6 +502,7 @@ class Database(
                 "db": database,
                 "charset": "utf8",
                 "use_unicode": True,
+                **MYSQL_NETWORK_KWARGS,
             }
             if port:
                 kwargs["port"] = int(port)
@@ -514,10 +528,17 @@ class Database(
         # psycopg3 handles Unicode natively, no need for register_type(UNICODE)
         # psycopg3 has native Decimal support, no adapter registration needed
 
+        # PG_NETWORK_KWARGS bounds the connect itself and arms TCP keepalives on
+        # the resulting socket. Without the keepalives a connection to a remote
+        # database (typically over a VPN) does not fail when the link drops --
+        # it hangs forever inside the kernel's retransmit loop, taking the HUD's
+        # event loop and the auto-import worker down with it. libpq ignores the
+        # keepalive settings on a local Unix socket, so the peer connection
+        # below is unaffected.
         self.__connected = False
         if self.host in ("localhost", "127.0.0.1"):
             try:
-                self.connection = psycopg.connect(dbname=database)
+                self.connection = psycopg.connect(dbname=database, **PG_NETWORK_KWARGS)
                 self.__connected = True
             except psycopg.OperationalError:
                 # direct connection failed so try user/pass/... version
@@ -531,6 +552,7 @@ class Database(
                     user=user,
                     password=password,
                     dbname=database,
+                    **PG_NETWORK_KWARGS,
                 )
                 self.__connected = True
             except Exception as ex:  # intentional broad catch: psycopg connection error inspected and re-raised as a typed FpdbError
@@ -737,9 +759,108 @@ class Database(
 
     def reconnect(self, due_to_error=False) -> None:
         """Reconnects the DB."""
-        # print "started reconnect"
         self.disconnect(due_to_error)
-        self.connect(self.backend, self.host, self.database, self.user, self.password)
+        # Keyword arguments on purpose: connect() takes (backend, host, port,
+        # database, user, password), so the positional call this used to make
+        # silently passed the database as the port and the user as the database.
+        self.connect(
+            backend=self.backend,
+            host=self.host,
+            port=self.port,
+            database=self.database,
+            user=self.user,
+            password=self.password,
+        )
+
+    def _force_disconnect(self) -> None:
+        """Drop the connection without touching it, for use after it has died.
+
+        ``disconnect()`` commits or rolls back on the way out, which is exactly
+        what a broken socket cannot do: the recovery path would raise inside its
+        own cleanup and never get as far as reconnecting.
+        """
+        self._close_cursor_quietly()
+        with contextlib.suppress(Exception):
+            if self.connection is not None:
+                self.connection.close()
+        self.connection = None
+        self.__connected = False
+
+    def connection_is_alive(self) -> bool:
+        """Check the connection with a round trip to the server.
+
+        Cheap, but not free -- it is a real query, so callers should use it to
+        check once per work cycle rather than once per statement. Query paths
+        detect a dead connection reactively instead, via
+        ``reconnect_on_connection_loss``.
+        """
+        if not self.is_connected() or self.connection is None:
+            return False
+        if self.backend == self.SQLITE:
+            return True
+        try:
+            c = self.connection.cursor()
+            c.execute("SELECT 1")
+            c.fetchone()
+            c.close()
+        except Exception as exc:  # intentional broad catch: any failure here means the connection is unusable
+            log.debug("Connection liveness check failed: %s", exc)
+            return False
+        return True
+
+    def recover_connection(self) -> bool:
+        """Re-open a connection that has been lost, at most once per cooldown.
+
+        Returns:
+            True when a usable connection is available afterwards.
+
+        A database that stays unreachable -- the VPN is still down -- must stay
+        cheap to ask about: without the cooldown every HUD hand would pay a full
+        connect timeout, recreating the stall this whole mechanism exists to
+        remove. Recovery happens on the first query after the link returns.
+        """
+        if self.backend == self.SQLITE:
+            return self.is_connected()
+
+        now = time()
+        if now < self._reconnect_blocked_until:
+            log.debug(
+                "Skipping reconnect attempt, still in cooldown for %.1fs",
+                self._reconnect_blocked_until - now,
+            )
+            return False
+
+        self._force_disconnect()
+        try:
+            self.reconnect(due_to_error=True)
+        except Exception as exc:  # intentional broad catch: any connect failure means we stay offline and retry later
+            self._reconnect_blocked_until = time() + RECONNECT_COOLDOWN
+            if not self._connection_down_logged:
+                # Log the outage once, then stay quiet: the auto-import retries
+                # every few seconds and would otherwise flood the log.
+                log.error("Database is unreachable, will keep retrying: %s", exc)
+                self._connection_down_logged = True
+            else:
+                log.debug("Reconnect attempt failed: %s", exc)
+            return False
+
+        self._reconnect_blocked_until = 0.0
+        if self._connection_down_logged:
+            log.info("Database connection re-established.")
+            self._connection_down_logged = False
+        return self.is_connected()
+
+    def ensure_connection(self) -> bool:
+        """Make sure the connection is usable before starting a unit of work.
+
+        Returns:
+            True when the caller may proceed to query the database.
+        """
+        if self.connection_is_alive():
+            return True
+        if not self._connection_down_logged:
+            log.warning("Database connection is not usable; attempting to reconnect.")
+        return self.recover_connection()
 
     def get_backend_name(self) -> str:
         """Returns the name of the currently used backend."""
@@ -755,11 +876,13 @@ class Database(
     def get_db_info(self):
         return (self.host, self.database, self.user, self.password)
 
+    @reconnect_on_connection_loss
     def get_table_name(self, hand_id):
         c = self.connection.cursor()
         c.execute(self.sql.query["get_table_name"], (hand_id,))
         return c.fetchone()
 
+    @reconnect_on_connection_loss
     def get_table_info(self, hand_id):
         c = self.connection.cursor()
         c.execute(self.sql.query["get_table_name"], (hand_id,))
@@ -904,6 +1027,7 @@ class Database(
         row = c.fetchone()
         return row[0]
 
+    @reconnect_on_connection_loss
     def get_cards(self, hand):
         """Get and return the cards for each player in the hand."""
         cards = {}  # dict of cards, the key is the seat number,
@@ -949,6 +1073,7 @@ class Database(
 
 
 
+    @reconnect_on_connection_loss
     def get_common_cards(self, hand):
         """Get and return the community cards for the specified hand."""
         cards = {}

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -35,7 +35,7 @@ from typing import Any
 
 import pytz
 
-from fpdb_3_legacy import SQL, Card, Configuration
+from fpdb_3_legacy import SQL, Card, Configuration, db_profile
 from fpdb_3_legacy.database_aof import DatabaseAofMixin
 from fpdb_3_legacy.database_auto_notes import DatabaseAutoNotesMixin
 from fpdb_3_legacy.database_bulk_import import DatabaseBulkImportMixin
@@ -474,6 +474,11 @@ class Database(
             database, create = self._connect_sqlite(database, create)
         else:
             raise FpdbError("unrecognised database backend:" + str(backend))
+
+        # Off unless FPDB_DB_PROFILE=1, in which case every statement issued
+        # through this connection is counted and attributed (see db_profile).
+        # Done here so it survives a reconnect, which comes back through connect().
+        self.connection = db_profile.wrap_connection(self.connection, getattr(self.sql, "query", None))
 
         if self.is_connected():
             self.cursor = self.connection.cursor()

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -34,6 +34,7 @@ from time import sleep, time
 from typing import Any
 
 import pytz
+from cachetools import TTLCache
 
 from fpdb_3_legacy import SQL, Card, Configuration, db_profile
 from fpdb_3_legacy.database_aof import DatabaseAofMixin
@@ -81,6 +82,12 @@ from fpdb_3_legacy.loggingFpdb import get_logger
 
 
 re_char = re.compile("[^a-zA-Z]")
+
+# Gametype-per-hand cache. A hand's game is fixed when the hand is written, so
+# the TTL is only there to bound how long a re-imported hand could be served
+# from a stale entry; the size bounds a long multi-tabling session.
+GAMEINFO_CACHE_SIZE = 2000
+GAMEINFO_CACHE_TTL = 3600
 
 #    FreePokerTools modules
 
@@ -280,6 +287,12 @@ class Database(
         self._hero = None
         self._has_lock = False
         self.printdata = False
+        # Read caches for values the HUD asks for once per open table per hand
+        # dealt, but which cannot have changed in between; see
+        # get_gameinfo_from_hid and database_hud_stats._refresh_hand_1day_ago.
+        # Created before resetCache, which is what empties them.
+        self._gameinfo_cache: TTLCache = TTLCache(maxsize=GAMEINFO_CACHE_SIZE, ttl=GAMEINFO_CACHE_TTL)
+        self._hand_1day_ago_read_at = 0.0
         self.resetCache()
         self.resetBulkCache()
         self._in_transaction = 0
@@ -957,6 +970,18 @@ class Database(
         return c.fetchall()
 
     def get_gameinfo_from_hid(self, hand_id):
+        """Return the gametype of a hand, as Hand.hand_factory wants it.
+
+        Cached: a hand's game is settled when the hand is written and never
+        changes afterwards, while the HUD asks for it once per open table per
+        hand dealt -- measurably the joint second-largest source of round trips
+        (see tools/measure_hud_round_trips.py), which over a VPN is pure
+        latency for an answer that cannot have moved.
+        """
+        cached = self._gameinfo_cache.get(hand_id)
+        if cached is not None:
+            return cached
+
         # returns a gameinfo (gametype) dictionary suitable for passing
         # to Hand.hand_factory
         c = self.connection.cursor()
@@ -966,10 +991,12 @@ class Database(
         row = c.fetchone()
 
         if row is None:
+            # Not cached: the hand may simply not be committed yet, and caching
+            # the miss would keep answering "no such hand" after it arrives.
             log.warning(f"No game info found for hand ID {hand_id}")
             return None
 
-        return {
+        gameinfo = {
             "sitename": row[0],
             "category": row[1],
             "base": row[2],
@@ -984,6 +1011,8 @@ class Database(
             "gametypeId": row[11],
             "split": row[12],
         }
+        self._gameinfo_cache[hand_id] = gameinfo
+        return gameinfo
 
     #   Query 'get_hand_info' does not exist, so it seems
     #    def get_hand_info(self, new_hand_id):
@@ -1214,6 +1243,15 @@ class Database(
         self.tcache = None  # TourneyId cache
         self.pcache = None  # PlayerId cache
         self.tpcache = None  # TourneysPlayersId cache
+        # Read caches keyed by hand id. recreate_tables() comes through here,
+        # and it restarts hand ids from 1 -- an entry kept across that would be
+        # served for a different hand entirely. Read defensively: resetCache
+        # also runs on the transaction-rollback path, and clearing a cache must
+        # never be the thing that makes a rollback fail.
+        gameinfo_cache = getattr(self, "_gameinfo_cache", None)
+        if gameinfo_cache is not None:
+            gameinfo_cache.clear()
+        self._hand_1day_ago_read_at = 0.0
 
     def get_last_insert_id(self, cursor=None):
         ret = None

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -112,6 +112,10 @@ class GuiAutoImport(QWidget):
         # than once per interval, and its return is reported too.
         self._deferred_cycles = 0
         self._db_offline = False
+        # When Stop's bounded wait expires, cleanup is deferred until the
+        # worker really exits. The importer, its database connection and the
+        # global lock must remain exclusively owned by that worker meanwhile.
+        self._stop_cleanup_pending = False
         self.settings = settings
         self.config = config
         self.sql = sql
@@ -386,7 +390,8 @@ class GuiAutoImport(QWidget):
         if self._db_offline:
             self._db_offline = False
             self.addText(_("\nDatabase is back. Auto Import resumed."), "info")
-        self.statusLabel.setText(_("Ready"))
+        status = _("Stopping Auto Import...") if self._stop_cleanup_pending else _("Ready")
+        self.statusLabel.setText(status)
         log.debug("AutoImport: background import cycle finished successfully")
 
     def import_db_offline(self) -> None:
@@ -420,6 +425,33 @@ class GuiAutoImport(QWidget):
             "warning",
         )
         return False
+
+    def _wait_for_import_worker_stop(self) -> None:
+        """Finish a pending Stop once the import worker has really exited."""
+        if not self._stop_cleanup_pending:
+            return
+        if self.import_thread is not None and self.import_thread.isRunning():
+            QTimer.singleShot(250, self._wait_for_import_worker_stop)
+            return
+        self._finalize_auto_import_stop()
+
+    def _finalize_auto_import_stop(self) -> None:
+        """Release importer resources after no worker can still be using them."""
+        self._stop_cleanup_pending = False
+        self.importer.autoSummaryGrab(True)
+        self.settings["global_lock"].release()
+        self.addText("\nStopping Auto Import. Global lock released.", "unlock")
+        self.progressBar.setVisible(False)
+        self.statusLabel.setText(_("Ready"))
+        if self.pipe_to_hud and self.pipe_to_hud.poll() is not None:
+            self.addText("\n * Stop Auto Import: HUD already terminated.", "hud")
+        else:
+            if self.pipe_to_hud:
+                self.pipe_to_hud.terminate()
+                log.debug(f"pipe_to_hud stdin: {self.pipe_to_hud.stdin}")
+            self.pipe_to_hud = None
+        self.intervalEntry.setEnabled(True)
+        self.startButton.setEnabled(True)
 
     def import_error(self, error_msg: str) -> None:
         """Called when auto import cycle fails in the background."""
@@ -718,20 +750,17 @@ class GuiAutoImport(QWidget):
             if self.importtimer:
                 self.importtimer.stop()
                 self.importtimer = None
-            self._stop_import_worker()
-            self.importer.autoSummaryGrab(True)
-            self.settings["global_lock"].release()
-            self.addText("\nStopping Auto Import. Global lock released.", "unlock")
-            self.progressBar.setVisible(False)
-            self.statusLabel.setText(_("Ready"))
-            if self.pipe_to_hud and self.pipe_to_hud.poll() is not None:
-                self.addText("\n * Stop Auto Import: HUD already terminated.", "hud")
-            else:
-                if self.pipe_to_hud:
-                    self.pipe_to_hud.terminate()
-                    log.debug(f"pipe_to_hud stdin: {self.pipe_to_hud.stdin}")
-                self.pipe_to_hud = None
-            self.intervalEntry.setEnabled(True)
+            if self._stop_cleanup_pending:
+                return
+            if not self._stop_import_worker():
+                # Do not touch the Importer, its connection, the HUD process or
+                # the global lock while runUpdated() can still be using them.
+                self._stop_cleanup_pending = True
+                self.startButton.setEnabled(False)
+                self.statusLabel.setText(_("Stopping Auto Import..."))
+                QTimer.singleShot(250, self._wait_for_import_worker_stop)
+                return
+            self._finalize_auto_import_stop()
 
     # end def GuiAutoImport.startClicked
 

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -60,14 +60,25 @@ if os.name == "nt":
         win32console = None
 
 
+# Import cycles overrunning their interval back to back. One or two is a large
+# batch; this many means the worker is wedged and the user deserves to be told.
+DEFERRED_CYCLES_BEFORE_WARNING = 6
+
+# How long "Stop Auto Import" waits for the worker before giving up on it. Long
+# enough for an ordinary cycle to land, short enough not to read as a freeze.
+STOP_WAIT_MS = 5000
+
+
 def to_raw(string) -> str:
     return rf"{string}"
 
 
 class AutoImportThread(QThread):
     """Worker thread to run auto-import cycle off the main GUI thread."""
+
     finished = Signal()
     error = Signal(str)
+    db_offline = Signal()
 
     def __init__(self, importer) -> None:
         super().__init__()
@@ -75,6 +86,12 @@ class AutoImportThread(QThread):
 
     def run(self) -> None:
         try:
+            # Checked here rather than left to fail mid-cycle so the GUI can say
+            # the database is away, instead of reporting a raw driver error once
+            # every interval for as long as the outage lasts.
+            if not self.importer.database.ensure_connection():
+                self.db_offline.emit()
+                return
             self.importer.autoSummaryGrab()
             self.importer.runUpdated()
             self.finished.emit()
@@ -91,6 +108,10 @@ class GuiAutoImport(QWidget):
             self.log_message.connect(self._addText_slot)
         self.importtimer: QTimer | None = None
         self.import_thread: AutoImportThread | None = None
+        # Outage bookkeeping, so the database going away is reported once rather
+        # than once per interval, and its return is reported too.
+        self._deferred_cycles = 0
+        self._db_offline = False
         self.settings = settings
         self.config = config
         self.sql = sql
@@ -330,15 +351,31 @@ class GuiAutoImport(QWidget):
         """Callback for timer to do an import iteration asynchronously."""
         if self.doAutoImportBool:
             if self.import_thread is not None and self.import_thread.isRunning():
-                log.debug("AutoImport: previous import thread is still running, deferring this iteration.")
+                # A cycle that overruns one interval is normal on a big batch;
+                # one that overruns many means the worker is wedged -- most
+                # often on a database that stopped answering. Say so once,
+                # because silence here is what made this look like the importer
+                # had simply decided to stop working.
+                self._deferred_cycles += 1
+                if self._deferred_cycles == DEFERRED_CYCLES_BEFORE_WARNING:
+                    log.warning(
+                        "AutoImport: no import cycle has completed in %d intervals; "
+                        "the worker is still busy (slow import, or an unresponsive database).",
+                        self._deferred_cycles,
+                    )
+                    self.statusLabel.setText(_("Import cycle is taking longer than usual..."))
+                else:
+                    log.debug("AutoImport: previous import thread is still running, deferring this iteration.")
                 return True
 
+            self._deferred_cycles = 0
             self.progressBar.setVisible(True)
             self.progressBar.setMaximum(0)  # Indeterminate progress
 
             self.import_thread = AutoImportThread(self.importer)
             self.import_thread.finished.connect(self.import_finished)
             self.import_thread.error.connect(self.import_error)
+            self.import_thread.db_offline.connect(self.import_db_offline)
             self.import_thread.start()
             return True
         return False
@@ -346,7 +383,43 @@ class GuiAutoImport(QWidget):
     def import_finished(self) -> None:
         """Called when auto import cycle finishes in the background."""
         self.progressBar.setVisible(False)
+        if self._db_offline:
+            self._db_offline = False
+            self.addText(_("\nDatabase is back. Auto Import resumed."), "info")
+        self.statusLabel.setText(_("Ready"))
         log.debug("AutoImport: background import cycle finished successfully")
+
+    def import_db_offline(self) -> None:
+        """Called when a cycle was skipped because the database is unreachable."""
+        self.progressBar.setVisible(False)
+        self.statusLabel.setText(_("Database unreachable - retrying"))
+        if not self._db_offline:
+            # Once per outage, not once per interval.
+            self._db_offline = True
+            log.warning("AutoImport: database unreachable, cycles are paused until it returns.")
+            self.addText(_("\nDatabase unreachable. Auto Import paused, retrying..."), "error")
+
+    def _stop_import_worker(self) -> bool:
+        """Wait, briefly, for the running import cycle to finish.
+
+        Returns:
+            True when there is no longer a cycle running.
+
+        The wait is bounded on purpose. It runs on the UI thread, so waiting
+        without a timeout on a worker stuck against an unresponsive database
+        froze the window and left force-quit as the only way out. An overrunning
+        worker is left to finish on its own instead.
+        """
+        if self.import_thread is None or not self.import_thread.isRunning():
+            return True
+        if self.import_thread.wait(STOP_WAIT_MS):
+            return True
+        log.warning("AutoImport: import worker did not stop in time; leaving it to finish.")
+        self.addText(
+            _("\nStop requested while an import was still running; it will finish in the background."),
+            "warning",
+        )
+        return False
 
     def import_error(self, error_msg: str) -> None:
         """Called when auto import cycle fails in the background."""
@@ -645,8 +718,7 @@ class GuiAutoImport(QWidget):
             if self.importtimer:
                 self.importtimer.stop()
                 self.importtimer = None
-            if self.import_thread is not None and self.import_thread.isRunning():
-                self.import_thread.wait()
+            self._stop_import_worker()
             self.importer.autoSummaryGrab(True)
             self.settings["global_lock"].release()
             self.addText("\nStopping Auto Import. Global lock released.", "unlock")

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1259,6 +1259,12 @@ class HudMain(QObject):
             except Exception as exc:
                 if self.note_db_error(exc):
                     return stats_by_hand
+                # PostgreSQL leaves the transaction aborted after a statement
+                # error. Clear it before the caller falls back to per-table
+                # queries, otherwise the first fallback necessarily fails with
+                # InFailedSqlTransaction and that table remains stale.
+                with contextlib.suppress(Exception):
+                    self.db_connection.connection.rollback()
                 log.exception("Batched statistics failed for %d table(s); each will ask for its own", len(hand_ids))
         return stats_by_hand
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -40,7 +40,7 @@ from PySide6.QtGui import QCloseEvent, QIcon
 from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 from qt_material import apply_stylesheet
 
-from fpdb_3_legacy import Aux_Base, Configuration, Database, Deck, Hud, Options
+from fpdb_3_legacy import Aux_Base, Configuration, Database, Deck, Hud, Options, db_profile
 from fpdb_3_legacy.db_reconnect import is_connection_lost
 from fpdb_3_legacy.HudStatsPersistence import get_hud_stats_persistence
 from fpdb_3_legacy.loggingFpdb import get_logger, hud_trace
@@ -415,6 +415,9 @@ class HudMain(QObject):
             # connection to DbRecoveryWorker until it reports the link is back.
             self._db_available = True
             self._db_recovery_worker: DbRecoveryWorker | None = None
+            # Statements counted at the end of the previous batch, so each batch
+            # can report its own cost rather than the running total.
+            self._last_batch_queries = 0
             self.hud_params = self.config.get_hud_ui_parameters()
             self.deck = Deck.Deck(
                 self.config,
@@ -640,6 +643,8 @@ class HudMain(QObject):
             with contextlib.suppress(RuntimeError):
                 zmq_receiver.close()
             self.zmq_receiver = None
+
+        db_profile.get_profile().log_report("HUD database round-trip profile:")
 
         log.info("Quitting normally")
         QCoreApplication.quit()
@@ -974,6 +979,7 @@ class HudMain(QObject):
 
         return hud_poker_game, None
 
+    @db_profile.scoped("update_hud")
     def _update_existing_hud(
         self,
         new_hand_id: str,
@@ -1051,27 +1057,56 @@ class HudMain(QObject):
             log.debug("Dropping %d pending hand(s): database unavailable", len(pending))
             return
 
-        latest, unresolved = self._latest_hand_per_table(pending)
-        log.debug("Draining %d hand(s) into %d table(s)", len(pending), len(latest))
+        with db_profile.scope("batch"):
+            latest, unresolved = self._latest_hand_per_table(pending)
+            log.debug("Draining %d hand(s) into %d table(s)", len(pending), len(latest))
 
-        refreshed: set[str] = set()
-        for hand_id in [*latest.values(), *unresolved]:
-            try:
-                served = self.read_stdin(hand_id)
-            except Exception as exc:
-                if self.note_db_error(exc):
-                    log.warning("Abandoning this batch: database went away while processing hand %s", hand_id)
-                    return
-                log.exception("Error processing hand %s", hand_id)
-                with contextlib.suppress(Exception):
-                    self.db_connection.connection.rollback()
-            else:
-                if served is not None:
-                    refreshed.add(served)
+            refreshed: set[str] = set()
+            for hand_id in [*latest.values(), *unresolved]:
+                try:
+                    with db_profile.scope("hand"):
+                        served = self.read_stdin(hand_id)
+                except Exception as exc:
+                    if self.note_db_error(exc):
+                        log.warning("Abandoning this batch: database went away while processing hand %s", hand_id)
+                        return
+                    log.exception("Error processing hand %s", hand_id)
+                    with contextlib.suppress(Exception):
+                        self.db_connection.connection.rollback()
+                else:
+                    if served is not None:
+                        refreshed.add(served)
 
-        # Only the tables actually brought up to date are left out of the
-        # statistics refresh; one that failed still needs it.
-        self._refresh_other_huds(refreshed)
+            # Only the tables actually brought up to date are left out of the
+            # statistics refresh; one that failed still needs it.
+            self._refresh_other_huds(refreshed)
+
+        self._report_batch_round_trips(len(pending), len(self.hud_dict))
+
+    def _report_batch_round_trips(self, hands: int, tables: int) -> None:
+        """Log what this batch cost in statements, when profiling is on.
+
+        Per batch rather than per process: what decides how the HUD feels is the
+        cost of one round of hands with the tables the player actually has open,
+        and that is the number a cumulative total hides.
+        """
+        if not db_profile.is_enabled():
+            return
+        profile = db_profile.get_profile()
+        batch = profile.by_scope.get("batch")
+        hand_scope = profile.by_scope.get("hand")
+        if batch is None:
+            return
+        log.info(
+            "Round trips: batch of %d hand(s) over %d table(s) -- %d statements in this run "
+            "(running average %.1f per batch, %.1f per hand)",
+            hands,
+            tables,
+            batch.queries - getattr(self, "_last_batch_queries", 0),
+            batch.queries_per_entry,
+            hand_scope.queries_per_entry if hand_scope else 0.0,
+        )
+        self._last_batch_queries = batch.queries
 
     def _seat_players(self, hand_id: str) -> dict:
         """Seat players for a hand, read from the database once."""
@@ -1091,6 +1126,7 @@ class HudMain(QObject):
             self._hand_players[key] = cached
         return cached
 
+    @db_profile.scoped("secondary_refresh")
     def _refresh_secondary_hud(
         self,
         hand_id: str,
@@ -1195,6 +1231,7 @@ class HudMain(QObject):
                 with contextlib.suppress(Exception):
                     self.db_connection.connection.rollback()
 
+    @db_profile.scoped("create_hud")
     def _create_new_hud(
         self,
         new_hand_id: str,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1134,8 +1134,14 @@ class HudMain(QObject):
         game_type: str,
         site_id: int,
         num_seats: int,
+        stat_dict: dict | None = None,
     ) -> None:
         """Update a HUD whose own table has not dealt a new hand.
+
+        ``stat_dict`` is the statistics this table's caller already fetched, in
+        one query covering every table being refreshed; passing None makes this
+        fetch its own, which is the fallback when the tables cannot share a
+        query (see _refresh_other_huds).
 
         Only the aggregated statistics can have moved: the seats, the cards and
         the table stats all describe this table's own last hand, which is the
@@ -1156,15 +1162,16 @@ class HudMain(QObject):
         one and asking them to redraw is the whole job.
         """
         hud = self.hud_dict[temp_key]
-        self.db_connection.init_hud_stat_vars(hud.hud_params["hud_days"], hud.hud_params["h_hud_days"])
-        stat_dict = self.db_connection.get_stats_from_hand(
-            hand_id,
-            game_type,
-            hud.hud_params,
-            self.hero_ids[site_id],
-            num_seats,
-            poker_game=hud.poker_game,
-        )
+        if stat_dict is None:
+            self.db_connection.init_hud_stat_vars(hud.hud_params["hud_days"], hud.hud_params["h_hud_days"])
+            stat_dict = self.db_connection.get_stats_from_hand(
+                hand_id,
+                game_type,
+                hud.hud_params,
+                self.hero_ids[site_id],
+                num_seats,
+                poker_game=hud.poker_game,
+            )
         self._merge_positions(stat_dict, hand_id)
         hud.stat_dict = stat_dict
         for aux in hud.aux_windows:
@@ -1174,22 +1181,10 @@ class HudMain(QObject):
                 log.exception("Error redrawing aux window of table %s", temp_key)
         log.debug("secondary hud redrawn for table %s using hand %s", temp_key, hand_id)
 
-    def _refresh_other_huds(self, updated_tables: set[str]) -> None:
-        """Refresh every active HUD except the tables this batch already updated.
-
-        HUD statistics are aggregated globally, but each HUD must keep using
-        its own latest hand for seats, cards, positions, and game context.
-        Reusing that table's last processed hand makes all open HUDs observe
-        the latest HudCache state without mixing table-local data.
-
-        A secondary HUD is best-effort: one stale or failing table must not
-        prevent the remaining tables from refreshing.
-        """
+    def _tables_to_refresh(self, updated_tables: set[str]) -> list[tuple]:
+        """The tables owed a statistics refresh, with what each one needs."""
+        pending = []
         for table_name in list(self.hud_dict):
-            if not self._db_available:
-                # Opened by an earlier table in this same loop.
-                log.debug("Stopping the HUD refresh round: database unavailable")
-                return
             if table_name in updated_tables:
                 continue
 
@@ -1207,9 +1202,87 @@ class HudMain(QObject):
                 )
                 continue
 
-            game_type = table_info[3]
-            site_id = table_info[5]
-            num_seats = table_info[7]
+            pending.append((table_name, last_hand_id, table_info[3], table_info[5], table_info[7]))
+        return pending
+
+    def _batch_secondary_stats(self, pending: list[tuple]) -> dict:
+        """Fetch every refreshing table's statistics in as few queries as possible.
+
+        Tables can share a query only when every parameter of that query
+        matches, so they are grouped by the whole set: the stat-window
+        configuration, the hero, the seat count and the game. Multi-tabling one
+        site at one stake -- which is what makes this path expensive in the
+        first place -- collapses to a single group, and so to a single round
+        trip in place of one per table.
+
+        Best-effort by design: a group that fails leaves its tables without a
+        precomputed answer, and each falls back to fetching its own.
+        """
+        # The hero is only known once a hand has been processed. Before that
+        # there is nothing to group by, and each table falls back to fetching
+        # its own -- which is what this path did before it batched at all.
+        hero_ids = getattr(self, "hero_ids", None)
+        if not hero_ids:
+            return {}
+
+        groups: dict[str, tuple] = {}
+        for table_name, last_hand_id, game_type, site_id, num_seats in pending:
+            hud = self.hud_dict.get(table_name)
+            if hud is None:
+                continue
+            hero_id = hero_ids.get(site_id)
+            if hero_id is None:
+                continue
+            # repr rather than a tuple of the items: hud_params comes from
+            # user-edited configuration, and one unhashable value in it would
+            # otherwise take down the refresh round rather than merely stop it
+            # batching.
+            key = repr((sorted(hud.hud_params.items(), key=str), hero_id, num_seats, hud.poker_game, game_type))
+            if key not in groups:
+                groups[key] = (hud.hud_params, hero_id, num_seats, hud.poker_game, game_type, [])
+            groups[key][5].append(last_hand_id)
+
+        stats_by_hand: dict = {}
+        for hud_params, hero_id, num_seats, poker_game, game_type, hand_ids in groups.values():
+            try:
+                self.db_connection.init_hud_stat_vars(hud_params["hud_days"], hud_params["h_hud_days"])
+                stats_by_hand.update(
+                    self.db_connection.get_stats_from_hands(
+                        hand_ids,
+                        game_type,
+                        hud_params,
+                        hero_id,
+                        num_seats,
+                        poker_game=poker_game,
+                    ),
+                )
+            except Exception as exc:
+                if self.note_db_error(exc):
+                    return stats_by_hand
+                log.exception("Batched statistics failed for %d table(s); each will ask for its own", len(hand_ids))
+        return stats_by_hand
+
+    def _refresh_other_huds(self, updated_tables: set[str]) -> None:
+        """Refresh every active HUD except the tables this batch already updated.
+
+        HUD statistics are aggregated globally, but each HUD must keep using
+        its own latest hand for seats, cards, positions, and game context.
+        Reusing that table's last processed hand makes all open HUDs observe
+        the latest HudCache state without mixing table-local data.
+
+        A secondary HUD is best-effort: one stale or failing table must not
+        prevent the remaining tables from refreshing.
+        """
+        pending = self._tables_to_refresh(updated_tables)
+        if not pending:
+            return
+        stats_by_hand = self._batch_secondary_stats(pending)
+
+        for table_name, last_hand_id, game_type, site_id, num_seats in pending:
+            if not self._db_available:
+                # Opened by an earlier table in this same loop.
+                log.debug("Stopping the HUD refresh round: database unavailable")
+                return
             try:
                 self._refresh_secondary_hud(
                     last_hand_id,
@@ -1217,6 +1290,7 @@ class HudMain(QObject):
                     game_type,
                     site_id,
                     num_seats,
+                    stat_dict=stats_by_hand.get(last_hand_id),
                 )
             except Exception as exc:
                 if self.note_db_error(exc):

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -21,6 +21,7 @@ if _repo_root not in sys.path:
 if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
     os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -40,6 +41,7 @@ from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 from qt_material import apply_stylesheet
 
 from fpdb_3_legacy import Aux_Base, Configuration, Database, Deck, Hud, Options
+from fpdb_3_legacy.db_reconnect import is_connection_lost
 from fpdb_3_legacy.HudStatsPersistence import get_hud_stats_persistence
 from fpdb_3_legacy.loggingFpdb import get_logger, hud_trace
 from fpdb_3_legacy.SmartHudManager import RestartReason, get_smart_hud_manager
@@ -53,6 +55,11 @@ log = get_logger("hud_main")
 # into one batch, so each HUD is refreshed once rather than once per hand. Long
 # enough to catch the burst, short enough to stay ahead of the player acting.
 HAND_BATCH_INTERVAL_MS = 200
+
+# How long the recovery worker waits between attempts to re-open a database
+# connection that has dropped. Database.recover_connection has its own cooldown;
+# this only decides how often we ask.
+DB_RECOVERY_INTERVAL_S = 5.0
 
 
 @dataclass
@@ -95,6 +102,48 @@ class ZMQWorker(QThread):
         """Stop the worker thread."""
         self.is_running = False
         self.wait()
+
+
+class DbRecoveryWorker(QThread):
+    """Re-opens a dropped database connection away from the UI thread.
+
+    Reconnecting costs a full connect timeout when the database is unreachable,
+    which is exactly the stall the HUD must not take on the thread that repaints
+    it. This thread owns the connection for the duration of the outage: it is
+    started only once HudMain has stopped querying (the breaker is open) and it
+    stops before HudMain resumes, so the connection still has a single user at
+    any moment despite being touched from two threads.
+    """
+
+    recovered = Signal()
+
+    def __init__(self, db_connection, parent: QObject | None = None) -> None:
+        """Initialize the recovery worker."""
+        super().__init__(parent)
+        self.db_connection = db_connection
+        # An Event rather than a sleep plus a flag, so closing the HUD during an
+        # outage does not wait out the retry interval before shutting down.
+        self._stopping = threading.Event()
+
+    def run(self) -> None:
+        """Retry the connection until it comes back or shutdown is requested."""
+        log.info("Database recovery worker started")
+        while not self._stopping.wait(DB_RECOVERY_INTERVAL_S):
+            try:
+                if self.db_connection.recover_connection():
+                    log.info("Database connection recovered; resuming HUD updates")
+                    self.recovered.emit()
+                    return
+            except Exception:
+                log.exception("Database recovery attempt failed unexpectedly")
+
+    def stop(self) -> None:
+        """Stop the worker thread."""
+        self._stopping.set()
+        # Bounded: an attempt already inside connect() has to run out its own
+        # connect timeout, but shutdown must not hang on it either.
+        if not self.wait(15000):
+            log.warning("Database recovery worker did not stop in time")
 
 
 class ZMQReceiver(QObject):
@@ -359,6 +408,13 @@ class HudMain(QObject):
             # HUD exactly once, without re-running create/update on a duplicate.
             self._last_processed_hands: dict[str, str] = {}
             self.blacklist: list[Any] = []
+            # Circuit breaker around the database. Every read below runs on the
+            # UI thread, so one unreachable database would otherwise freeze the
+            # HUD once per hand for as long as the outage lasts. Once a read
+            # fails on a lost connection we stop querying entirely and hand the
+            # connection to DbRecoveryWorker until it reports the link is back.
+            self._db_available = True
+            self._db_recovery_worker: DbRecoveryWorker | None = None
             self.hud_params = self.config.get_hud_ui_parameters()
             self.deck = Deck.Deck(
                 self.config,
@@ -448,6 +504,53 @@ class HudMain(QObject):
         """Handle errors from the ZMQ worker."""
         log.error("ZMQWorker encountered an error: %s", error_message)
 
+    def note_db_error(self, exc: BaseException) -> bool:
+        """Open the breaker if ``exc`` means the connection is gone.
+
+        Returns:
+            True when the database is now considered unavailable, so the caller
+            can stop working on a hand it has no way of finishing.
+
+        Database already reconnects and replays a query transparently; an error
+        still reaching here means that failed too, and the link is genuinely
+        down rather than merely interrupted.
+        """
+        if not is_connection_lost(self.db_connection.backend, exc):
+            return False
+        if self._db_available:
+            log.error("Database unreachable; HUD updates are paused until it returns (%s)", exc)
+            self._db_available = False
+            self._start_db_recovery()
+        return True
+
+    def _start_db_recovery(self) -> None:
+        """Hand the connection to the recovery thread for the outage."""
+        if self._db_recovery_worker is not None and self._db_recovery_worker.isRunning():
+            return
+        worker = DbRecoveryWorker(self.db_connection, parent=self)
+        worker.recovered.connect(self._on_db_recovered)
+        self._db_recovery_worker = worker
+        worker.start()
+
+    def _on_db_recovered(self) -> None:
+        """Resume querying once the recovery thread has restored the link."""
+        # Runs on the UI thread (queued signal), and the worker has already
+        # returned from run(), so the connection is unowned at this point.
+        self._db_available = True
+        # Table info cached against the old connection is still valid -- it
+        # describes hands, not the connection -- but hands that arrived during
+        # the outage are gone, and the HUDs are repainted from the next hand.
+        log.info("Database available again; HUD updates resumed")
+
+    def _stop_db_recovery(self) -> None:
+        """Stop the recovery thread, if one is running."""
+        worker = getattr(self, "_db_recovery_worker", None)
+        if worker is None:
+            return
+        self._db_recovery_worker = None
+        with contextlib.suppress(RuntimeError):
+            worker.stop()
+
     def init_main_window(self) -> None:
         """Initialize the main application window."""
         self.main_window = HudMainWindow(self.close_event_handler)
@@ -481,6 +584,12 @@ class HudMain(QObject):
         """Handle an incoming message from the ZMQ receiver."""
         # This method will be called in the main thread
         log.info("HUD RECEIVED MESSAGE - hand_id: %s", hand_id)
+
+        if not self._db_available:
+            # The recovery thread owns the connection while the breaker is open;
+            # touching it here would both race with it and block the UI thread.
+            log.debug("Dropping hand %s: database unavailable", hand_id)
+            return
 
         # Defensive rollback: ensure the PostgreSQL connection is not stuck in
         # an aborted transaction state from a previous error.  Under PostgreSQL,
@@ -517,6 +626,8 @@ class HudMain(QObject):
             with contextlib.suppress(RuntimeError):
                 batch_timer.stop()
         self._pending_hands = []
+
+        self._stop_db_recovery()
 
         zmq_worker = getattr(self, "zmq_worker", None)
         if zmq_worker is not None:
@@ -750,7 +861,12 @@ class HudMain(QObject):
         log.debug("Data not found in cache for hand_id: %s", hand_id)
         try:
             table_info = self.db_connection.get_table_info(hand_id)
-        except Exception:
+        except Exception as exc:
+            if self.note_db_error(exc):
+                # Swallowing this one would make every hand of the outage look
+                # like a hand that is merely not committed yet, which is how the
+                # HUD used to die silently and stay dead.
+                return None
             log.exception("Database error while processing hand %s", hand_id)
             try:
                 self.db_connection.connection.rollback()
@@ -931,6 +1047,9 @@ class HudMain(QObject):
         pending, self._pending_hands = self._pending_hands, []
         if not pending:
             return
+        if not self._db_available:
+            log.debug("Dropping %d pending hand(s): database unavailable", len(pending))
+            return
 
         latest, unresolved = self._latest_hand_per_table(pending)
         log.debug("Draining %d hand(s) into %d table(s)", len(pending), len(latest))
@@ -939,7 +1058,10 @@ class HudMain(QObject):
         for hand_id in [*latest.values(), *unresolved]:
             try:
                 served = self.read_stdin(hand_id)
-            except Exception:
+            except Exception as exc:
+                if self.note_db_error(exc):
+                    log.warning("Abandoning this batch: database went away while processing hand %s", hand_id)
+                    return
                 log.exception("Error processing hand %s", hand_id)
                 with contextlib.suppress(Exception):
                     self.db_connection.connection.rollback()
@@ -1028,6 +1150,10 @@ class HudMain(QObject):
         prevent the remaining tables from refreshing.
         """
         for table_name in list(self.hud_dict):
+            if not self._db_available:
+                # Opened by an earlier table in this same loop.
+                log.debug("Stopping the HUD refresh round: database unavailable")
+                return
             if table_name in updated_tables:
                 continue
 
@@ -1056,7 +1182,9 @@ class HudMain(QObject):
                     site_id,
                     num_seats,
                 )
-            except Exception:
+            except Exception as exc:
+                if self.note_db_error(exc):
+                    return
                 log.exception(
                     "Global HUD refresh failed for table %s using hand %s",
                     table_name,

--- a/fpdb_3_legacy/Hand.py
+++ b/fpdb_3_legacy/Hand.py
@@ -2224,7 +2224,6 @@ class HoldemOmahaHand(Hand):
         fh = self._output_stream(fh)
         super().writeHand(fh)
 
-        is_aof = self.gametype.get("category", "")
         hole_street = self.holeStreets[0] if self.holeStreets else "PREFLOP"
         # First non-blind street with actions (the decision street in AoF).
         initial_street = "FLOP"

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -962,6 +962,15 @@ class Importer:
 
         Scans the tracked directories and files, imports any files that have changed, updates their state, and performs post-import cleanup.
         """
+        # Importing a file is a multi-statement transaction, so there is no safe
+        # way to replay it after the connection dies half way through -- the
+        # connection is checked here instead, between cycles. Skipping the cycle
+        # (rather than raising) leaves the files untracked and un-timestamped,
+        # so they are picked up by the next cycle once the database is back.
+        if not self.database.ensure_connection():
+            log.warning("Auto-import cycle skipped: database unreachable.")
+            return
+
         for site, type in self.dirlist:
             self.addImportDirectory(
                 self.dirlist[(site, type)][0],

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -29,7 +29,7 @@ import zmq as _zmq
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QDialog, QLabel, QProgressBar, QVBoxLayout
 
-from fpdb_3_legacy import Configuration, Database, IdentifySite
+from fpdb_3_legacy import Configuration, Database, IdentifySite, db_profile
 from fpdb_3_legacy.Exceptions import (
     FpdbHandDuplicate,
     FpdbHandPartial,
@@ -70,6 +70,11 @@ log = get_logger("importer")
 
 IMPORTER_FILE_READ_ERRORS = (OSError, UnicodeDecodeError)
 ZMQ_CLOSE_ERRORS = (RuntimeError, zmq.ZMQError)
+
+# Round-trip profiling (off unless FPDB_DB_PROFILE=1). Module-level rather than
+# per-Importer: the profile it reports is process-wide anyway, and a profiling
+# hook must not be something the import path can trip over.
+_profile_reporter = db_profile.DeltaReporter("Auto-import round-trip profile:")
 
 
 class ZMQSender:
@@ -971,6 +976,12 @@ class Importer:
             log.warning("Auto-import cycle skipped: database unreachable.")
             return
 
+        with db_profile.scope("import_cycle"):
+            self._run_updated_cycle()
+        _profile_reporter.maybe_log()
+
+    def _run_updated_cycle(self) -> None:
+        """One pass over the tracked directories and files."""
         for site, type in self.dirlist:
             self.addImportDirectory(
                 self.dirlist[(site, type)][0],

--- a/fpdb_3_legacy/database_hud_stats.py
+++ b/fpdb_3_legacy/database_hud_stats.py
@@ -23,6 +23,12 @@ from fpdb_3_legacy.loggingFpdb import get_logger
 
 log = get_logger("db")
 
+# How long the 24-hour boundary hand id is reused before being re-read. It is a
+# sliding boundary, so any value here is a compromise; five minutes of drift on
+# a 24-hour window is invisible, and it turns one query per table per hand into
+# one query per five minutes.
+HAND_1DAY_AGO_TTL = 300.0
+
 
 class DatabaseHudStatsMixin:
     """Reads the aggregates the HUD displays.
@@ -47,6 +53,9 @@ class DatabaseHudStatsMixin:
 
     # Set by _inject_hud_chipev_columns, below.
     _hud_chipev_clause: str
+
+    # Provided by Database; reset by its resetCache.
+    _hand_1day_ago_read_at: float
 
     if TYPE_CHECKING:
 
@@ -157,18 +166,35 @@ class DatabaseHudStatsMixin:
                 self._hud_chipev_clause = ""
         return sql_text.replace("<chipev_columns>", self._hud_chipev_clause)
 
-    def init_hud_stat_vars(self, hud_days, h_hud_days) -> None:
-        """Initialise variables used by Hud to fetch stats:
-        self.hand_1day_ago     handId of latest hand played more than a day ago
-        self.date_ndays_ago    date n days ago
-        self.h_date_ndays_ago  date n days ago for hero (different n).
+    def _refresh_hand_1day_ago(self) -> None:
+        """Re-read the 24-hour boundary hand id, at most once per TTL.
+
+        It is a sliding boundary on a 24-hour window, so it is always a little
+        stale by construction and a few minutes more changes nothing about
+        which hands count as "this session". The HUD asks for it once per open
+        table per hand dealt, which measurably made it one of the three largest
+        sources of round trips (tools/measure_hud_round_trips.py) -- for a
+        value that moves once a day.
         """
+        now = time()
+        if self._hand_1day_ago_read_at and now - self._hand_1day_ago_read_at < HAND_1DAY_AGO_TTL:
+            return
+
         self.hand_1day_ago = 1
         c = self.get_cursor()
         c.execute(self.sql.query["get_hand_1day_ago"])
         row = c.fetchone()
         if row and row[0]:
             self.hand_1day_ago = int(row[0])
+        self._hand_1day_ago_read_at = now
+
+    def init_hud_stat_vars(self, hud_days, h_hud_days) -> None:
+        """Initialise variables used by Hud to fetch stats:
+        self.hand_1day_ago     handId of latest hand played more than a day ago
+        self.date_ndays_ago    date n days ago
+        self.h_date_ndays_ago  date n days ago for hero (different n).
+        """
+        self._refresh_hand_1day_ago()
 
         tz = datetime.utcnow() - datetime.today()
         tz_offset = (tz.seconds) // (3600)

--- a/fpdb_3_legacy/database_hud_stats.py
+++ b/fpdb_3_legacy/database_hud_stats.py
@@ -18,6 +18,7 @@ from time import time
 from typing import TYPE_CHECKING, Any
 
 from fpdb_3_legacy.autonotes_aof import AOF_CATEGORIES
+from fpdb_3_legacy.db_reconnect import reconnect_on_connection_loss
 from fpdb_3_legacy.loggingFpdb import get_logger
 
 log = get_logger("db")
@@ -34,6 +35,7 @@ class DatabaseHudStatsMixin:
     sql: Any
     config: Any
     connection: Any
+    backend: int
     db_server: str
     day_start: float
     hero: dict[Any, Any]
@@ -59,6 +61,8 @@ class DatabaseHudStatsMixin:
         def getAofProfileStats(self, player_ids: Any, category: str) -> Any: ...
 
         def _rollback_after_failed_read(self) -> None: ...
+
+        def recover_connection(self) -> bool: ...
 
     def get_seat_players(self, hand_id: str) -> dict[int, dict[str, object]]:
         """Return seatNo -> {player_id, screen_name} dict for a hand.
@@ -178,6 +182,7 @@ class DatabaseHudStatsMixin:
         now = datetime.utcnow() - d
         self.h_date_ndays_ago = "d%02d%02d%02d" % (now.year - 2000, now.month, now.day)
 
+    @reconnect_on_connection_loss
     def get_stats_from_hand(
         self,
         hand,

--- a/fpdb_3_legacy/database_hud_stats.py
+++ b/fpdb_3_legacy/database_hud_stats.py
@@ -29,6 +29,21 @@ log = get_logger("db")
 # one query per five minutes.
 HAND_1DAY_AGO_TTL = 300.0
 
+# What a caller gets when it asks for statistics without saying how. Kept here
+# so the per-hand and batched paths cannot disagree about it.
+_DEFAULT_HUD_PARAMS = {
+    "stat_range": "A",
+    "agg_bb_mult": 1000,
+    "seats_style": "A",
+    "seats_cust_nums_low": 1,
+    "seats_cust_nums_high": 10,
+    "h_stat_range": "A",
+    "h_agg_bb_mult": 1000,
+    "h_seats_style": "A",
+    "h_seats_cust_nums_low": 1,
+    "h_seats_cust_nums_high": 10,
+}
+
 
 class DatabaseHudStatsMixin:
     """Reads the aggregates the HUD displays.
@@ -208,6 +223,41 @@ class DatabaseHudStatsMixin:
         now = datetime.utcnow() - d
         self.h_date_ndays_ago = "d%02d%02d%02d" % (now.year - 2000, now.month, now.day)
 
+    @staticmethod
+    def _seat_bounds(style, cust_low, cust_high, num_seats) -> tuple[int, int]:
+        """The seat range a stat window covers, from its configured style.
+
+        'A' means every seat count, 'C' a configured range, 'E' exactly this
+        table's. Anything else is a configuration error and is treated as 'A',
+        because showing stats over all seat counts is a great deal less wrong
+        than showing none.
+        """
+        if style == "A":
+            return 0, 10
+        if style == "C":
+            return cust_low, cust_high
+        if style == "E":
+            return num_seats, num_seats
+        log.warning("bad seats_style value: %s", style)
+        return 0, 10
+
+    def _style_key(self, stat_range, *, hero: bool) -> str:
+        """The styleKey floor for a stat range.
+
+        styleKey is 'd' followed by yyyymmdd, so a floor below every real key
+        ('0000000') means all of history and one above every real key
+        ('zzzzzzz') means none of it -- the session range reads its numbers
+        from a different query entirely.
+        """
+        if stat_range == "T":
+            return self.h_date_ndays_ago if hero else self.date_ndays_ago
+        if stat_range == "A":
+            return "0000000"
+        if stat_range == "S":
+            return "zzzzzzz"
+        log.info("unknown stat_range %r, reading all of history", stat_range)
+        return "0000000"
+
     @reconnect_on_connection_loss
     def get_stats_from_hand(
         self,
@@ -225,50 +275,28 @@ class DatabaseHudStatsMixin:
             log.warning("Ignoring unknown get_stats_from_hand arguments: %s", ", ".join(sorted(kwargs)))
 
         if hud_params is None:
-            hud_params = {
-                "stat_range": "A",
-                "agg_bb_mult": 1000,
-                "seats_style": "A",
-                "seats_cust_nums_low": 1,
-                "seats_cust_nums_high": 10,
-                "h_stat_range": "S",
-                "h_agg_bb_mult": 1000,
-                "h_seats_style": "A",
-                "h_seats_cust_nums_low": 1,
-                "h_seats_cust_nums_high": 10,
-            }
+            hud_params = dict(_DEFAULT_HUD_PARAMS, h_stat_range="S")
         stat_range = hud_params["stat_range"]
         agg_bb_mult = hud_params["agg_bb_mult"]
-        seats_style = hud_params["seats_style"]
-        seats_cust_nums_low = hud_params["seats_cust_nums_low"]
-        seats_cust_nums_high = hud_params["seats_cust_nums_high"]
         h_stat_range = hud_params["h_stat_range"]
         h_agg_bb_mult = hud_params["h_agg_bb_mult"]
-        h_seats_style = hud_params["h_seats_style"]
-        h_seats_cust_nums_low = hud_params["h_seats_cust_nums_low"]
-        h_seats_cust_nums_high = hud_params["h_seats_cust_nums_high"]
 
         stat_dict: dict[Any, Any] = {}
 
-        if seats_style == "A":
-            seats_min, seats_max = 0, 10
-        elif seats_style == "C":
-            seats_min, seats_max = seats_cust_nums_low, seats_cust_nums_high
-        elif seats_style == "E":
-            seats_min, seats_max = num_seats, num_seats
-        else:
-            seats_min, seats_max = 0, 10
-            log.warning(f"bad seats_style value: {seats_style}")
-
-        if h_seats_style == "A":
-            h_seats_min, h_seats_max = 0, 10
-        elif h_seats_style == "C":
-            h_seats_min, h_seats_max = h_seats_cust_nums_low, h_seats_cust_nums_high
-        elif h_seats_style == "E":
-            h_seats_min, h_seats_max = num_seats, num_seats
-        else:
-            h_seats_min, h_seats_max = 0, 10
-            log.warning(f"bad h_seats_style value: {h_seats_style}")
+        # Shared with the batched path (get_stats_from_hands): two ways of
+        # deriving these would mean two answers for the same table.
+        seats_min, seats_max = self._seat_bounds(
+            hud_params["seats_style"],
+            hud_params["seats_cust_nums_low"],
+            hud_params["seats_cust_nums_high"],
+            num_seats,
+        )
+        h_seats_min, h_seats_max = self._seat_bounds(
+            hud_params["h_seats_style"],
+            hud_params["h_seats_cust_nums_low"],
+            hud_params["h_seats_cust_nums_high"],
+            num_seats,
+        )
 
         if stat_range == "S" or h_stat_range == "S":
             self.get_stats_from_hand_session(
@@ -287,25 +315,8 @@ class DatabaseHudStatsMixin:
                 self._merge_aof_profile_stats(stat_dict, poker_game)
                 return stat_dict
 
-        if stat_range == "T":
-            stylekey = self.date_ndays_ago
-        elif stat_range == "A":
-            stylekey = "0000000"  # all stylekey values should be higher than this
-        elif stat_range == "S":
-            stylekey = "zzzzzzz"  # all stylekey values should be lower than this
-        else:
-            stylekey = "0000000"
-            log.info(f"stat_range: {stat_range}")
-
-        if h_stat_range == "T":
-            h_stylekey = self.h_date_ndays_ago
-        elif h_stat_range == "A":
-            h_stylekey = "0000000"  # all stylekey values should be higher than this
-        elif h_stat_range == "S":
-            h_stylekey = "zzzzzzz"  # all stylekey values should be lower than this
-        else:
-            h_stylekey = "00000000"
-            log.info(f"h_stat_range: {h_stat_range}")
+        stylekey = self._style_key(stat_range, hero=False)
+        h_stylekey = self._style_key(h_stat_range, hero=True)
 
         # lookup gametypeId from hand
         handinfo = self.get_gameinfo_from_hid(hand)
@@ -369,6 +380,186 @@ class DatabaseHudStatsMixin:
 
         self._merge_aof_profile_stats(stat_dict, poker_game or handinfo["category"])
         return stat_dict
+
+    def _batch_rewrites(self, placeholder: str):
+        """The edits that turn the per-hand aggregate into a per-batch one.
+
+        Expressed as substitutions on the single source query rather than as a
+        second copy of it: the aggregate is 300 lines of stat columns, and two
+        copies would drift, which would show up as the HUD reporting different
+        numbers depending on which path happened to serve a table.
+
+        The bind placeholder has to be passed in: the catalogue is rewritten
+        per backend on load (``finalize_query_placeholders``), so the query
+        says ``= ?`` under SQLite and ``= %s`` under PostgreSQL.
+        """
+        return (
+            # Appended at the end of the select list rather than the start, so
+            # the query still opens with the text the round-trip profiler
+            # matches it against and its report can still name it.
+            ("FROM Hands h", ", h.id AS batch_hand_id FROM Hands h"),
+            (f"WHERE h.id = {placeholder}", "WHERE h.id IN (<hand_ids>)"),
+            ("GROUP BY hc.PlayerId, p.name", "GROUP BY h.id, hc.PlayerId, p.name"),
+            ("ORDER BY hc.PlayerId, p.name", "ORDER BY h.id, hc.PlayerId, p.name"),
+        )
+
+    def _batched_aggregated_sql(self, sql_text: str, hand_count: int) -> str | None:
+        """Rewrite the aggregate to answer for several hands in one round trip.
+
+        Returns None if the query has changed shape such that any of the
+        rewrites no longer applies -- the caller then falls back to asking per
+        hand, which is slower but cannot be subtly wrong.
+        """
+        placeholder = self.sql.query.get("placeholder", "%s")
+        for original, replacement in self._batch_rewrites(placeholder):
+            if original not in sql_text:
+                log.warning(
+                    "Cannot batch the HUD aggregate: %r is no longer in the query; asking per hand instead.",
+                    original,
+                )
+                return None
+            sql_text = sql_text.replace(original, replacement, 1)
+
+        return sql_text.replace("<hand_ids>", ", ".join([placeholder] * hand_count))
+
+    @reconnect_on_connection_loss
+    def get_stats_from_hands(
+        self,
+        hands,
+        game_type=None,
+        hud_params=None,
+        hero_id=-1,
+        num_seats=6,
+        poker_game: str | None = None,
+    ) -> dict[Any, dict[Any, Any]]:
+        """Return ``{hand_id: stat_dict}`` for several hands at once.
+
+        Every open table refreshes its statistics on every hand dealt at any
+        table, so this path runs once per table per hand -- one round trip each,
+        which over a VPN is the single largest cost the HUD imposes. The hands
+        given must share their HUD parameters; they are split internally by
+        gametype, which is the one parameter that varies per hand rather than
+        per table.
+
+        Falls back to asking per hand for the session stat range, which reads a
+        different query per hand and has nothing to batch.
+        """
+        hands = list(dict.fromkeys(hands))
+        if not hands:
+            return {}
+
+        params = hud_params if hud_params is not None else _DEFAULT_HUD_PARAMS
+        if params["stat_range"] == "S" or params["h_stat_range"] == "S":
+            return self._stats_per_hand(hands, game_type, params, hero_id, num_seats, poker_game)
+
+        by_gametype: dict[Any, list[Any]] = {}
+        categories: dict[Any, Any] = {}
+        for hand in hands:
+            handinfo = self.get_gameinfo_from_hid(hand)
+            if handinfo is None:
+                log.warning("No game info found for hand ID %s", hand)
+                continue
+            by_gametype.setdefault(handinfo["gametypeId"], []).append(hand)
+            categories[hand] = handinfo["category"]
+
+        results: dict[Any, dict[Any, Any]] = {}
+        for gametype_id, group in by_gametype.items():
+            batched = self._run_batched_aggregate(group, gametype_id, params, hero_id, num_seats)
+            if batched is None:
+                results.update(self._stats_per_hand(group, game_type, params, hero_id, num_seats, poker_game))
+                continue
+            for hand in group:
+                stat_dict = batched.get(hand, {})
+                self._merge_aof_profile_stats(stat_dict, poker_game or categories.get(hand))
+                results[hand] = stat_dict
+        return results
+
+    def _stats_per_hand(self, hands, game_type, hud_params, hero_id, num_seats, poker_game):
+        """The unbatched path, kept as the answer of record."""
+        return {
+            hand: self.get_stats_from_hand(
+                hand,
+                game_type,
+                hud_params,
+                hero_id,
+                num_seats,
+                poker_game=poker_game,
+            )
+            for hand in hands
+        }
+
+    def _run_batched_aggregate(self, hands, gametype_id, hud_params, hero_id, num_seats):
+        """One aggregate covering ``hands``, or None if it could not be built."""
+        seats_min, seats_max = self._seat_bounds(
+            hud_params["seats_style"],
+            hud_params["seats_cust_nums_low"],
+            hud_params["seats_cust_nums_high"],
+            num_seats,
+        )
+        h_seats_min, h_seats_max = self._seat_bounds(
+            hud_params["h_seats_style"],
+            hud_params["h_seats_cust_nums_low"],
+            hud_params["h_seats_cust_nums_high"],
+            num_seats,
+        )
+        stylekey = self._style_key(hud_params["stat_range"], hero=False)
+        h_stylekey = self._style_key(hud_params["h_stat_range"], hero=True)
+
+        sql_text = self._inject_hud_chipev_columns(self.sql.query["get_stats_from_hand_aggregated"])
+        batched = self._batched_aggregated_sql(sql_text, len(hands))
+        if batched is None:
+            return None
+
+        subs = (
+            *hands,
+            hero_id,
+            stylekey,
+            hud_params["agg_bb_mult"],
+            hud_params["agg_bb_mult"],
+            gametype_id,
+            seats_min,
+            seats_max,  # villain params
+            hero_id,
+            h_stylekey,
+            hud_params["h_agg_bb_mult"],
+            hud_params["h_agg_bb_mult"],
+            gametype_id,
+            h_seats_min,
+            h_seats_max,  # hero params
+        )
+
+        stime = time()
+        c = self.connection.cursor()
+        c.execute(batched, subs)
+        log.info(
+            "HudCache batched aggregate covered %d hand(s) in %.3f seconds",
+            len(hands),
+            time() - stime,
+        )
+        colnames = [desc[0].lower() for desc in c.description]
+        results: dict[Any, dict[Any, Any]] = {hand: {} for hand in hands}
+        for row in c.fetchall():
+            t_dict = dict(zip(colnames, row, strict=False))
+            # Not a statistic: it only says which table's row this is, and
+            # leaving it in stat_dict would offer it to the stat renderer.
+            hand = t_dict.pop("batch_hand_id")
+            if not self._row_is_wanted(t_dict["player_id"], hero_id, hud_params):
+                continue
+            results.setdefault(hand, {})[t_dict["player_id"]] = t_dict
+        return results
+
+    @staticmethod
+    def _row_is_wanted(playerid, hero_id, hud_params) -> bool:
+        """Apply the same hero/villain stat-range filter the per-hand path does."""
+        is_hero = False
+        if hero_id is not None:
+            try:
+                is_hero = int(playerid) == int(hero_id)
+            except (ValueError, TypeError):
+                is_hero = str(playerid) == str(hero_id)
+        if is_hero:
+            return hud_params["h_stat_range"] != "S"
+        return hud_params["stat_range"] != "S"
 
     def _merge_aof_profile_stats(
         self,

--- a/fpdb_3_legacy/database_hud_stats.py
+++ b/fpdb_3_legacy/database_hud_stats.py
@@ -537,12 +537,17 @@ class DatabaseHudStatsMixin:
             time() - stime,
         )
         colnames = [desc[0].lower() for desc in c.description]
+        # ZMQ supplies hand ids as strings while every SQL backend returns the
+        # selected Hands.id as an integer. Preserve the caller's key type in the
+        # public result while using a canonical representation to match rows.
+        hand_key_by_id = {str(hand): hand for hand in hands}
         results: dict[Any, dict[Any, Any]] = {hand: {} for hand in hands}
         for row in c.fetchall():
             t_dict = dict(zip(colnames, row, strict=False))
             # Not a statistic: it only says which table's row this is, and
             # leaving it in stat_dict would offer it to the stat renderer.
-            hand = t_dict.pop("batch_hand_id")
+            returned_hand = t_dict.pop("batch_hand_id")
+            hand = hand_key_by_id.get(str(returned_hand), returned_hand)
             if not self._row_is_wanted(t_dict["player_id"], hero_id, hud_params):
                 continue
             results.setdefault(hand, {})[t_dict["player_id"]] = t_dict

--- a/fpdb_3_legacy/db_profile.py
+++ b/fpdb_3_legacy/db_profile.py
@@ -1,0 +1,363 @@
+"""Count database round trips, and attribute them to what asked for them.
+
+Why round trips rather than query time: with the database on the other side of a
+VPN, a statement costs one network latency whatever the server does with it. A
+query that runs in 200us locally still costs 40ms from a hotel, so the thing that
+decides how the HUD feels is *how many* statements it issues per hand and per
+table -- a number no CPU-time benchmark reports.
+
+Off unless ``FPDB_DB_PROFILE=1`` is set in the environment. When on, ``Database``
+wraps its driver connection in :class:`CountingConnection`, and callers mark the
+work they are doing with :meth:`QueryProfile.scope` so the report can say "12
+tables, 41 statements" rather than just "41 statements".
+
+    FPDB_DB_PROFILE=1 fpdb
+
+Statements are named after the entry in the SQL catalogue they came from where
+one matches, so a report names ``get_hand_1day_ago`` rather than showing 60
+characters of SELECT.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import re
+import threading
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("db_profile")
+
+ENV_FLAG = "FPDB_DB_PROFILE"
+
+# How much of an unrecognised statement identifies it in the report.
+_LABEL_CHARS = 70
+
+# How much of a statement's opening is taken as identifying, for recognising a
+# catalogue query that had columns injected into it before being run.
+_PREFIX_CHARS = 60
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def is_enabled() -> bool:
+    """Report whether round-trip profiling was switched on for this process."""
+    return os.getenv(ENV_FLAG, "") == "1"
+
+
+def _normalise(sql: str) -> str:
+    """Collapse a statement to a form that survives formatting differences."""
+    return _WHITESPACE.sub(" ", sql).strip().lower()
+
+
+@dataclass
+class StatementStats:
+    """What one distinct statement cost over the profiled run."""
+
+    calls: int = 0
+    seconds: float = 0.0
+
+
+@dataclass
+class ScopeStats:
+    """What one kind of work cost, summed over every time it ran."""
+
+    entries: int = 0
+    queries: int = 0
+    seconds: float = 0.0
+
+    @property
+    def queries_per_entry(self) -> float:
+        return self.queries / self.entries if self.entries else 0.0
+
+
+@dataclass
+class QueryProfile:
+    """Round-trip counters for one process.
+
+    Scopes nest, and a statement is counted against every scope it runs inside,
+    so a hand scope inside a batch scope reports the hand's own statements and
+    the batch reports the sum -- which is what makes "per hand" and "per batch"
+    separately answerable.
+    """
+
+    total: StatementStats = field(default_factory=StatementStats)
+    by_statement: dict[str, StatementStats] = field(default_factory=lambda: defaultdict(StatementStats))
+    by_scope: dict[str, ScopeStats] = field(default_factory=lambda: defaultdict(ScopeStats))
+    _names: dict[str, str] = field(default_factory=dict)
+    _prefixes: dict[str, str] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _local: threading.local = field(default_factory=threading.local)
+
+    # -- setup ------------------------------------------------------------
+
+    def learn_query_names(self, catalogue: dict[str, Any]) -> None:
+        """Teach the profile the SQL catalogue, so reports use its names."""
+        collisions = set()
+        for name, sql in catalogue.items():
+            if not isinstance(sql, str) or not sql.strip():
+                continue
+            normalised = _normalise(sql)
+            self._names.setdefault(normalised, name)
+            # Some statements are assembled at run time -- the HUD aggregate has
+            # extra columns injected into its SELECT list -- so an exact match
+            # would lose the name of the one query it matters most to see. The
+            # opening of a statement is enough to recognise it, as long as no
+            # two catalogue entries share it.
+            prefix = normalised[:_PREFIX_CHARS]
+            if prefix in self._prefixes and self._prefixes[prefix] != name:
+                collisions.add(prefix)
+            else:
+                self._prefixes[prefix] = name
+        for prefix in collisions:
+            self._prefixes.pop(prefix, None)
+
+    def label_for(self, sql: str) -> str:
+        """Name a statement: its catalogue name, or a readable prefix."""
+        normalised = _normalise(sql)
+        known = self._names.get(normalised)
+        if known is not None:
+            return known
+        assembled = self._prefixes.get(normalised[:_PREFIX_CHARS])
+        if assembled is not None:
+            return assembled + " (assembled)"
+        if len(normalised) <= _LABEL_CHARS:
+            return normalised
+        return normalised[:_LABEL_CHARS] + "..."
+
+    # -- recording --------------------------------------------------------
+
+    @property
+    def _stack(self) -> list[str]:
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        return stack
+
+    def record(self, sql: str, seconds: float) -> None:
+        """Count one executed statement against the total and open scopes."""
+        label = self.label_for(sql)
+        with self._lock:
+            self.total.calls += 1
+            self.total.seconds += seconds
+            statement = self.by_statement[label]
+            statement.calls += 1
+            statement.seconds += seconds
+            # A statement belongs to every scope it ran inside, counted once
+            # per distinct scope name so a recursive scope cannot inflate it.
+            for name in dict.fromkeys(self._stack):
+                self.by_scope[name].queries += 1
+
+    @contextmanager
+    def scope(self, name: str):
+        """Attribute the statements run inside the block to ``name``."""
+        stack = self._stack
+        stack.append(name)
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            stack.pop()
+            elapsed = time.perf_counter() - started
+            with self._lock:
+                entry = self.by_scope[name]
+                entry.entries += 1
+                entry.seconds += elapsed
+
+    def reset(self) -> None:
+        """Forget everything recorded so far."""
+        with self._lock:
+            self.total = StatementStats()
+            self.by_statement.clear()
+            self.by_scope.clear()
+
+    # -- reporting --------------------------------------------------------
+
+    def report(self, top: int = 15) -> str:
+        """Render the counters as a block of text for the log."""
+        with self._lock:
+            total = StatementStats(self.total.calls, self.total.seconds)
+            scopes = sorted(self.by_scope.items(), key=lambda kv: -kv[1].queries)
+            statements = sorted(self.by_statement.items(), key=lambda kv: -kv[1].calls)[:top]
+
+        if not total.calls:
+            return "Database round trips: none recorded."
+
+        lines = [
+            f"Database round trips: {total.calls} statements, {total.seconds * 1000:.0f}ms in the driver.",
+        ]
+        if scopes:
+            lines.append(f"  {'scope':<28}{'runs':>7}{'queries':>9}{'per run':>10}{'wall ms':>10}")
+            for name, stats in scopes:
+                lines.append(
+                    f"  {name:<28}{stats.entries:>7}{stats.queries:>9}"
+                    f"{stats.queries_per_entry:>10.1f}{stats.seconds * 1000:>10.0f}",
+                )
+        lines.append(f"  {'statement':<28}{'calls':>7}{'':>9}{'':>10}{'db ms':>10}")
+        for label, stats in statements:
+            shown = label if len(label) <= 28 else label[:25] + "..."
+            lines.append(f"  {shown:<28}{stats.calls:>7}{'':>9}{'':>10}{stats.seconds * 1000:>10.0f}")
+        return "\n".join(lines)
+
+    def log_report(self, header: str = "") -> None:
+        """Write the report to the log, if anything was recorded."""
+        if not self.total.calls:
+            return
+        log.info("%s%s%s", header, "\n" if header else "", self.report())
+
+
+class DeltaReporter:
+    """Logs the profile only when statements have been recorded since last time.
+
+    A loop that runs every few seconds would otherwise repeat an unchanged
+    report until the log is useless.
+    """
+
+    def __init__(self, header: str, profile: QueryProfile | None = None) -> None:
+        self.header = header
+        self.profile = profile if profile is not None else get_profile()
+        self._seen = 0
+
+    def maybe_log(self) -> bool:
+        """Log the report if it has moved. Returns whether it did."""
+        if not is_enabled():
+            return False
+        calls = self.profile.total.calls
+        if calls == self._seen:
+            return False
+        self._seen = calls
+        self.profile.log_report(self.header)
+        return True
+
+
+# One profile per process; the HUD and the importer are separate processes and
+# each answers a different question, so there is nothing to merge.
+_PROFILE = QueryProfile()
+
+
+def get_profile() -> QueryProfile:
+    """Return this process's profile."""
+    return _PROFILE
+
+
+@contextmanager
+def scope(name: str):
+    """Attribute statements to ``name``, cheaply when profiling is off."""
+    if not is_enabled():
+        yield
+        return
+    with _PROFILE.scope(name):
+        yield
+
+
+def scoped(name: str):
+    """Method decorator form of :func:`scope`.
+
+    Preferred over wrapping a method body in a ``with`` block: it leaves the
+    body untouched, so the profiling does not show up as a re-indentation of
+    code that has nothing to do with it.
+    """
+
+    def decorate(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not is_enabled():
+                return func(*args, **kwargs)
+            with _PROFILE.scope(name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorate
+
+
+class CountingCursor:
+    """Delegates to a driver cursor, timing and counting what it executes."""
+
+    __slots__ = ("_cursor", "_profile")
+
+    def __init__(self, cursor: Any, profile: QueryProfile) -> None:
+        object.__setattr__(self, "_cursor", cursor)
+        object.__setattr__(self, "_profile", profile)
+
+    def execute(self, sql, *args, **kwargs):
+        started = time.perf_counter()
+        try:
+            return self._cursor.execute(sql, *args, **kwargs)
+        finally:
+            # Recorded even when the statement raises: a failed round trip
+            # still cost a round trip, and hiding it would flatter the report.
+            self._profile.record(str(sql), time.perf_counter() - started)
+
+    def executemany(self, sql, *args, **kwargs):
+        started = time.perf_counter()
+        try:
+            return self._cursor.executemany(sql, *args, **kwargs)
+        finally:
+            self._profile.record(str(sql), time.perf_counter() - started)
+
+    def __iter__(self):
+        return iter(self._cursor)
+
+    def __enter__(self):
+        self._cursor.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._cursor.__exit__(*exc_info)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._cursor, name, value)
+
+
+class CountingConnection:
+    """Delegates to a driver connection, handing out counting cursors.
+
+    Everything except ``cursor()`` passes straight through, including attribute
+    writes -- the dialects toggle ``autocommit`` on the connection, and that has
+    to reach the real one.
+    """
+
+    __slots__ = ("_connection", "_profile")
+
+    def __init__(self, connection: Any, profile: QueryProfile) -> None:
+        object.__setattr__(self, "_connection", connection)
+        object.__setattr__(self, "_profile", profile)
+
+    def cursor(self, *args, **kwargs):
+        return CountingCursor(self._connection.cursor(*args, **kwargs), self._profile)
+
+    def __enter__(self):
+        self._connection.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._connection.__exit__(*exc_info)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._connection, name, value)
+
+
+def wrap_connection(connection: Any, catalogue: dict[str, Any] | None = None) -> Any:
+    """Return ``connection`` counted, or unchanged when profiling is off."""
+    if not is_enabled() or connection is None:
+        return connection
+    if catalogue:
+        _PROFILE.learn_query_names(catalogue)
+    if isinstance(connection, CountingConnection):
+        return connection
+    log.info("Database round-trip profiling is on (%s=1)", ENV_FLAG)
+    return CountingConnection(connection, _PROFILE)

--- a/fpdb_3_legacy/db_reconnect.py
+++ b/fpdb_3_legacy/db_reconnect.py
@@ -1,0 +1,168 @@
+"""Recovery from a lost database connection.
+
+Why this exists
+---------------
+fpdb keeps one long-lived connection per process (HUD, importer, GUI). When the
+database lives at the other end of a VPN or a flaky Wi-Fi link, that connection
+does not fail cleanly: the tunnel drops, the TCP socket is left in a black hole,
+and the next ``execute()`` blocks inside the kernel's retransmit loop. No
+exception is ever raised, so no ``try/except`` can react -- the HUD's Qt event
+loop and the auto-import worker simply stop, for good.
+
+Two pieces are needed to fix that, and both live here:
+
+1. ``PG_NETWORK_KWARGS`` / ``MYSQL_NETWORK_KWARGS`` (applied by ``Database``)
+   arm TCP keepalives so a dead peer surfaces as a real error within about a
+   minute instead of never.
+2. ``is_connection_lost`` plus the ``reconnect_on_connection_loss`` decorator
+   turn that error into a transparent reconnect-and-retry.
+
+Ordering matters: without (1) the errors in (2) never happen.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("database")
+
+
+# libpq connection parameters. ``keepalives_idle``/``interval``/``count`` mean a
+# silently dead peer is detected after roughly 30 + 3*10 = 60 seconds, even in
+# the middle of a query that is waiting for a result. ``connect_timeout`` bounds
+# the reconnect attempts themselves, which is what keeps the recovery path from
+# becoming the new place where everything hangs.
+PG_NETWORK_KWARGS: dict[str, Any] = {
+    "connect_timeout": 10,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
+# MySQL over the same VPN has the same failure mode; MySQLdb/pymysql expose the
+# connect timeout but leave keepalives to the OS defaults.
+MYSQL_NETWORK_KWARGS: dict[str, Any] = {
+    "connect_timeout": 10,
+}
+
+# Seconds to wait before attempting another reconnect after one has failed.
+# Without this, every hand the HUD receives while the VPN is down would pay a
+# full ``connect_timeout``, which is precisely the stall we are removing.
+RECONNECT_COOLDOWN = 10.0
+
+# MySQL server error codes that mean the connection itself is gone.
+_MYSQL_LOST_CONNECTION_CODES = frozenset({2006, 2013, 2055, 4031})
+
+# Fallback for drivers/wrappers that report a dead socket through a plain
+# exception type. Matched case-insensitively against ``str(exc)``.
+_LOST_CONNECTION_MARKERS = (
+    "server closed the connection",
+    "connection already closed",
+    "the connection is closed",
+    "connection not open",
+    "consuming input failed",
+    "ssl connection has been closed",
+    "terminating connection",
+    "no connection to the server",
+    "broken pipe",
+    "connection reset by peer",
+    "connection timed out",
+    "server has gone away",
+    "lost connection to",
+    "eof detected",
+)
+
+
+def _psycopg_lost(exc: BaseException) -> bool:
+    """Report whether a psycopg exception means the connection died."""
+    try:
+        import psycopg
+    except ImportError:  # backend not installed in this process
+        return False
+    # psycopg3 raises OperationalError for anything the network did to us and
+    # InterfaceError for using a connection that is already gone.
+    return isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError))
+
+
+def _mysql_lost(exc: BaseException) -> bool:
+    """Report whether a MySQLdb/pymysql exception means the connection died."""
+    try:
+        import MySQLdb
+    except ImportError:
+        return False
+    if isinstance(exc, MySQLdb.InterfaceError):
+        return True
+    if isinstance(exc, MySQLdb.OperationalError):
+        code = exc.args[0] if exc.args else None
+        return code in _MYSQL_LOST_CONNECTION_CODES
+    return False
+
+
+def is_connection_lost(backend: int, exc: BaseException) -> bool:
+    """Tell a dead connection apart from an ordinary SQL error.
+
+    Only the networked backends can lose a connection, so SQLite always answers
+    False: retrying a SQLite failure would just repeat a genuine error (a locked
+    file, a constraint violation) at twice the cost.
+
+    Args:
+        backend: The ``Database.PGSQL`` / ``MYSQL_INNODB`` / ``SQLITE`` constant.
+        exc: The exception raised while running a query.
+
+    Returns:
+        True when reconnecting is a sensible response to ``exc``.
+    """
+    from fpdb_3_legacy.Database import Database
+
+    if backend == Database.SQLITE:
+        return False
+    if backend == Database.PGSQL and _psycopg_lost(exc):
+        return True
+    if backend == Database.MYSQL_INNODB and _mysql_lost(exc):
+        return True
+    text = str(exc).lower()
+    return any(marker in text for marker in _LOST_CONNECTION_MARKERS)
+
+
+def reconnect_on_connection_loss(func: Callable) -> Callable:
+    """Reconnect once and replay ``func`` when the connection drops mid-query.
+
+    Meant for read-only ``Database`` methods that a long-running process calls
+    repeatedly -- the HUD's per-hand lookups above all. Writes are deliberately
+    left out: replaying half of a transaction is not something a decorator can
+    reason about, so the importer instead checks the connection between files
+    (see ``Importer.runUpdated``).
+
+    Nested decorated calls are collapsed: only the outermost one owns the retry,
+    so a single dropped connection costs one reconnect rather than one per layer.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if getattr(self, "_reconnect_guard", False):
+            # An enclosing decorated call already owns the retry for this query.
+            return func(self, *args, **kwargs)
+        self._reconnect_guard = True
+        try:
+            try:
+                return func(self, *args, **kwargs)
+            except Exception as exc:
+                if not is_connection_lost(self.backend, exc):
+                    raise
+                log.warning(
+                    "Database connection lost during %s (%s); attempting to reconnect.",
+                    func.__name__,
+                    exc,
+                )
+                if not self.recover_connection():
+                    raise
+                return func(self, *args, **kwargs)
+        finally:
+            self._reconnect_guard = False
+
+    return wrapper

--- a/fpdb_3_legacy/db_reconnect.py
+++ b/fpdb_3_legacy/db_reconnect.py
@@ -32,15 +32,19 @@ log = get_logger("database")
 
 
 # libpq connection parameters. ``keepalives_idle``/``interval``/``count`` mean a
-# silently dead peer is detected after roughly 30 + 3*10 = 60 seconds, even in
-# the middle of a query that is waiting for a result. ``connect_timeout`` bounds
-# the reconnect attempts themselves, which is what keeps the recovery path from
-# becoming the new place where everything hangs.
+# silently dead peer is detected after roughly 10 + 3*5 = 25 seconds, even in the
+# middle of a query that is waiting for a result -- that window is how long the
+# HUD can still stall once, before the breaker in HUD_main takes over. Probing
+# this often costs a handful of packets a minute on an idle connection, which is
+# cheap next to a 25-second freeze; going lower starts to risk declaring a merely
+# slow link dead. ``connect_timeout`` bounds the reconnect attempts themselves,
+# which is what keeps the recovery path from becoming the new place where
+# everything hangs.
 PG_NETWORK_KWARGS: dict[str, Any] = {
     "connect_timeout": 10,
     "keepalives": 1,
-    "keepalives_idle": 30,
-    "keepalives_interval": 10,
+    "keepalives_idle": 10,
+    "keepalives_interval": 5,
     "keepalives_count": 3,
 }
 

--- a/fpdb_3_legacy/db_reconnect.py
+++ b/fpdb_3_legacy/db_reconnect.py
@@ -62,12 +62,20 @@ RECONNECT_COOLDOWN = 10.0
 # MySQL server error codes that mean the connection itself is gone.
 _MYSQL_LOST_CONNECTION_CODES = frozenset({2006, 2013, 2055, 4031})
 
+# PostgreSQL SQLSTATE class 08 is "connection exception". These class-57
+# conditions also terminate an established server session rather than merely
+# cancelling its current statement. In particular, 57014 (query cancelled,
+# including statement_timeout) is deliberately absent: that connection remains
+# usable and the caller explicitly asked for the query to stop.
+_PG_LOST_CONNECTION_SQLSTATES = frozenset({"57P01", "57P02", "57P04", "57P05"})
+
 # Fallback for drivers/wrappers that report a dead socket through a plain
 # exception type. Matched case-insensitively against ``str(exc)``.
 _LOST_CONNECTION_MARKERS = (
     "server closed the connection",
     "connection already closed",
     "the connection is closed",
+    "connection is bad",
     "connection not open",
     "consuming input failed",
     "ssl connection has been closed",
@@ -88,9 +96,13 @@ def _psycopg_lost(exc: BaseException) -> bool:
         import psycopg
     except ImportError:  # backend not installed in this process
         return False
-    # psycopg3 raises OperationalError for anything the network did to us and
-    # InterfaceError for using a connection that is already gone.
-    return isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError))
+    if not isinstance(exc, (psycopg.OperationalError, psycopg.InterfaceError)):
+        return False
+    sqlstate = getattr(exc, "sqlstate", None)
+    return bool(
+        sqlstate
+        and (sqlstate.startswith("08") or sqlstate in _PG_LOST_CONNECTION_SQLSTATES)
+    )
 
 
 def _mysql_lost(exc: BaseException) -> bool:

--- a/pyoxidizer-requirements.txt
+++ b/pyoxidizer-requirements.txt
@@ -1,0 +1,21 @@
+# Keep this list synchronized with [project].dependencies in pyproject.toml.
+# pypoker-eval is installed separately in pyoxidizer.bzl because its metadata
+# requires Python 3.11 while PyOxidizer 0.24 embeds Python 3.10.
+beautifulsoup4==4.12.3
+matplotlib>=3.10.7
+pandas>=2.2.2
+psutil>=5.9.0
+pyobjc==10.3.1; sys_platform == 'darwin'
+PySide6>=6.8.1
+colorlog==6.9.0
+pyzmq>=26.0.3
+qt-material==2.14
+numpy>=2.1.0
+pytz==2024.1
+aiohttp>=3.13.2
+cachetools==5.5.0
+mplfinance>=0.12.10b0
+xlrd==2.0.1
+playwright>=1.40.0
+pymysql>=1.1.0
+defusedxml>=0.7.1

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -6,8 +6,9 @@ def make_dist():
     # archives. These 2024 distributions are still v7-compatible and avoid
     # depending on PyOxidizer's much older bundled 2022 Python.
     # PyOxidizer 0.24 cannot link CPython 3.11+ (missing _Py_Deepfreeze_*
-    # symbols). Stay on 3.10.14 for embedding; the CI workflow relaxes
-    # requires-python before building so pip_install succeeds.
+    # symbols). Stay on 3.10.14 for embedding. The package installation below
+    # limits the Python-version exception to the still-compatible fpdb and
+    # pypoker-eval sources; normal dependencies keep their metadata checks.
     distributions = {
         "aarch64-apple-darwin": [
             "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
@@ -101,9 +102,19 @@ def make_exe(dist):
     
     # Read resources from python packages and include them
     pip_resources = []
-    for resource in exe.pip_install([CWD]):
-        if keep_pip_resource(resource):
-            pip_resources.append(resource)
+    pip_install_commands = [
+        ["-r", CWD + "/pyoxidizer-requirements.txt"],
+        [
+            "--ignore-requires-python",
+            "--no-deps",
+            CWD,
+            "pypoker-eval @ git+https://github.com/jejellyroll-fr/poker-eval.git@v1.1.0",
+        ],
+    ]
+    for command in pip_install_commands:
+        for resource in exe.pip_install(command):
+            if keep_pip_resource(resource):
+                pip_resources.append(resource)
     exe.add_python_resources(pip_resources)
     exe.add_python_resources(exe.read_package_root(
         path=CWD,

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -103,16 +103,22 @@ def make_exe(dist):
     # Read resources from python packages and include them
     pip_resources = []
     pip_install_commands = [
-        ["-r", CWD + "/pyoxidizer-requirements.txt"],
+        [["-r", CWD + "/pyoxidizer-requirements.txt"], {}],
         [
-            "--ignore-requires-python",
-            "--no-deps",
-            CWD,
-            "pypoker-eval @ git+https://github.com/jejellyroll-fr/poker-eval.git@v1.1.0",
+            [
+                "--ignore-requires-python",
+                "--no-deps",
+                CWD,
+                "pypoker-eval @ git+https://github.com/jejellyroll-fr/poker-eval.git@v1.1.0",
+            ],
+            # A release artifact must not inherit the runner CPU. In
+            # particular, newer GitHub hosts expose AVX10 features that make
+            # Clang reject poker-eval's -march=native under -Werror.
+            {"CMAKE_ARGS": "-DENABLE_NATIVE_ARCH=OFF"},
         ],
     ]
     for command in pip_install_commands:
-        for resource in exe.pip_install(command):
+        for resource in exe.pip_install(command[0], extra_envs=command[1]):
             if keep_pip_resource(resource):
                 pip_resources.append(resource)
     exe.add_python_resources(pip_resources)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,9 @@ requires = [
     # Read by the Merge and Winamax summary parsers.
     "beautifulsoup4==4.12.3",
     # Imported when the user points fpdb at a MySQL database.
-    "pymysql>=1.1.0"
+    "pymysql>=1.1.0",
+    # Native equity backend used by the equity calculator and AoF tools.
+    "pypoker-eval @ git+https://github.com/jejellyroll-fr/poker-eval.git@v1.1.0"
 ]
 
 [tool.briefcase.app.fpdb.macOS]

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -307,8 +307,10 @@ def test_refresh_other_huds_uses_each_tables_last_hand(hud_main) -> None:
 
     assert get_table_info.call_args_list == [call("hand-b"), call("hand-c"), call("hand-missing")]
     assert update_existing_hud.call_args_list == [
-        call("hand-b", "table-b", "ring", 2, 5),
-        call("hand-c", "table-c", "tour", 3, 8),
+        # stat_dict=None: with no hero known yet there is nothing to batch, so
+        # each table fetches its own statistics, as this path always did.
+        call("hand-b", "table-b", "ring", 2, 5, stat_dict=None),
+        call("hand-c", "table-c", "tour", 3, 8, stat_dict=None),
     ]
 
 
@@ -341,8 +343,8 @@ def test_refresh_other_huds_isolates_secondary_table_failure(hud_main) -> None:
         hud_main._refresh_other_huds("source")
 
     assert update_existing_hud.call_args_list == [
-        call("hand-broken", "broken", "ring", 1, 6),
-        call("hand-healthy", "healthy", "ring", 1, 6),
+        call("hand-broken", "broken", "ring", 1, 6, stat_dict=None),
+        call("hand-healthy", "healthy", "ring", 1, 6, stat_dict=None),
     ]
     hud_main.db_connection.connection.rollback.assert_called_once_with()
 
@@ -1208,7 +1210,7 @@ def test_a_table_that_missed_the_round_is_refreshed_once(hud_main) -> None:
     ):
         hud_main._drain_pending_hands()
 
-    secondary.assert_called_once_with("h-idle", "table-idle", "ring", 1, 6)
+    secondary.assert_called_once_with("h-idle", "table-idle", "ring", 1, 6, stat_dict=None)
 
 
 # --- the two aux families -----------------------------------------------------
@@ -1303,7 +1305,7 @@ def test_a_table_whose_hand_failed_is_still_refreshed(hud_main) -> None:
     ):
         hud_main._drain_pending_hands()
 
-    secondary.assert_called_once_with("h-earlier", "table-bad", "ring", 1, 6)
+    secondary.assert_called_once_with("h-earlier", "table-bad", "ring", 1, 6, stat_dict=None)
 
 
 def test_a_table_skipped_rather_than_updated_is_still_refreshed(hud_main) -> None:
@@ -1323,7 +1325,7 @@ def test_a_table_skipped_rather_than_updated_is_still_refreshed(hud_main) -> Non
     ):
         hud_main._drain_pending_hands()
 
-    secondary.assert_called_once_with("h-earlier", "table-a", "ring", 1, 6)
+    secondary.assert_called_once_with("h-earlier", "table-a", "ring", 1, 6, stat_dict=None)
 
 
 # --- a tournament table the player was moved away from ------------------------

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -349,6 +349,24 @@ def test_refresh_other_huds_isolates_secondary_table_failure(hud_main) -> None:
     hud_main.db_connection.connection.rollback.assert_called_once_with()
 
 
+def test_batched_stats_failure_rolls_back_before_per_table_fallback(hud_main) -> None:
+    """PostgreSQL must leave the connection usable for the promised fallback."""
+    hud = MagicMock()
+    hud.hud_params = {"hud_days": 30, "h_hud_days": 90}
+    hud.poker_game = "holdem"
+    hud_main.hud_dict = {"table": hud}
+    hud_main.hero_ids = {1: 42}
+    hud_main.db_connection.get_stats_from_hands.side_effect = RuntimeError("bad batched query")
+    hud_main.db_connection.connection.rollback.reset_mock()
+    pending = [("table", "hand", "ring", 1, 6)]
+
+    with patch.object(hud_main, "note_db_error", return_value=False):
+        result = hud_main._batch_secondary_stats(pending)
+
+    assert result == {}
+    hud_main.db_connection.connection.rollback.assert_called_once_with()
+
+
 def test_refresh_secondary_hud_only_rereads_the_statistics(hud_main) -> None:
     """A table with no new hand of its own is refreshed with one query, not six.
 

--- a/test/test_hud_db_outage.py
+++ b/test/test_hud_db_outage.py
@@ -1,0 +1,198 @@
+"""Tests for the HUD's behaviour while the database is unreachable.
+
+Every HUD database read runs on the Qt thread that repaints the windows. When
+the database sits behind a VPN that drops, each read stalls that thread, so the
+HUD froze once per hand for as long as the outage lasted -- and, because the
+table-info lookup swallowed the error, it looked like hands that were merely not
+committed yet, so the HUD stayed dead after the link came back.
+
+HudMain now trips a breaker on the first lost connection: it stops querying,
+hands the connection to DbRecoveryWorker (a thread, so the reconnect cost is not
+paid on the UI thread), and resumes when that reports the link is back.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.qt
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _load_hud_main():
+    """Load HUD_main.pyw, reusing the instance another test module loaded.
+
+    Executing the source a second time would leave two module objects under the
+    same name: patches applied by one test module would then miss the classes
+    the other is using, and the ZMQ sockets bound by its fixtures would never be
+    released.
+    """
+    existing = sys.modules.get("HUD_main")
+    if existing is not None:
+        return existing
+
+    win_tables_module = types.ModuleType("WinTables")
+    win_tables_module.Table = MagicMock()
+    sys.modules["WinTables"] = win_tables_module
+
+    source_file = Path(__file__).parent.parent / "fpdb_3_legacy" / "HUD_main.pyw"
+    loader = importlib.machinery.SourceFileLoader("HUD_main", str(source_file))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["HUD_main"] = module
+    try:
+        loader.exec_module(module)
+    except (ImportError, ModuleNotFoundError) as exc:
+        del sys.modules["HUD_main"]
+        pytest.skip(f"HUD_main eager-load failed: {exc}", allow_module_level=True)
+    return module
+
+
+HUD_main = _load_hud_main()
+
+psycopg = pytest.importorskip("psycopg")
+
+from fpdb_3_legacy.Database import Database  # noqa: E402
+
+
+def make_hud_main(**attrs):
+    """A HudMain carrying only what the breaker touches.
+
+    ``__new__`` skips ``__init__``, which would open a database connection and
+    bind a ZMQ socket.
+    """
+    hud = HUD_main.HudMain.__new__(HUD_main.HudMain)
+    hud.db_connection = MagicMock()
+    hud.db_connection.backend = Database.PGSQL
+    hud._db_available = True
+    hud._db_recovery_worker = None
+    hud._pending_hands = []
+    hud.hud_dict = {}
+    hud.cache = {}
+    hud.started_recovery = 0
+
+    def record_recovery() -> None:
+        hud.started_recovery += 1
+
+    hud._start_db_recovery = record_recovery
+    for name, value in attrs.items():
+        setattr(hud, name, value)
+    return hud
+
+
+def lost_connection_error():
+    return psycopg.OperationalError("consuming input failed: server closed the connection unexpectedly")
+
+
+def test_a_lost_connection_opens_the_breaker_once() -> None:
+    hud = make_hud_main()
+
+    assert hud.note_db_error(lost_connection_error()) is True
+    assert hud._db_available is False
+    assert hud.started_recovery == 1
+
+    # Later failures during the same outage must not restart recovery.
+    assert hud.note_db_error(lost_connection_error()) is True
+    assert hud.started_recovery == 1
+
+
+def test_an_ordinary_sql_error_leaves_the_breaker_closed() -> None:
+    """A bad query is not an outage; the HUD must carry on serving hands."""
+    hud = make_hud_main()
+
+    assert hud.note_db_error(psycopg.ProgrammingError('column "nope" does not exist')) is False
+    assert hud._db_available is True
+    assert hud.started_recovery == 0
+
+
+def test_table_info_reports_the_outage_instead_of_swallowing_it() -> None:
+    """Returning None here is what made the HUD look merely out of date."""
+    hud = make_hud_main()
+    hud.db_connection.get_table_info.side_effect = lost_connection_error()
+
+    assert hud._get_table_info("123") is None
+    assert hud._db_available is False
+    # No rollback attempt: the connection is gone and now belongs to recovery.
+    hud.db_connection.connection.rollback.assert_not_called()
+
+
+def test_hands_arriving_during_an_outage_are_dropped_not_queried() -> None:
+    hud = make_hud_main(_db_available=False)
+
+    hud.handle_message("456")
+
+    assert hud._pending_hands == []
+    hud.db_connection.connection.rollback.assert_not_called()
+
+
+def test_a_pending_batch_is_dropped_rather_than_run_against_a_dead_link() -> None:
+    hud = make_hud_main(_db_available=False, _pending_hands=["1", "2", "3"])
+
+    hud._drain_pending_hands()
+
+    assert hud._pending_hands == []
+    hud.db_connection.get_table_info.assert_not_called()
+
+
+def test_recovery_closes_the_breaker() -> None:
+    hud = make_hud_main(_db_available=False)
+
+    hud._on_db_recovered()
+
+    assert hud._db_available is True
+
+
+def test_recovery_worker_stops_at_the_first_success() -> None:
+    """It must hand the connection back rather than keep polling it."""
+    db = MagicMock()
+    db.recover_connection.side_effect = [False, False, True]
+    worker = HUD_main.DbRecoveryWorker(db)
+    recovered = []
+    worker.recovered.connect(lambda: recovered.append(True))
+
+    # Drive run() inline, without the retry interval.
+    HUD_main.DB_RECOVERY_INTERVAL_S, saved = 0.0, HUD_main.DB_RECOVERY_INTERVAL_S
+    try:
+        worker.run()
+    finally:
+        HUD_main.DB_RECOVERY_INTERVAL_S = saved
+
+    assert db.recover_connection.call_count == 3
+    assert recovered == [True]
+
+
+def test_recovery_worker_survives_an_unexpected_failure() -> None:
+    """A raising attempt must not end recovery -- the outage would be permanent."""
+    db = MagicMock()
+    db.recover_connection.side_effect = [RuntimeError("boom"), True]
+    worker = HUD_main.DbRecoveryWorker(db)
+    recovered = []
+    worker.recovered.connect(lambda: recovered.append(True))
+
+    HUD_main.DB_RECOVERY_INTERVAL_S, saved = 0.0, HUD_main.DB_RECOVERY_INTERVAL_S
+    try:
+        worker.run()
+    finally:
+        HUD_main.DB_RECOVERY_INTERVAL_S = saved
+
+    assert db.recover_connection.call_count == 2
+    assert recovered == [True]
+
+
+def test_stopping_the_worker_ends_the_loop() -> None:
+    db = MagicMock()
+    db.recover_connection.return_value = False
+    worker = HUD_main.DbRecoveryWorker(db)
+    worker._stopping.set()
+
+    worker.run()
+
+    db.recover_connection.assert_not_called()

--- a/tests/test_autoimport_db_outage.py
+++ b/tests/test_autoimport_db_outage.py
@@ -1,0 +1,183 @@
+"""Tests for the auto-import tab while the database is unreachable.
+
+A wedged import cycle used to be invisible: ``do_import`` logged "deferring this
+iteration" at debug level and returned, every interval, forever, so the importer
+looked like it had simply decided to stop. Pressing Stop then called
+``wait()`` with no timeout on the UI thread and froze the window.
+
+The cycle now reports an unreachable database to the GUI, says so once per
+outage rather than once per interval, and Stop gives up on a worker that will
+not finish.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# GuiAutoImport uses legacy-style bare imports, so the package directory must be
+# importable directly.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _make_gui():
+    """A headless GuiAutoImport with the Importer mocked out, plus GUI stubs.
+
+    ``cli=True`` skips the widget construction, so the progress bar and status
+    label the outage path writes to are stubbed in here.
+    """
+    from fpdb_3_legacy import GuiAutoImport
+
+    settings = {
+        "db-host": "localhost",
+        "db-user": "fpdb",
+        "db-password": "",
+        "db-databaseName": "fpdb",
+        "global_lock": MagicMock(),
+    }
+    config = MagicMock()
+    config.get_import_parameters.return_value = {"interval": "5"}
+    config.get_supported_sites.return_value = []
+    config.get_db_parameters.return_value = {}
+
+    with patch.object(GuiAutoImport.Importer, "Importer", return_value=MagicMock()):
+        gui = GuiAutoImport.GuiAutoImport(settings, config, cli=True)
+
+    gui.progressBar = MagicMock()
+    gui.statusLabel = MagicMock()
+    gui.addText = MagicMock()
+    return gui
+
+
+def test_an_unreachable_database_is_announced_once_per_outage() -> None:
+    gui = _make_gui()
+
+    gui.import_db_offline()
+    gui.import_db_offline()
+    gui.import_db_offline()
+
+    assert gui._db_offline is True
+    assert gui.addText.call_count == 1, "the outage must not be re-announced every interval"
+    assert "unreachable" in gui.statusLabel.setText.call_args[0][0].lower()
+
+
+def test_the_database_coming_back_is_announced_too() -> None:
+    gui = _make_gui()
+    gui.import_db_offline()
+    gui.addText.reset_mock()
+
+    gui.import_finished()
+
+    assert gui._db_offline is False
+    assert gui.addText.call_count == 1
+    assert "back" in gui.addText.call_args[0][0].lower()
+
+
+def test_an_ordinary_cycle_says_nothing() -> None:
+    """Only a recovery is worth a line; every other cycle is silent."""
+    gui = _make_gui()
+
+    gui.import_finished()
+
+    gui.addText.assert_not_called()
+
+
+def test_a_wedged_worker_is_reported_after_several_missed_cycles() -> None:
+    from fpdb_3_legacy.GuiAutoImport import DEFERRED_CYCLES_BEFORE_WARNING
+
+    gui = _make_gui()
+    gui.doAutoImportBool = True
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = True
+
+    for _ in range(DEFERRED_CYCLES_BEFORE_WARNING - 1):
+        assert gui.do_import() is True
+    gui.statusLabel.setText.assert_not_called()
+
+    gui.do_import()
+
+    assert gui._deferred_cycles == DEFERRED_CYCLES_BEFORE_WARNING
+    assert "longer" in gui.statusLabel.setText.call_args[0][0].lower()
+
+
+def test_the_deferral_count_resets_when_a_cycle_starts() -> None:
+    gui = _make_gui()
+    gui.doAutoImportBool = True
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = True
+    gui.do_import()
+    assert gui._deferred_cycles == 1
+
+    gui.import_thread.isRunning.return_value = False
+    with patch("fpdb_3_legacy.GuiAutoImport.AutoImportThread"):
+        gui.do_import()
+
+    assert gui._deferred_cycles == 0
+
+
+def test_worker_reports_an_unreachable_database_instead_of_importing() -> None:
+    from fpdb_3_legacy.GuiAutoImport import AutoImportThread
+
+    importer = MagicMock()
+    importer.database.ensure_connection.return_value = False
+    thread = AutoImportThread(importer)
+    seen = []
+    thread.db_offline.connect(lambda: seen.append("offline"))
+    thread.finished.connect(lambda: seen.append("finished"))
+
+    thread.run()
+
+    assert seen == ["offline"]
+    importer.runUpdated.assert_not_called()
+    importer.autoSummaryGrab.assert_not_called()
+
+
+def test_worker_imports_normally_when_the_database_answers() -> None:
+    from fpdb_3_legacy.GuiAutoImport import AutoImportThread
+
+    importer = MagicMock()
+    importer.database.ensure_connection.return_value = True
+    thread = AutoImportThread(importer)
+    seen = []
+    thread.db_offline.connect(lambda: seen.append("offline"))
+    thread.finished.connect(lambda: seen.append("finished"))
+
+    thread.run()
+
+    assert seen == ["finished"]
+    importer.runUpdated.assert_called_once()
+
+
+def test_stop_waits_with_a_timeout_not_forever() -> None:
+    """An unbounded wait on the UI thread is what froze the window."""
+    from fpdb_3_legacy.GuiAutoImport import STOP_WAIT_MS
+
+    gui = _make_gui()
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = True
+    gui.import_thread.wait.return_value = True
+
+    assert gui._stop_import_worker() is True
+    gui.import_thread.wait.assert_called_once_with(STOP_WAIT_MS)
+
+
+def test_stop_gives_up_on_a_worker_that_will_not_finish() -> None:
+    gui = _make_gui()
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = True
+    gui.import_thread.wait.return_value = False  # still running when the wait expires
+
+    assert gui._stop_import_worker() is False
+    assert "background" in gui.addText.call_args[0][0].lower()
+
+
+def test_stop_is_immediate_when_no_cycle_is_running() -> None:
+    gui = _make_gui()
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = False
+
+    assert gui._stop_import_worker() is True
+    gui.import_thread.wait.assert_not_called()
+    gui.addText.assert_not_called()

--- a/tests/test_autoimport_db_outage.py
+++ b/tests/test_autoimport_db_outage.py
@@ -181,3 +181,40 @@ def test_stop_is_immediate_when_no_cycle_is_running() -> None:
     assert gui._stop_import_worker() is True
     gui.import_thread.wait.assert_not_called()
     gui.addText.assert_not_called()
+
+
+def test_stop_defers_cleanup_while_the_worker_is_still_running() -> None:
+    """The Importer and global lock stay owned until the worker really exits."""
+    from fpdb_3_legacy import GuiAutoImport
+
+    gui = _make_gui()
+    gui.startButton = MagicMock()
+    gui.startButton.isChecked.return_value = False
+    gui.intervalEntry = MagicMock()
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = True
+
+    with (
+        patch.object(gui, "_stop_import_worker", return_value=False),
+        patch.object(gui, "_finalize_auto_import_stop") as finalize,
+        patch.object(GuiAutoImport.QTimer, "singleShot") as single_shot,
+    ):
+        gui.startClicked()
+
+    assert gui._stop_cleanup_pending is True
+    gui.importer.autoSummaryGrab.assert_not_called()
+    gui.settings["global_lock"].release.assert_not_called()
+    finalize.assert_not_called()
+    single_shot.assert_called_once_with(250, gui._wait_for_import_worker_stop)
+
+
+def test_deferred_stop_finishes_after_the_worker_exits() -> None:
+    gui = _make_gui()
+    gui._stop_cleanup_pending = True
+    gui.import_thread = MagicMock()
+    gui.import_thread.isRunning.return_value = False
+
+    with patch.object(gui, "_finalize_auto_import_stop") as finalize:
+        gui._wait_for_import_worker_stop()
+
+    finalize.assert_called_once_with()

--- a/tests/test_database_schema_migrations.py
+++ b/tests/test_database_schema_migrations.py
@@ -1,0 +1,70 @@
+"""Focused tests for additive database schema migrations."""
+
+from __future__ import annotations
+
+import pytest
+
+from fpdb_3_legacy.Database import Database
+
+
+class RecordingCursor:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.statements: list[str] = []
+
+    def execute(self, statement: str) -> None:
+        self.statements.append(statement)
+        if self.error is not None:
+            raise self.error
+
+
+def migration_db(backend: int, cursor: RecordingCursor) -> tuple[Database, list[str]]:
+    db = Database.__new__(Database)
+    db.backend = backend
+    db._get_table_columns = lambda _table: {"id", "CATEGORY"}
+    db.get_cursor = lambda: cursor
+    events: list[str] = []
+    db.commit = lambda: events.append("commit")
+    db.rollback = lambda: events.append("rollback")
+    return db, events
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        (Database.MYSQL_INNODB, "ALTER TABLE Gametypes MODIFY category VARCHAR(10) NOT NULL"),
+        (Database.PGSQL, "ALTER TABLE Gametypes ALTER COLUMN category TYPE VARCHAR(10)"),
+    ],
+)
+def test_gametype_category_is_widened_for_server_databases(backend: int, expected: str) -> None:
+    cursor = RecordingCursor()
+    db, events = migration_db(backend, cursor)
+
+    db._ensure_gametype_category_width()
+
+    assert cursor.statements == [expected]
+    assert events == ["commit"]
+
+
+def test_gametype_category_lookup_failure_rolls_back() -> None:
+    cursor = RecordingCursor()
+    db, events = migration_db(Database.PGSQL, cursor)
+
+    def fail_lookup(_table: str) -> set[str]:
+        raise RuntimeError("missing table")
+
+    db._get_table_columns = fail_lookup
+
+    db._ensure_gametype_category_width()
+
+    assert cursor.statements == []
+    assert events == ["rollback"]
+
+
+def test_gametype_category_alter_failure_rolls_back() -> None:
+    cursor = RecordingCursor(RuntimeError("table locked"))
+    db, events = migration_db(Database.PGSQL, cursor)
+
+    db._ensure_gametype_category_width()
+
+    assert events == ["rollback"]

--- a/tests/test_db_profile.py
+++ b/tests/test_db_profile.py
@@ -1,0 +1,293 @@
+"""Tests for the database round-trip counter.
+
+The number that decides how the HUD feels over a VPN is how many statements it
+issues per hand and per table: each one costs a network latency whatever the
+server does with it. These cover the counting itself, the attribution to the
+work that asked for the statements, and the fact that the whole thing stays out
+of the way when it is switched off.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from fpdb_3_legacy import db_profile
+
+
+@pytest.fixture
+def on(monkeypatch):
+    """Switch profiling on and hand back a clean process-wide profile."""
+    monkeypatch.setenv(db_profile.ENV_FLAG, "1")
+    profile = db_profile.get_profile()
+    profile.reset()
+    yield profile
+    profile.reset()
+
+
+@pytest.fixture
+def connection():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO t (name) VALUES ('a'), ('b')")
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+# -- counting -------------------------------------------------------------
+
+
+def test_every_statement_is_counted(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection)
+
+    c = counted.cursor()
+    c.execute("SELECT * FROM t")
+    c.fetchall()
+    c.execute("SELECT COUNT(*) FROM t")
+    c.fetchone()
+
+    assert on.total.calls == 2
+    assert on.total.seconds > 0
+
+
+def test_a_failing_statement_still_cost_a_round_trip(on, connection) -> None:
+    """Hiding failures would flatter the report; the packets still went out."""
+    counted = db_profile.wrap_connection(connection)
+
+    with pytest.raises(sqlite3.OperationalError):
+        counted.cursor().execute("SELECT * FROM nope")
+
+    assert on.total.calls == 1
+
+
+def test_results_still_come_back_through_the_wrapper(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection)
+
+    c = counted.cursor()
+    c.execute("SELECT name FROM t ORDER BY name")
+
+    assert [row[0] for row in c.fetchall()] == ["a", "b"]
+
+
+def test_the_connection_is_otherwise_transparent(on, connection) -> None:
+    """The dialects set autocommit on the connection; that must reach the real one."""
+    counted = db_profile.wrap_connection(connection)
+
+    assert hasattr(counted, "commit")
+    counted.isolation_level = None
+    assert connection.isolation_level is None
+    counted.commit()
+
+
+def test_nothing_is_wrapped_when_profiling_is_off(monkeypatch, connection) -> None:
+    monkeypatch.delenv(db_profile.ENV_FLAG, raising=False)
+
+    assert db_profile.wrap_connection(connection) is connection
+
+
+def test_wrapping_twice_does_not_double_count(on, connection) -> None:
+    counted = db_profile.wrap_connection(db_profile.wrap_connection(connection))
+
+    counted.cursor().execute("SELECT 1")
+
+    assert on.total.calls == 1
+
+
+# -- attribution ----------------------------------------------------------
+
+
+def test_a_statement_counts_for_every_scope_it_ran_inside(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection)
+
+    with db_profile.scope("batch"):
+        with db_profile.scope("hand"):
+            counted.cursor().execute("SELECT 1")
+            counted.cursor().execute("SELECT 2")
+        with db_profile.scope("hand"):
+            counted.cursor().execute("SELECT 3")
+
+    assert on.by_scope["batch"].queries == 3
+    assert on.by_scope["batch"].entries == 1
+    assert on.by_scope["hand"].queries == 3
+    assert on.by_scope["hand"].entries == 2
+    assert on.by_scope["hand"].queries_per_entry == 1.5
+
+
+def test_a_scope_inside_itself_counts_a_statement_once(on, connection) -> None:
+    """Otherwise a recursive path would report round trips it never made."""
+    counted = db_profile.wrap_connection(connection)
+
+    with db_profile.scope("refresh"), db_profile.scope("refresh"):
+        counted.cursor().execute("SELECT 1")
+
+    assert on.by_scope["refresh"].queries == 1
+
+
+def test_the_decorator_attributes_a_whole_method(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection)
+
+    @db_profile.scoped("secondary_refresh")
+    def refresh_one_table() -> None:
+        counted.cursor().execute("SELECT 1")
+        counted.cursor().execute("SELECT 2")
+
+    refresh_one_table()
+    refresh_one_table()
+
+    assert on.by_scope["secondary_refresh"].entries == 2
+    assert on.by_scope["secondary_refresh"].queries_per_entry == 2.0
+
+
+def test_the_decorator_keeps_the_method_it_wraps(on) -> None:
+    @db_profile.scoped("whatever")
+    def named(a, b=2):
+        """Doc."""
+        return a + b
+
+    assert named.__name__ == "named"
+    assert named(1, b=3) == 4
+
+
+def test_scopes_are_per_thread(on, connection) -> None:
+    """An importer thread must not land its statements in the HUD's scope."""
+    import threading
+
+    counted = db_profile.wrap_connection(connection)
+    started = threading.Event()
+
+    def other_thread() -> None:
+        started.wait()
+        # No scope open on this thread.
+        sqlite3.connect(":memory:").close()
+        db_profile.get_profile().record("SELECT 'other'", 0.0)
+
+    worker = threading.Thread(target=other_thread)
+    worker.start()
+    with db_profile.scope("hand"):
+        started.set()
+        worker.join()
+        counted.cursor().execute("SELECT 1")
+
+    assert on.by_scope["hand"].queries == 1
+    assert on.total.calls == 2
+
+
+# -- naming and reporting -------------------------------------------------
+
+
+def test_statements_are_named_after_the_sql_catalogue(on, connection) -> None:
+    catalogue = {"get_hand_1day_ago": "SELECT max(id)\n  FROM Hands\n WHERE startTime < ?"}
+    counted = db_profile.wrap_connection(connection, catalogue)
+
+    with pytest.raises(sqlite3.OperationalError):
+        # Naming must not depend on the statement succeeding.
+        counted.cursor().execute("SELECT max(id) FROM Hands WHERE startTime < ?", (1,))
+
+    assert "get_hand_1day_ago" in on.by_statement
+    assert on.by_statement["get_hand_1day_ago"].calls == 1
+
+
+def test_a_query_with_injected_columns_keeps_its_name(on, connection) -> None:
+    """The HUD aggregate has columns injected before it runs; it is the one
+    statement whose name matters most, and an exact match would lose it."""
+    catalogue = {
+        "get_stats_from_hand_aggregated": (
+            "/* explain query plan */ SELECT hp.playerId, count(1) AS n, sum(hp.street0VPI) AS vpip FROM HandsPlayers hp"
+        ),
+    }
+    counted = db_profile.wrap_connection(connection, catalogue)
+
+    with pytest.raises(sqlite3.OperationalError):
+        counted.cursor().execute(
+            "/* explain query plan */ SELECT hp.playerId, count(1) AS n, "
+            "sum(hp.chipEvBtn) AS ev_btn, sum(hp.street0VPI) AS vpip FROM HandsPlayers hp",
+        )
+
+    assert "get_stats_from_hand_aggregated (assembled)" in on.by_statement
+
+
+def test_an_ambiguous_opening_is_not_used_to_name_anything(on, connection) -> None:
+    """Two catalogue entries sharing an opening must not be confused."""
+    shared = "SELECT playerId, count(1), sum(street0VPI), sum(street0Aggr) FROM HandsPlayers WHERE "
+    counted = db_profile.wrap_connection(connection, {"query_a": shared + "a = 1", "query_b": shared + "b = 2"})
+
+    with pytest.raises(sqlite3.OperationalError):
+        counted.cursor().execute(shared + "c = 3")
+
+    assert not any("assembled" in label for label in on.by_statement)
+
+
+def test_an_unknown_statement_is_named_by_its_text(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection, {})
+
+    counted.cursor().execute("SELECT name FROM t")
+
+    assert "select name from t" in on.by_statement
+
+
+def test_the_report_names_the_repeat_offenders(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection, {"cheap_lookup": "SELECT 1"})
+
+    with db_profile.scope("hand"):
+        for _ in range(12):
+            counted.cursor().execute("SELECT 1")
+
+    report = on.report()
+    assert "cheap_lookup" in report
+    assert "12" in report
+    assert "hand" in report
+
+
+def test_an_empty_report_says_so(on) -> None:
+    assert "none recorded" in on.report()
+
+
+def test_the_delta_reporter_stays_quiet_until_something_changes(on, connection) -> None:
+    counted = db_profile.wrap_connection(connection)
+    reporter = db_profile.DeltaReporter("profile:", on)
+
+    assert reporter.maybe_log() is False
+
+    counted.cursor().execute("SELECT 1")
+    assert reporter.maybe_log() is True
+    assert reporter.maybe_log() is False
+
+
+def test_the_delta_reporter_is_silent_when_profiling_is_off(monkeypatch, connection) -> None:
+    monkeypatch.delenv(db_profile.ENV_FLAG, raising=False)
+    profile = db_profile.QueryProfile()
+    profile.record("SELECT 1", 0.0)
+
+    assert db_profile.DeltaReporter("profile:", profile).maybe_log() is False
+
+
+# -- end to end -----------------------------------------------------------
+
+
+def test_a_real_database_counts_and_names_its_own_statements(monkeypatch, legacy_config) -> None:
+    """The wiring in Database.connect, against a real schema."""
+    monkeypatch.setenv(db_profile.ENV_FLAG, "1")
+    profile = db_profile.get_profile()
+    profile.reset()
+
+    from fpdb_3_legacy.Database import Database
+
+    db = Database(legacy_config)
+    try:
+        db.recreate_tables()
+        profile.reset()
+        with db_profile.scope("hand"):
+            db.get_table_info("1")
+        # Read before the teardown below resets the counters.
+        calls = profile.total.calls
+        hand_queries = profile.by_scope["hand"].queries
+        named = "get_table_name" in profile.by_statement
+    finally:
+        db.disconnect()
+        profile.reset()
+
+    assert calls >= 1, "statements through a real Database must be counted"
+    assert hand_queries == calls, "and attributed to the scope that asked for them"
+    assert named, "and named after the SQL catalogue entry they came from"

--- a/tests/test_db_reconnect.py
+++ b/tests/test_db_reconnect.py
@@ -192,6 +192,26 @@ def test_ordinary_sql_error_is_reported_not_retried() -> None:
     assert db.recoveries == 0
 
 
+def test_postgresql_query_cancellation_keeps_the_healthy_connection() -> None:
+    """statement_timeout must not reconnect and replay the cancelled query."""
+    err = psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+
+    assert db_reconnect.is_connection_lost(Database.PGSQL, err) is False
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        psycopg.errors.ConnectionFailure("transport unavailable"),
+        psycopg.errors.AdminShutdown("server is shutting down"),
+        psycopg.errors.DatabaseDropped("database was dropped"),
+        psycopg.errors.IdleSessionTimeout("idle session timed out"),
+    ],
+)
+def test_postgresql_session_termination_is_a_lost_connection(error) -> None:
+    assert db_reconnect.is_connection_lost(Database.PGSQL, error) is True
+
+
 def test_failed_recovery_lets_the_original_error_through() -> None:
     class Db:
         backend = Database.PGSQL

--- a/tests/test_db_reconnect.py
+++ b/tests/test_db_reconnect.py
@@ -1,0 +1,324 @@
+"""Regression tests for surviving a database connection that drops mid-session.
+
+The failure being guarded against: with the database at the far end of a VPN,
+a dropped tunnel left the TCP socket in a black hole. Queries never returned and
+never raised, so the HUD's Qt event loop and the auto-import worker both stopped
+permanently. Two things had to hold for that to be fixable at all --
+
+* the connection must be opened with TCP keepalives, or the error that recovery
+  reacts to is never raised in the first place;
+* ``reconnect()`` must actually work; it used to pass its arguments positionally
+  into a signature that had gained a ``port`` parameter, so the database name
+  went in as the port and the user as the database.
+
+Both are asserted below, along with the retry behaviour built on top of them.
+"""
+
+import pytest
+
+from fpdb_3_legacy import db_reconnect
+from fpdb_3_legacy.Database import Database
+
+psycopg = pytest.importorskip("psycopg")
+
+
+def make_db(**attrs):
+    """Build a Database with only the attributes the connection code touches.
+
+    ``__new__`` skips ``__init__`` (which would open a real connection); the
+    methods under test are deliberately narrow enough not to need the rest.
+    """
+    db = Database.__new__(Database)
+    db.backend = Database.PGSQL
+    db.host = "192.168.1.10"
+    db.port = 5432
+    db.database = "fpdb"
+    db.user = "fpdb_user"
+    db.password = "secret"
+    db.connection = None
+    db.cursor = None
+    db._reconnect_guard = False
+    db._reconnect_blocked_until = 0.0
+    db._connection_down_logged = False
+    db._Database__connected = True
+    for name, value in attrs.items():
+        setattr(db, name, value)
+    return db
+
+
+class FakeConnection:
+    """A psycopg-shaped connection whose queries fail on demand."""
+
+    def __init__(self, fail_with=None) -> None:
+        self.fail_with = fail_with
+        self.closed = False
+
+    def cursor(self):
+        return FakeCursor(self.fail_with)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeCursor:
+    def __init__(self, fail_with=None) -> None:
+        self.fail_with = fail_with
+
+    def execute(self, *args) -> None:
+        if self.fail_with is not None:
+            raise self.fail_with
+
+    def fetchone(self):
+        return (1,)
+
+    def close(self) -> None:
+        pass
+
+
+# --------------------------------------------------------------------------
+# A. the connection must be opened so that a dead peer becomes a real error
+# --------------------------------------------------------------------------
+
+
+def test_postgresql_connect_arms_keepalives_and_bounds_the_connect(monkeypatch) -> None:
+    captured = {}
+
+    def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return FakeConnection()
+
+    monkeypatch.setattr(psycopg, "connect", fake_connect)
+    db = make_db(host="192.168.1.10", _Database__connected=False)
+    db._connect_postgresql("192.168.1.10", 5432, "fpdb_user", "secret", "fpdb")
+
+    assert captured["connect_timeout"] == 10
+    assert captured["keepalives"] == 1
+    assert captured["keepalives_idle"] == 30
+    assert captured["keepalives_interval"] == 10
+    assert captured["keepalives_count"] == 3
+
+
+def test_local_peer_connection_also_bounded(monkeypatch) -> None:
+    captured = {}
+
+    def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return FakeConnection()
+
+    monkeypatch.setattr(psycopg, "connect", fake_connect)
+    db = make_db(host="localhost", _Database__connected=False)
+    db._connect_postgresql("localhost", 5432, "fpdb_user", "secret", "fpdb")
+
+    assert captured["dbname"] == "fpdb"
+    assert captured["connect_timeout"] == 10
+
+
+# --------------------------------------------------------------------------
+# B. reconnect, and the retry built on it
+# --------------------------------------------------------------------------
+
+
+def test_reconnect_passes_each_parameter_to_its_own_slot() -> None:
+    """The positional call used to shift database into port and user into database."""
+    captured = {}
+    db = make_db()
+    db.disconnect = lambda due_to_error=False: None
+    db.connect = lambda **kwargs: captured.update(kwargs)
+
+    db.reconnect(due_to_error=True)
+
+    assert captured == {
+        "backend": Database.PGSQL,
+        "host": "192.168.1.10",
+        "port": 5432,
+        "database": "fpdb",
+        "user": "fpdb_user",
+        "password": "secret",
+    }
+
+
+def test_dropped_connection_is_reconnected_and_the_query_replayed() -> None:
+    attempts = []
+
+    class Db:
+        backend = Database.PGSQL
+
+        def __init__(self) -> None:
+            self.recoveries = 0
+
+        def recover_connection(self) -> bool:
+            self.recoveries += 1
+            return True
+
+        @db_reconnect.reconnect_on_connection_loss
+        def get_table_info(self, hand_id):
+            attempts.append(hand_id)
+            if len(attempts) == 1:
+                msg = "consuming input failed: server closed the connection unexpectedly"
+                raise psycopg.OperationalError(msg)
+            return ("Table 1", 6)
+
+    db = Db()
+    assert db.get_table_info(42) == ("Table 1", 6)
+    assert attempts == [42, 42]
+    assert db.recoveries == 1
+
+
+def test_ordinary_sql_error_is_reported_not_retried() -> None:
+    attempts = []
+
+    class Db:
+        backend = Database.PGSQL
+        recoveries = 0
+
+        def recover_connection(self) -> bool:
+            self.recoveries += 1
+            return True
+
+        @db_reconnect.reconnect_on_connection_loss
+        def get_table_info(self, hand_id):
+            attempts.append(hand_id)
+            msg = 'column "nope" does not exist'
+            raise psycopg.ProgrammingError(msg)
+
+    db = Db()
+    with pytest.raises(psycopg.ProgrammingError):
+        db.get_table_info(42)
+    assert attempts == [42]
+    assert db.recoveries == 0
+
+
+def test_failed_recovery_lets_the_original_error_through() -> None:
+    class Db:
+        backend = Database.PGSQL
+
+        def recover_connection(self) -> bool:
+            return False
+
+        @db_reconnect.reconnect_on_connection_loss
+        def get_table_info(self, hand_id):
+            msg = "server closed the connection unexpectedly"
+            raise psycopg.OperationalError(msg)
+
+    with pytest.raises(psycopg.OperationalError):
+        Db().get_table_info(42)
+
+
+def test_nested_decorated_calls_recover_only_once() -> None:
+    """One dropped connection must cost one reconnect, not one per call layer."""
+    inner_attempts = []
+
+    class Db:
+        backend = Database.PGSQL
+
+        def __init__(self) -> None:
+            self.recoveries = 0
+
+        def recover_connection(self) -> bool:
+            self.recoveries += 1
+            return True
+
+        @db_reconnect.reconnect_on_connection_loss
+        def get_gameinfo(self, hand_id):
+            inner_attempts.append(hand_id)
+            if len(inner_attempts) == 1:
+                msg = "server closed the connection unexpectedly"
+                raise psycopg.OperationalError(msg)
+            return {"gametypeId": 7}
+
+        @db_reconnect.reconnect_on_connection_loss
+        def get_stats_from_hand(self, hand_id):
+            return self.get_gameinfo(hand_id)
+
+    db = Db()
+    assert db.get_stats_from_hand(42) == {"gametypeId": 7}
+    assert db.recoveries == 1
+
+
+def test_sqlite_failures_are_never_treated_as_a_lost_connection() -> None:
+    """SQLite has no socket to lose; retrying would just repeat a real error."""
+    err = Exception("database is locked")
+    assert db_reconnect.is_connection_lost(Database.SQLITE, err) is False
+
+
+# --------------------------------------------------------------------------
+# recover_connection: bounded, and quiet while the database stays away
+# --------------------------------------------------------------------------
+
+
+def test_recover_connection_backs_off_after_a_failure() -> None:
+    """A database that stays down must not cost a connect timeout per query."""
+    attempts = []
+
+    def failing_reconnect(due_to_error=False):
+        attempts.append(due_to_error)
+        msg = "connection to server failed: Operation timed out"
+        raise psycopg.OperationalError(msg)
+
+    db = make_db()
+    db.reconnect = failing_reconnect
+
+    assert db.recover_connection() is False
+    assert db.recover_connection() is False
+    assert db.recover_connection() is False
+    assert len(attempts) == 1, "cooldown should suppress the follow-up attempts"
+    assert db._reconnect_blocked_until > 0
+
+
+def test_recover_connection_clears_the_backoff_once_it_succeeds() -> None:
+    db = make_db(_reconnect_blocked_until=0.0, _connection_down_logged=True)
+
+    def stub_reconnect(due_to_error=False):
+        db._Database__connected = True
+
+    db.reconnect = stub_reconnect
+
+    assert db.recover_connection() is True
+    assert db._reconnect_blocked_until == 0.0
+    assert db._connection_down_logged is False
+
+
+def test_force_disconnect_survives_a_broken_connection() -> None:
+    """The normal disconnect commits on the way out, which a dead socket cannot."""
+
+    class BrokenConnection:
+        def close(self) -> None:
+            msg = "the connection is closed"
+            raise psycopg.OperationalError(msg)
+
+        def commit(self) -> None:
+            msg = "the connection is closed"
+            raise psycopg.OperationalError(msg)
+
+    db = make_db(connection=BrokenConnection())
+    db._force_disconnect()
+
+    assert db.connection is None
+    assert db.is_connected() is False
+
+
+# --------------------------------------------------------------------------
+# ensure_connection: the seam the auto-import cycle uses
+# --------------------------------------------------------------------------
+
+
+def test_ensure_connection_accepts_a_live_connection() -> None:
+    db = make_db(connection=FakeConnection())
+    assert db.ensure_connection() is True
+
+
+def test_ensure_connection_recovers_a_dead_one() -> None:
+    dead = FakeConnection(fail_with=psycopg.OperationalError("server closed the connection"))
+    db = make_db(connection=dead)
+
+    def stub_reconnect(due_to_error=False):
+        # What the real connect() does on success, and what recover_connection
+        # reads back before reporting that the caller may query again.
+        db.connection = FakeConnection()
+        db._Database__connected = True
+
+    db.reconnect = stub_reconnect
+
+    assert db.ensure_connection() is True
+    assert db.connection is not dead
+    assert dead.closed is True

--- a/tests/test_db_reconnect.py
+++ b/tests/test_db_reconnect.py
@@ -93,9 +93,13 @@ def test_postgresql_connect_arms_keepalives_and_bounds_the_connect(monkeypatch) 
 
     assert captured["connect_timeout"] == 10
     assert captured["keepalives"] == 1
-    assert captured["keepalives_idle"] == 30
-    assert captured["keepalives_interval"] == 10
+    assert captured["keepalives_idle"] == 10
+    assert captured["keepalives_interval"] == 5
     assert captured["keepalives_count"] == 3
+    # Detection window, which is how long the HUD can stall on a dead link.
+    idle = captured["keepalives_idle"]
+    probes = captured["keepalives_interval"] * captured["keepalives_count"]
+    assert idle + probes <= 30
 
 
 def test_local_peer_connection_also_bounded(monkeypatch) -> None:

--- a/tests/test_explain_hud_queries.py
+++ b/tests/test_explain_hud_queries.py
@@ -1,0 +1,72 @@
+"""Tests for the plan review in tools/explain_hud_queries.
+
+The tool itself needs a PostgreSQL database to run against, so what is checked
+here is the part that decides what a plan is telling you -- against plan text
+of the shape PostgreSQL actually emits.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent.parent / "tools" / "explain_hud_queries.py"
+spec = importlib.util.spec_from_file_location("explain_hud_queries", TOOL)
+explain_hud_queries = importlib.util.module_from_spec(spec)
+sys.modules["explain_hud_queries"] = explain_hud_queries
+spec.loader.exec_module(explain_hud_queries)
+
+review = explain_hud_queries.review
+
+
+def test_a_sequential_scan_over_hudcache_is_flagged() -> None:
+    """The join that the compound index cannot serve is the whole question."""
+    plan = [
+        "Seq Scan on hudcache hc  (cost=0.00..91234.00 rows=2100000 width=520)",
+        "  Filter: ((gametypeid + 0) = ANY (...))",
+    ]
+
+    findings = review(plan)
+
+    assert any("sequential scan over hudcache" in f for f in findings)
+
+
+def test_a_sequential_scan_over_a_lookup_table_is_not_flagged() -> None:
+    """Gametypes is small and is supposed to be scanned; saying so is noise."""
+    assert review(["Seq Scan on gametypes gt2  (cost=0.00..1.30 rows=30 width=8)"]) == []
+
+
+def test_an_index_scan_is_not_flagged() -> None:
+    plan = ["Index Scan using hudcache_playerid_idx on hudcache hc  (cost=0.42..8.44 rows=1 width=520)"]
+
+    assert review(plan) == []
+
+
+def test_a_bad_row_estimate_is_flagged() -> None:
+    """A planner that expects 12 rows and gets 40000 picks the wrong join."""
+    plan = ["Nested Loop  (cost=0.85..123.45 rows=12 width=8) (actual time=0.02..812.33 rows=40000 loops=1)"]
+
+    findings = review(plan)
+
+    assert any("row estimate off by" in f for f in findings)
+
+
+def test_a_good_row_estimate_is_not_flagged() -> None:
+    plan = ["Hash Join  (cost=0.85..123.45 rows=900 width=8) (actual time=0.02..3.10 rows=1000 loops=1)"]
+
+    assert review(plan) == []
+
+
+def test_blocks_read_from_disk_are_flagged() -> None:
+    findings = review(["Buffers: shared hit=12 read=8140"])
+
+    assert any("8140 blocks read from disk" in f for f in findings)
+
+
+def test_an_all_cache_hit_is_not_flagged() -> None:
+    assert review(["Buffers: shared hit=12043 read=0"]) == []
+
+
+def test_an_empty_plan_says_nothing() -> None:
+    assert review([]) == []

--- a/tests/test_hud_read_caches.py
+++ b/tests/test_hud_read_caches.py
@@ -1,0 +1,165 @@
+"""Tests for the two HUD read caches, and for the round-trip count they buy.
+
+The HUD asked the database for a hand's gametype, and for the 24-hour boundary
+hand id, once per open table per hand dealt. Measured at twelve tables that was
+24 of the 41 statements a dealt hand cost -- pure latency over a VPN for two
+answers that cannot have moved in between. Caching them takes the cost of a
+secondary table refresh from three statements to one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fpdb_3_legacy import database_hud_stats
+
+# -- gametype per hand ----------------------------------------------------
+
+
+def test_a_hands_gametype_is_read_once(fresh_db) -> None:
+    """A hand's game is settled when the hand is written."""
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = ("PokerStars", "holdem", "hold", "ring", "nl", "h", 1, 2, 1, 2, "USD", 7, 0)
+
+    first = fresh_db.get_gameinfo_from_hid(42)
+    second = fresh_db.get_gameinfo_from_hid(42)
+
+    assert first == second
+    assert first["gametypeId"] == 7
+    assert cursor.execute.call_count == 1
+
+
+def test_a_different_hand_is_read_again(fresh_db) -> None:
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = ("PokerStars", "holdem", "hold", "ring", "nl", "h", 1, 2, 1, 2, "USD", 7, 0)
+
+    fresh_db.get_gameinfo_from_hid(42)
+    fresh_db.get_gameinfo_from_hid(43)
+
+    assert cursor.execute.call_count == 2
+
+
+def test_a_hand_that_is_not_there_yet_is_not_cached(fresh_db) -> None:
+    """Caching the miss would keep denying the hand after the import lands."""
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = None
+
+    assert fresh_db.get_gameinfo_from_hid(99) is None
+
+    cursor.fetchone.return_value = ("PokerStars", "holdem", "hold", "ring", "nl", "h", 1, 2, 1, 2, "USD", 7, 0)
+    assert fresh_db.get_gameinfo_from_hid(99)["gametypeId"] == 7
+    assert cursor.execute.call_count == 2
+
+
+def test_wiping_the_database_drops_the_cache(fresh_db) -> None:
+    """recreate_tables restarts hand ids from 1; a kept entry would be another hand's."""
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = ("PokerStars", "holdem", "hold", "ring", "nl", "h", 1, 2, 1, 2, "USD", 7, 0)
+    fresh_db.get_gameinfo_from_hid(1)
+
+    fresh_db.resetCache()
+    fresh_db.get_gameinfo_from_hid(1)
+
+    assert cursor.execute.call_count == 2
+
+
+# -- the 24-hour boundary -------------------------------------------------
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A time source the boundary cache can be walked forward against."""
+    now = [1000.0]
+    monkeypatch.setattr(database_hud_stats, "time", lambda: now[0])
+    return now
+
+
+def test_the_boundary_is_read_once_per_ttl(fresh_db, clock) -> None:
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = (5150,)
+
+    for _ in range(12):  # one per open table, as the HUD would
+        fresh_db.init_hud_stat_vars(30, 30)
+
+    assert cursor.execute.call_count == 1
+    assert fresh_db.hand_1day_ago == 5150
+
+
+def test_the_boundary_is_re_read_once_the_ttl_expires(fresh_db, clock) -> None:
+    """It is a sliding window; it has to move eventually."""
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = (5150,)
+    fresh_db.init_hud_stat_vars(30, 30)
+
+    clock[0] += database_hud_stats.HAND_1DAY_AGO_TTL + 1
+    cursor.fetchone.return_value = (5320,)
+    fresh_db.init_hud_stat_vars(30, 30)
+
+    assert cursor.execute.call_count == 2
+    assert fresh_db.hand_1day_ago == 5320
+
+
+def test_the_dates_are_still_recomputed_every_time(fresh_db, clock) -> None:
+    """Only the query is cached; the day windows are free and must stay fresh."""
+    fresh_db.connection = MagicMock()
+    fresh_db.connection.cursor.return_value.fetchone.return_value = (5150,)
+
+    fresh_db.init_hud_stat_vars(30, 30)
+    thirty_days = fresh_db.date_ndays_ago
+    fresh_db.init_hud_stat_vars(1, 1)
+
+    assert fresh_db.date_ndays_ago != thirty_days
+
+
+def test_wiping_the_database_drops_the_boundary(fresh_db, clock) -> None:
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.return_value = (5150,)
+    fresh_db.init_hud_stat_vars(30, 30)
+
+    fresh_db.resetCache()
+    fresh_db.init_hud_stat_vars(30, 30)
+
+    assert cursor.execute.call_count == 2
+
+
+# -- what it is worth, counted --------------------------------------------
+
+
+def test_the_cacheable_part_of_a_table_refresh_costs_nothing(fresh_db, clock) -> None:
+    """The regression guard for the win.
+
+    A secondary refresh -- what every open table other than the one that just
+    dealt pays, once per hand -- used to issue three statements: the boundary,
+    the gametype, and the statistics aggregate. Only the aggregate does work
+    that has to reach the server; the other two must now cost nothing, because
+    whatever they cost is multiplied by the number of open tables on the thread
+    that repaints the HUD.
+    """
+    fresh_db.connection = MagicMock()
+    cursor = fresh_db.connection.cursor.return_value
+    cursor.fetchone.side_effect = [
+        (5150,),  # the boundary
+        ("PokerStars", "holdem", "hold", "ring", "nl", "h", 1, 2, 1, 2, "USD", 7, 0),  # the gametype
+    ]
+
+    # The hand that dealt warms both, exactly as HUD_main's update path does.
+    fresh_db.init_hud_stat_vars(30, 30)
+    fresh_db.get_gameinfo_from_hid(42)
+    warmed = cursor.execute.call_count
+    assert warmed == 2, "the warm-up itself must still read both"
+
+    # Then eleven other open tables refresh against the same hand.
+    for _ in range(11):
+        fresh_db.init_hud_stat_vars(30, 30)
+        fresh_db.get_gameinfo_from_hid(42)
+
+    assert cursor.execute.call_count == warmed, "eleven tables must add no statements at all"

--- a/tests/test_hud_stats_batching.py
+++ b/tests/test_hud_stats_batching.py
@@ -105,6 +105,20 @@ def test_batched_stats_equal_per_hand_stats(imported_db) -> None:
         assert batched[hand] == one_at_a_time[hand], f"hand {hand} differs between the two paths"
 
 
+def test_batched_stats_preserve_string_hand_ids_from_zmq(imported_db) -> None:
+    """SQL returns integer ids, but HUD_main indexes results with ZMQ strings."""
+    db, _ = imported_db
+    hands = [str(hand) for hand in some_hands(db, 12)]
+
+    batched = db.get_stats_from_hands(hands, "ring", HUD_PARAMS, -1, 6)
+
+    assert set(batched) == set(hands)
+    for hand in hands:
+        expected = db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6)
+        assert expected
+        assert batched[hand] == expected
+
+
 def test_the_seat_of_each_player_survives_batching(imported_db) -> None:
     """Seat is the one column that is per-hand rather than per-player.
 

--- a/tests/test_hud_stats_batching.py
+++ b/tests/test_hud_stats_batching.py
@@ -1,0 +1,215 @@
+"""Equivalence tests for the batched HUD statistics query.
+
+Every open table refreshes its statistics on every hand dealt at any table, so
+the aggregate runs once per table per hand -- one round trip each, and over a
+VPN that is the largest cost the HUD imposes. get_stats_from_hands answers for
+several tables in one round trip.
+
+These are the tests that make that change trustworthy: the batched answer is
+compared against the per-hand answer, over real imported hands, stat by stat.
+A HUD is something a player bets money on, so "faster" is only worth having if
+it is first identical.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HANDS_DIR = REPO / "regression-test-files" / "cash" / "Stars" / "Flop"
+SITE = "PokerStars.COM"
+
+HUD_PARAMS = {
+    "stat_range": "A",
+    "agg_bb_mult": 1000,
+    "seats_style": "A",
+    "seats_cust_nums_low": 1,
+    "seats_cust_nums_high": 10,
+    "h_stat_range": "A",
+    "h_agg_bb_mult": 1000,
+    "h_seats_style": "A",
+    "h_seats_cust_nums_low": 1,
+    "h_seats_cust_nums_high": 10,
+}
+
+
+@pytest.fixture(scope="module")
+def imported_db():
+    """A database with the regression corpus imported, built once."""
+    from fpdb_3_legacy.Configuration import Config
+    from fpdb_3_legacy.Database import Database
+    from fpdb_3_legacy.Importer import Importer
+
+    if not HANDS_DIR.is_dir():
+        pytest.skip(f"no hand histories at {HANDS_DIR}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg = Config(file=str(REPO / "HUD_config.xml"))
+        params = cfg.get_db_parameters()
+        params.update(
+            {
+                "db-host": "localhost",
+                "db-server": "sqlite",
+                "db-backend": 4,
+                "db-databaseName": str(Path(tmpdir) / "batching.sqlite3"),
+                "db-path": "",
+            },
+        )
+        cfg.get_db_parameters = lambda: params
+
+        db = Database(cfg)
+        db.recreate_tables()
+        importer = Importer(None, {"threads": 1}, cfg, sql=db.sql)
+        importer.database = db
+        importer.setCallHud(False)
+        importer.setMode("bulk")
+        importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
+        importer.runImport()
+        db.connection.commit()
+
+        # importer stays referenced: its __del__ disconnects importer.database,
+        # which is this database.
+        yield db, importer
+        db.disconnect()
+
+
+def some_hands(db, count):
+    c = db.get_cursor()
+    c.execute(f"SELECT id FROM Hands ORDER BY id DESC LIMIT {int(count)}")
+    return [row[0] for row in c.fetchall()]
+
+
+def test_the_corpus_actually_imported(imported_db) -> None:
+    """Otherwise every equivalence below would pass on two empty dicts."""
+    db, _ = imported_db
+    hands = some_hands(db, 12)
+
+    assert len(hands) == 12
+    stats = db.get_stats_from_hand(hands[0], "ring", HUD_PARAMS, -1, 6)
+    assert stats, "the corpus must yield real statistics to compare"
+
+
+def test_batched_stats_equal_per_hand_stats(imported_db) -> None:
+    """The whole point: same numbers, fewer round trips."""
+    db, _ = imported_db
+    hands = some_hands(db, 12)
+
+    one_at_a_time = {hand: db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6) for hand in hands}
+    batched = db.get_stats_from_hands(hands, "ring", HUD_PARAMS, -1, 6)
+
+    assert set(batched) == set(one_at_a_time)
+    for hand in hands:
+        assert batched[hand] == one_at_a_time[hand], f"hand {hand} differs between the two paths"
+
+
+def test_the_seat_of_each_player_survives_batching(imported_db) -> None:
+    """Seat is the one column that is per-hand rather than per-player.
+
+    It comes from a max() over the join, so it is exactly what a missing hand
+    id in the GROUP BY would corrupt -- silently, and only when a player sits
+    at more than one of the batched tables.
+    """
+    db, _ = imported_db
+    hands = some_hands(db, 12)
+
+    batched = db.get_stats_from_hands(hands, "ring", HUD_PARAMS, -1, 6)
+
+    for hand in hands:
+        per_hand = db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6)
+        for player_id, stats in per_hand.items():
+            assert batched[hand][player_id]["seat"] == stats["seat"]
+
+
+def test_a_player_at_several_batched_tables_keeps_each_seat(imported_db) -> None:
+    """The corruption this guards against needs a shared player to appear."""
+    db, _ = imported_db
+    hands = some_hands(db, 12)
+    batched = db.get_stats_from_hands(hands, "ring", HUD_PARAMS, -1, 6)
+
+    seen: dict[int, list] = {}
+    for hand, stats in batched.items():
+        for player_id in stats:
+            seen.setdefault(player_id, []).append(hand)
+    shared = {p: hs for p, hs in seen.items() if len(hs) > 1}
+    if not shared:
+        pytest.skip("no player appears in more than one hand of this corpus")
+
+    for player_id, hand_ids in shared.items():
+        for hand in hand_ids:
+            expected = db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6)
+            assert batched[hand][player_id] == expected[player_id]
+
+
+def test_hands_of_different_gametypes_are_split_and_still_correct(imported_db) -> None:
+    """gametypeId is a query parameter, so mixed stakes cannot share one query."""
+    db, _ = imported_db
+    c = db.get_cursor()
+    c.execute("SELECT id, gametypeId FROM Hands ORDER BY id DESC LIMIT 40")
+    rows = c.fetchall()
+    by_type: dict = {}
+    for hand_id, gametype_id in rows:
+        by_type.setdefault(gametype_id, []).append(hand_id)
+    if len(by_type) < 2:
+        pytest.skip("corpus does not contain two gametypes")
+
+    hands = [group[0] for group in by_type.values()][:4]
+    batched = db.get_stats_from_hands(hands, "ring", HUD_PARAMS, -1, 6)
+
+    for hand in hands:
+        assert batched[hand] == db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6)
+
+
+def test_one_hand_batched_matches_that_hand_alone(imported_db) -> None:
+    db, _ = imported_db
+    hand = some_hands(db, 1)[0]
+
+    batched = db.get_stats_from_hands([hand], "ring", HUD_PARAMS, -1, 6)
+
+    assert batched[hand] == db.get_stats_from_hand(hand, "ring", HUD_PARAMS, -1, 6)
+
+
+def test_no_hands_asks_nothing(imported_db) -> None:
+    db, _ = imported_db
+    assert db.get_stats_from_hands([]) == {}
+
+
+def test_a_repeated_hand_is_asked_for_once(imported_db) -> None:
+    db, _ = imported_db
+    hand = some_hands(db, 1)[0]
+
+    batched = db.get_stats_from_hands([hand, hand, hand], "ring", HUD_PARAMS, -1, 6)
+
+    assert list(batched) == [hand]
+
+
+def test_an_unknown_hand_is_skipped_not_fatal(imported_db) -> None:
+    """A hand the HUD has but the database has not committed yet."""
+    db, _ = imported_db
+    known = some_hands(db, 1)[0]
+
+    batched = db.get_stats_from_hands([known, 99999999], "ring", HUD_PARAMS, -1, 6)
+
+    assert known in batched
+    assert 99999999 not in batched
+
+
+def test_the_session_range_falls_back_to_asking_per_hand(imported_db) -> None:
+    """Session stats read a different query per hand; there is nothing to batch."""
+    db, _ = imported_db
+    hands = some_hands(db, 4)
+    session_params = dict(HUD_PARAMS, stat_range="S", h_stat_range="S")
+
+    batched = db.get_stats_from_hands(hands, "ring", session_params, -1, 6)
+
+    for hand in hands:
+        assert batched[hand] == db.get_stats_from_hand(hand, "ring", session_params, -1, 6)
+
+
+def test_a_query_that_can_no_longer_be_rewritten_falls_back(imported_db) -> None:
+    """The rewrite must fail loudly into the slow path, never into wrong numbers."""
+    db, _ = imported_db
+
+    assert db._batched_aggregated_sql("SELECT 1 FROM Hands", 3) is None

--- a/tests/test_hud_stats_batching.py
+++ b/tests/test_hud_stats_batching.py
@@ -63,6 +63,10 @@ def imported_db():
         db = Database(cfg)
         db.recreate_tables()
         importer = Importer(None, {"threads": 1}, cfg, sql=db.sql)
+        # Importer creates its own connection before the fixture replaces it.
+        # POSIX lets TemporaryDirectory unlink that still-open SQLite file, but
+        # Windows keeps it locked, so close the superseded connection first.
+        importer.database.disconnect()
         importer.database = db
         importer.setCallHud(False)
         importer.setMode("bulk")
@@ -70,9 +74,10 @@ def imported_db():
         importer.runImport()
         db.connection.commit()
 
-        # importer stays referenced: its __del__ disconnects importer.database,
-        # which is this database.
+        # Keep importer referenced while the tests run: its __del__ would
+        # otherwise disconnect the shared database early.
         yield db, importer
+        importer.database = None
         db.disconnect()
 
 

--- a/tests/test_hud_stats_batching.py
+++ b/tests/test_hud_stats_batching.py
@@ -68,17 +68,29 @@ def imported_db():
         # Windows keeps it locked, so close the superseded connection first.
         importer.database.disconnect()
         importer.database = db
-        importer.setCallHud(False)
-        importer.setMode("bulk")
-        importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
-        importer.runImport()
-        db.connection.commit()
+        try:
+            importer.setCallHud(False)
+            importer.setMode("bulk")
+            importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
+            importer.runImport()
+            db.connection.commit()
 
-        # Keep importer referenced while the tests run: its __del__ would
-        # otherwise disconnect the shared database early.
-        yield db, importer
-        importer.database = None
-        db.disconnect()
+            # The worker connections are no longer needed after runImport and
+            # would keep the SQLite file locked through fixture teardown on
+            # Windows.
+            for writer_db in importer.writerdbs:
+                writer_db.disconnect()
+            importer.writerdbs.clear()
+
+            # Keep importer referenced while the tests run: its __del__ would
+            # otherwise disconnect the shared database early.
+            yield db, importer
+        finally:
+            importer.database = None
+            for writer_db in importer.writerdbs:
+                writer_db.disconnect()
+            importer.writerdbs.clear()
+            db.disconnect()
 
 
 def some_hands(db, count):

--- a/tests/test_hud_stats_batching.py
+++ b/tests/test_hud_stats_batching.py
@@ -13,8 +13,10 @@ it is first identical.
 
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -47,6 +49,14 @@ def imported_db():
         pytest.skip(f"no hand histories at {HANDS_DIR}")
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        sqlite_connections = []
+        sqlite_connect = sqlite3.connect
+
+        def tracked_sqlite_connect(*args, **kwargs):
+            connection = sqlite_connect(*args, **kwargs)
+            sqlite_connections.append(connection)
+            return connection
+
         cfg = Config(file=str(REPO / "HUD_config.xml"))
         params = cfg.get_db_parameters()
         params.update(
@@ -60,37 +70,44 @@ def imported_db():
         )
         cfg.get_db_parameters = lambda: params
 
-        db = Database(cfg)
-        db.recreate_tables()
-        importer = Importer(None, {"threads": 1}, cfg, sql=db.sql)
-        # Importer creates its own connection before the fixture replaces it.
-        # POSIX lets TemporaryDirectory unlink that still-open SQLite file, but
-        # Windows keeps it locked, so close the superseded connection first.
-        importer.database.disconnect()
-        importer.database = db
-        try:
-            importer.setCallHud(False)
-            importer.setMode("bulk")
-            importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
-            importer.runImport()
-            db.connection.commit()
+        with patch("sqlite3.connect", side_effect=tracked_sqlite_connect):
+            db = Database(cfg)
+            db.recreate_tables()
+            importer = Importer(None, {"threads": 1}, cfg, sql=db.sql)
+            # Importer creates its own connection before the fixture replaces it.
+            # POSIX lets TemporaryDirectory unlink that still-open SQLite file, but
+            # Windows keeps it locked, so close the superseded connection first.
+            importer.database.disconnect()
+            importer.database = db
+            try:
+                importer.setCallHud(False)
+                importer.setMode("bulk")
+                importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
+                importer.runImport()
+                db.connection.commit()
 
-            # The worker connections are no longer needed after runImport and
-            # would keep the SQLite file locked through fixture teardown on
-            # Windows.
-            for writer_db in importer.writerdbs:
-                writer_db.disconnect()
-            importer.writerdbs.clear()
+                # The worker connections are no longer needed after runImport and
+                # would keep the SQLite file locked through fixture teardown on
+                # Windows.
+                for writer_db in importer.writerdbs:
+                    writer_db.disconnect()
+                importer.writerdbs.clear()
 
-            # Keep importer referenced while the tests run: its __del__ would
-            # otherwise disconnect the shared database early.
-            yield db, importer
-        finally:
-            importer.database = None
-            for writer_db in importer.writerdbs:
-                writer_db.disconnect()
-            importer.writerdbs.clear()
-            db.disconnect()
+                # Keep importer referenced while the tests run: its __del__ would
+                # otherwise disconnect the shared database early.
+                yield db, importer
+            finally:
+                importer.database = None
+                for writer_db in importer.writerdbs:
+                    writer_db.disconnect()
+                importer.writerdbs.clear()
+                db.disconnect()
+
+                # Some import paths create short-lived Database objects outside
+                # Importer's public connection lists. Closing every connection
+                # opened by this fixture makes Windows teardown deterministic.
+                for connection in reversed(sqlite_connections):
+                    connection.close()
 
 
 def some_hands(db, count):

--- a/tests/test_legacy_autonotes_hwang_plo.py
+++ b/tests/test_legacy_autonotes_hwang_plo.py
@@ -1455,6 +1455,7 @@ def sqlite_autonote_db():
 
     db = Database.__new__(Database)
     db.sql = sql
+    db.backend = Database.SQLITE
     db.conn = conn
     db.panbulk = []
     db.get_cursor = conn.cursor

--- a/tests/test_packaging_dependencies.py
+++ b/tests/test_packaging_dependencies.py
@@ -46,6 +46,12 @@ def briefcase_app(pyproject) -> dict:
     return pyproject["tool"]["briefcase"]["app"]["fpdb"]
 
 
+@pytest.fixture(scope="module")
+def pyoxidizer_requirements() -> set[str]:
+    lines = (ROOT / "pyoxidizer-requirements.txt").read_text().splitlines()
+    return {line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")}
+
+
 def declared_to_briefcase(app: dict) -> set[str]:
     sections = (app, app.get("macOS", {}), app.get("windows", {}), app.get("linux", {}))
     return {requirement_name(spec) for section in sections for spec in section.get("requires", [])}
@@ -68,6 +74,18 @@ def test_a_deliberate_omission_is_still_a_real_dependency(pyproject) -> None:
     wanted = {requirement_name(spec) for spec in pyproject["project"]["dependencies"]}
 
     assert set(NOT_PACKAGED) <= wanted
+
+
+def test_pyoxidizer_dependency_file_matches_project(pyproject, pyoxidizer_requirements) -> None:
+    # pypoker-eval is installed separately with the Python-version exception
+    # needed by PyOxidizer's embedded Python 3.10.
+    wanted = {
+        spec
+        for spec in pyproject["project"]["dependencies"]
+        if requirement_name(spec) != "pypoker-eval"
+    }
+
+    assert pyoxidizer_requirements == wanted
 
 
 @pytest.mark.parametrize("package", ["beautifulsoup4", "pymysql", "defusedxml"])

--- a/tools/explain_hud_queries.py
+++ b/tools/explain_hud_queries.py
@@ -1,0 +1,217 @@
+"""Run EXPLAIN (ANALYZE, BUFFERS) on the queries the HUD issues per hand.
+
+The round-trip counter (tools/measure_hud_round_trips.py) answers how many
+statements the HUD sends. This answers what each one costs once it arrives --
+which only your own database, with your own volume of hands and your own
+planner statistics, can say. Run it against the database your HUD actually
+uses:
+
+    python tools/explain_hud_queries.py                  # the configured database
+    python tools/explain_hud_queries.py --hand 123456    # a specific hand
+
+It reports, per query, the total time, the rows the planner expected against the
+rows it got, and the buffers read. It then flags what usually matters:
+
+  * sequential scans over the big tables (HudCache, HandsPlayers, Hands)
+  * row estimates off by more than 10x, which is what makes a planner pick a
+    nested loop over a hash join and lose an order of magnitude
+  * blocks read from disk rather than cache
+
+PostgreSQL only: EXPLAIN ANALYZE with buffer accounting is what makes this
+worth running, and SQLite's EXPLAIN QUERY PLAN does not carry the same
+information. Nothing is written; every statement runs inside a transaction that
+is rolled back.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from fpdb_3_legacy.Configuration import Config  # noqa: E402
+from fpdb_3_legacy.Database import Database  # noqa: E402
+
+# Tables where a sequential scan is worth knowing about; the small lookup
+# tables (Gametypes, Sites) are supposed to be scanned.
+BIG_TABLES = ("hudcache", "handsplayers", "hands", "players")
+
+# How far a row estimate may be out before the plan is worth distrusting.
+ESTIMATE_TOLERANCE = 10
+
+DEFAULT_HUD_PARAMS = {
+    "stat_range": "A",
+    "agg_bb_mult": 1000,
+    "seats_style": "A",
+    "seats_cust_nums_low": 1,
+    "seats_cust_nums_high": 10,
+    "h_stat_range": "A",
+    "h_agg_bb_mult": 1000,
+    "h_seats_style": "A",
+    "h_seats_cust_nums_low": 1,
+    "h_seats_cust_nums_high": 10,
+}
+
+
+def latest_hand(db) -> int | None:
+    c = db.get_cursor()
+    c.execute("SELECT id FROM Hands ORDER BY id DESC LIMIT 1")
+    row = c.fetchone()
+    return row[0] if row else None
+
+
+def hero_of(db, hand_id: int) -> int:
+    """The hero's playerId, preferring one actually seated in ``hand_id``.
+
+    The aggregate splits players into hero and villains with different filters,
+    so a hero who is not at the table would explain a plan the HUD never runs.
+    """
+    c = db.get_cursor()
+    c.execute(
+        "SELECT p.id FROM Players p "
+        "INNER JOIN HandsPlayers hp ON hp.playerId = p.id "
+        "WHERE hp.handId = %s AND p.hero = TRUE LIMIT 1",
+        (hand_id,),
+    )
+    row = c.fetchone()
+    if row:
+        return int(row[0])
+    c.execute("SELECT id FROM Players WHERE hero = TRUE LIMIT 1")
+    row = c.fetchone()
+    return int(row[0]) if row else -1
+
+
+def hud_queries(db, hand_id: int, hero_id: int):
+    """The statements a single table's HUD refresh issues, with real parameters.
+
+    Returns (name, sql, params) triples in the order the HUD sends them.
+    """
+    gameinfo = db.get_gameinfo_from_hid(hand_id)
+    if gameinfo is None:
+        msg = f"hand {hand_id} has no game info"
+        raise SystemExit(msg)
+    gametype_id = gameinfo["gametypeId"]
+    placeholder = db.sql.query["placeholder"]
+
+    aggregated = db._inject_hud_chipev_columns(db.sql.query["get_stats_from_hand_aggregated"])
+    agg_params = (
+        hand_id,
+        hero_id,
+        "0000000",
+        DEFAULT_HUD_PARAMS["agg_bb_mult"],
+        DEFAULT_HUD_PARAMS["agg_bb_mult"],
+        gametype_id,
+        0,
+        10,
+        hero_id,
+        "0000000",
+        DEFAULT_HUD_PARAMS["h_agg_bb_mult"],
+        DEFAULT_HUD_PARAMS["h_agg_bb_mult"],
+        gametype_id,
+        0,
+        10,
+    )
+
+    gameinfo_sql = db.sql.query["get_gameinfo_from_hid"].replace("%s", placeholder)
+    return [
+        ("get_stats_from_hand_aggregated", aggregated, agg_params),
+        ("get_table_name", db.sql.query["get_table_name"], (hand_id,)),
+        ("get_gameinfo_from_hid", gameinfo_sql, (hand_id,)),
+        ("get_hand_1day_ago", db.sql.query["get_hand_1day_ago"], ()),
+    ]
+
+
+def explain(db, sql: str, params) -> list[str]:
+    """Return the EXPLAIN (ANALYZE, BUFFERS) plan lines for one statement."""
+    c = db.get_cursor()
+    c.execute("EXPLAIN (ANALYZE, BUFFERS) " + sql, params)
+    return [row[0] for row in c.fetchall()]
+
+
+def review(plan: list[str]) -> list[str]:
+    """Pick out of a plan the things usually worth acting on."""
+    findings = []
+    for line in plan:
+        lowered = line.lower()
+
+        if "seq scan on" in lowered:
+            table = lowered.split("seq scan on", 1)[1].strip().split()[0]
+            if table in BIG_TABLES:
+                findings.append(f"sequential scan over {table}: {line.strip()}")
+
+        estimate = re.search(r"rows=(\d+).*?rows=(\d+)", line)
+        if estimate and "actual" in lowered:
+            expected, actual = int(estimate.group(1)), int(estimate.group(2))
+            worse = max(expected, actual)
+            better = max(min(expected, actual), 1)
+            if worse / better > ESTIMATE_TOLERANCE:
+                findings.append(f"row estimate off by {worse // better}x: {line.strip()}")
+
+        read = re.search(r"Buffers:.*read=(\d+)", line)
+        if read and int(read.group(1)) > 0:
+            findings.append(f"{read.group(1)} blocks read from disk: {line.strip()}")
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=None, help="HUD_config.xml to use")
+    parser.add_argument("--hand", type=int, default=None, help="hand id to explain against")
+    parser.add_argument("--plans", action="store_true", help="print the full plans, not just the findings")
+    args = parser.parse_args()
+
+    cfg = Config(file=args.config) if args.config else Config()
+    db = Database(cfg)
+    try:
+        if db.backend != Database.PGSQL:
+            print(f"This needs PostgreSQL; the configured backend is {db.get_backend_name()}.")
+            return 1
+
+        hand_id = args.hand or latest_hand(db)
+        if hand_id is None:
+            print("No hands in the database.")
+            return 1
+
+        hero_id = hero_of(db, hand_id)
+        print(f"Explaining against hand {hand_id} (hero id {hero_id}) on {db.database}@{db.host}\n")
+
+        all_findings = []
+        for name, sql, params in hud_queries(db, hand_id, hero_id):
+            plan = explain(db, sql, params)
+            total = next((line for line in plan if line.startswith("Execution Time")), "")
+            print(f"--- {name} {total}")
+            if args.plans:
+                for line in plan:
+                    print(f"    {line}")
+            findings = review(plan)
+            for finding in findings:
+                print(f"  ! {finding}")
+            if not findings:
+                print("  nothing to flag")
+            print()
+            all_findings.extend(findings)
+
+        # Nothing here should have written anything, but EXPLAIN ANALYZE does
+        # execute the statement, so end the transaction explicitly.
+        db.rollback(force=True)
+
+        print(f"{len(all_findings)} thing(s) flagged.")
+        if any("hudcache" in f for f in all_findings):
+            print(
+                "\nHudCache showing up is expected to be the interesting one: the aggregate\n"
+                "joins it on playerId, but HudCache_Compound_idx leads with gametypeId, and\n"
+                "the query's `hc.gametypeId+0` (a MySQL hint to avoid an index) stops\n"
+                "PostgreSQL using an index on that column at all.",
+            )
+    finally:
+        db.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/explain_hud_queries.py
+++ b/tools/explain_hud_queries.py
@@ -204,9 +204,10 @@ def main() -> int:
         if any("hudcache" in f for f in all_findings):
             print(
                 "\nHudCache showing up is expected to be the interesting one: the aggregate\n"
-                "joins it on playerId, but HudCache_Compound_idx leads with gametypeId, and\n"
-                "the query's `hc.gametypeId+0` (a MySQL hint to avoid an index) stops\n"
-                "PostgreSQL using an index on that column at all.",
+                "already uses hudcache_playerid_idx for the join. If rows are then removed\n"
+                "by the gametype filter, inspect the hashed SubPlan: resolving the similar\n"
+                "gametype ids in the application can turn that filter into an index condition.\n"
+                "Measured plans show that removing `hc.gametypeId+0` alone does not fix it.",
             )
     finally:
         db.disconnect()

--- a/tools/measure_hud_round_trips.py
+++ b/tools/measure_hud_round_trips.py
@@ -1,0 +1,184 @@
+"""Measure how many database round trips the HUD makes per hand and per table.
+
+Over a VPN a statement costs one network latency whatever the server does with
+it, so what decides how the HUD feels is the *count*, which no CPU-time
+benchmark reports. This imports a directory of regression hands into a throwaway
+SQLite database, replays the sequence of Database calls HUD_main makes for one
+dealt hand with N tables open -- modelling its TTLCaches, so the number is
+statements that would reach the network rather than statements the code writes
+-- and prints the profile.
+
+    python tools/measure_hud_round_trips.py [--tables 12]
+
+The round-trip count is a property of the code path rather than of the data, so
+the small regression corpus answers the question as well as a season of real
+history would, and parses reliably.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Must be set before Database opens a connection: that is where the counting
+# wrapper is installed.
+os.environ["FPDB_DB_PROFILE"] = "1"
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+os.chdir(REPO)
+
+from fpdb_3_legacy import db_profile  # noqa: E402
+from fpdb_3_legacy.Configuration import Config  # noqa: E402
+
+HANDS_DIR = REPO / "regression-test-files" / "cash" / "Stars" / "Flop"
+SITE = "PokerStars.COM"
+DEFAULT_TABLES = 12
+RTTS_MS = (1, 20, 40, 80)
+
+
+def build_config(tmpdir: str) -> Config:
+    """A config pointed at a throwaway SQLite database."""
+    cfg = Config(file="HUD_config.xml")
+    params = cfg.get_db_parameters()
+    params.update(
+        {
+            "db-host": "localhost",
+            "db-server": "sqlite",
+            "db-backend": 4,
+            "db-databaseName": str(Path(tmpdir) / "measure.sqlite3"),
+            "db-path": "",
+        },
+    )
+    cfg.get_db_parameters = lambda: params
+    return cfg
+
+
+def populate(cfg: Config):
+    """Build a database with the regression hands imported into it.
+
+    Returns:
+        The database and the importer. The importer must be kept alive by the
+        caller: its ``__del__`` disconnects ``importer.database``, which is the
+        very database being returned here.
+    """
+    from fpdb_3_legacy.Database import Database
+    from fpdb_3_legacy.Importer import Importer
+
+    db = Database(cfg)
+    db.recreate_tables()
+
+    importer = Importer(None, {"threads": 1}, cfg, sql=db.sql)
+    importer.database = db
+    importer.setCallHud(False)
+    importer.setMode("bulk")
+    importer.addBulkImportImportFileOrDir(str(HANDS_DIR), site=SITE)
+    importer.runImport()
+    db.connection.commit()
+    return db, importer
+
+
+class HudReplay:
+    """Replays HUD_main's per-batch database calls, TTLCaches included.
+
+    Modelling the caches is what separates "statements the code issues" from
+    "statements that reach the network", and only the second is the answer to
+    how the HUD behaves over a VPN.
+    """
+
+    def __init__(self, db, hud_params, table_hands) -> None:
+        self.db = db
+        self.hud_params = hud_params
+        self.table_hands = table_hands
+        self._table_info: dict[int, object] = {}
+        self._positions: dict[int, object] = {}
+
+    def _table_info_for(self, hand_id):
+        if hand_id not in self._table_info:
+            self._table_info[hand_id] = self.db.get_table_info(hand_id)
+        return self._table_info[hand_id]
+
+    def _positions_for(self, hand_id):
+        if hand_id not in self._positions:
+            self._positions[hand_id] = self.db.get_hand_positions(hand_id)
+        return self._positions[hand_id]
+
+    def _stats_for(self, hand_id) -> None:
+        self.db.init_hud_stat_vars(self.hud_params["hud_days"], self.hud_params["h_hud_days"])
+        self.db.get_stats_from_hand(hand_id, "ring", self.hud_params, -1, 6)
+
+    def batch(self, active_hand) -> None:
+        """One drained batch: the table that dealt, then every other table."""
+        with db_profile.scope("batch"):
+            with db_profile.scope("hand"), db_profile.scope("update_hud"):
+                self._table_info_for(active_hand)
+                self._stats_for(active_hand)
+                self._positions_for(active_hand)
+                self.db.get_seat_players(active_hand)
+                self.db.get_table_min_stack_bb(active_hand)
+                self.db.get_cards(active_hand)
+                self.db.get_common_cards(active_hand)
+
+            for other_hand in self.table_hands[1:]:
+                with db_profile.scope("secondary_refresh"):
+                    self._table_info_for(other_hand)
+                    self._stats_for(other_hand)
+                    self._positions_for(other_hand)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tables", type=int, default=DEFAULT_TABLES, help="open tables to simulate")
+    args = parser.parse_args()
+    tables = max(1, args.tables)
+
+    if not HANDS_DIR.is_dir():
+        print(f"no hand histories at {HANDS_DIR}")
+        return 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg = build_config(tmpdir)
+        db, importer = populate(cfg)  # importer kept alive: see populate()
+
+        c = db.connection.cursor()
+        # Each open table shows its own last hand, so give every table one.
+        c.execute("SELECT id FROM Hands ORDER BY id DESC LIMIT ?", (tables,))
+        table_hands = [r[0] for r in c.fetchall()]
+        if len(table_hands) < tables:
+            print(f"only {len(table_hands)} hands imported, need {tables}")
+            return 1
+
+        db.get_hero_player_ids()
+        replay = HudReplay(db, cfg.get_hud_ui_parameters(), table_hands)
+        profile = db_profile.get_profile()
+
+        # The first batch pays the cache misses; the ones after it are what the
+        # player actually lives with, hand after hand.
+        profile.reset()
+        replay.batch(table_hands[0])
+        cold = profile.by_scope["batch"].queries
+
+        profile.reset()
+        for _ in range(3):
+            replay.batch(table_hands[0])
+        steady = profile.by_scope["batch"].queries_per_entry
+
+        print()
+        print(f"=== one hand dealt, {tables} tables open ===")
+        print(f"first batch (cold caches): {cold} statements")
+        print(profile.report())
+        print()
+        print(f"steady state: {steady:.0f} statements per hand dealt")
+        for rtt in RTTS_MS:
+            print(f"  at {rtt:>3}ms RTT: {steady * rtt / 1000:.2f}s per hand on the UI thread")
+
+        db.disconnect()
+        del importer
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/measure_hud_round_trips.py
+++ b/tools/measure_hud_round_trips.py
@@ -122,10 +122,15 @@ class HudReplay:
                 self.db.get_cards(active_hand)
                 self.db.get_common_cards(active_hand)
 
-            for other_hand in self.table_hands[1:]:
+            # Every other open table, whose statistics HUD_main now fetches for
+            # all of them at once (_batch_secondary_stats).
+            others = self.table_hands[1:]
+            with db_profile.scope("batched_stats"):
+                self.db.init_hud_stat_vars(self.hud_params["hud_days"], self.hud_params["h_hud_days"])
+                self.db.get_stats_from_hands(others, "ring", self.hud_params, -1, 6)
+            for other_hand in others:
                 with db_profile.scope("secondary_refresh"):
                     self._table_info_for(other_hand)
-                    self._stats_for(other_hand)
                     self._positions_for(other_hand)
 
 
@@ -144,11 +149,22 @@ def main() -> int:
         db, importer = populate(cfg)  # importer kept alive: see populate()
 
         c = db.connection.cursor()
-        # Each open table shows its own last hand, so give every table one.
-        c.execute("SELECT id FROM Hands ORDER BY id DESC LIMIT ?", (tables,))
+        # Each open table shows its own last hand, so give every table one --
+        # all at the same stake, because that is what multi-tabling is, and
+        # because gametype is what decides whether tables can share a
+        # statistics query. Drawing from the regression corpus at large would
+        # give twelve different games, which no session ever looks like.
+        c.execute(
+            "SELECT gametypeId FROM Hands GROUP BY gametypeId ORDER BY COUNT(*) DESC LIMIT 1",
+        )
+        row = c.fetchone()
+        if row is None:
+            print("no hands imported")
+            return 1
+        c.execute("SELECT id FROM Hands WHERE gametypeId = ? ORDER BY id DESC LIMIT ?", (row[0], tables))
         table_hands = [r[0] for r in c.fetchall()]
         if len(table_hands) < tables:
-            print(f"only {len(table_hands)} hands imported, need {tables}")
+            print(f"only {len(table_hands)} hands at the busiest stake, need {tables}")
             return 1
 
         db.get_hero_player_ids()


### PR DESCRIPTION
## Problem

The PostgreSQL database is accessed remotely over a VPN. When the tunnel drops, the TCP socket can remain in a black hole: the next query blocks in the kernel retransmission loop, never returns, and never raises an exception. The HUD then freezes on the Qt thread, auto-import stalls, and neither recovers when connectivity returns.

## Reliability

### Bound connection failures — `a1fca458`, `f9c74a3d`

PostgreSQL now uses `connect_timeout` and TCP keepalives (`idle=10`, `interval=5`, `count=3`). A dead peer is detected in roughly 25 seconds instead of hanging indefinitely. MySQL connections also receive a bounded connect timeout.

### Reconnection — `a1fca458`

`reconnect()` was broken and unused: a positional call no longer matched the current `connect()` signature, so the database name was passed as the port and the user as the database. The call now uses named arguments and is wired through `recover_connection()`, with a 10-second cooldown so an unreachable database does not consume one full connect timeout per query.

Read-only HUD queries are replayed once after reconnection through `reconnect_on_connection_loss`. PostgreSQL recovery is limited to connection SQLSTATEs, terminated sessions, and explicit network-loss markers; query cancellation and `statement_timeout` are not reconnected or replayed. Auto-import transactions cannot be replayed safely, so the connection is checked between import cycles instead.

### Keep the UI responsive — `0ac7eb58`

`HUD_main` now opens a circuit breaker on the first lost connection. It stops issuing queries and delegates reconnection to a `DbRecoveryWorker`, which pays the bounded connect timeout outside the Qt UI thread. HUD updates resume after the database returns.

Table-info lookup no longer silently turns a connection failure into “hand not committed yet.” Auto-import reports the outage and recovery once each. Stop blocks the UI for at most five seconds; if the worker is still active, cleanup continues asynchronously while the Importer, HUD process, and global lock remain exclusively owned until that worker exits.

## Performance

For a remote database, network round trips dominate query CPU time. Optional profiling (`FPDB_DB_PROFILE=1`) now counts and attributes those round trips.

Measured by `tools/measure_hud_round_trips.py` with 12 tables at one stake:

| Version | Queries per dealt hand | At 40 ms RTT |
|---|---:|---:|
| Before | 41 | 1.64 s |
| After read caches (`446defb8`) | 17 | 0.68 s |
| After batching (`3a14d517`) | **7** | **0.28 s** |

- `get_hand_1day_ago`: the sliding 24-hour boundary is refreshed at most every five minutes.
- `get_gameinfo_from_hid`: immutable hand gametype data is cached by hand ID. Misses are deliberately not cached because the importer may not have committed the hand yet.
- `get_stats_from_hand_aggregated`: all refreshing tables are now answered by one batched query when their parameters match. Integer IDs returned by SQL are mapped back to the caller's original ZMQ string keys.

Both caches are cleared by `resetCache`; `recreate_tables` restarts IDs at 1, so retaining entries would serve data for different hands.

The batched aggregate rewrites the existing query instead of duplicating roughly 300 lines of statistics SQL. Every required rewrite is validated; if the query shape changes, execution falls back to the per-hand path. A failed PostgreSQL batch is rolled back before that fallback so the first per-table query does not inherit an aborted transaction.

## PostgreSQL EXPLAIN results

The benchmark used PostgreSQL 16 in a container, the real fpdb schema and imported corpus, then grew `HudCache` to 1.07 million rows / 1.5 GB with roughly 365 rows per seated player. On the original 955-row table PostgreSQL correctly prefers sequential scans, so that fixture is too small to answer the indexing question.

The initial hypothesis was wrong: `hc.gametypeId+0` does **not** prevent PostgreSQL from using an index in this query.

| Variant | Median | Rows discarded per player |
|---|---:|---:|
| Current (`+0`, subquery) | 1.42 ms | 378 |
| Without `+0` | 1.09 ms | 378 |
| Without `+0` + `(playerId, gametypeId)` index | 1.06 ms | 378 |
| With `+0` + composite index | 1.03 ms | 378 |

All four plans discard the same 378 rows, and none performs a sequential scan: the join already uses `hudcache_playerid_idx`. Removing `+0` would change the most sensitive statistics query without fixing the plan.

The real blocker is the uncorrelatable “similar gametypes” subquery. PostgreSQL evaluates it as a hashed SubPlan and applies it as a filter only after fetching `HudCache` rows from the heap. An index cannot use values the planner only obtains at execution time.

Resolving that set in the application and passing the IDs as an array turns it into an index condition:

```
Index Cond: ((playerid = p.id) AND (gametypeid = ANY ('{3,4,7,...,60}'::smallint[])))
```

| Variant | Median | HudCache buffers | Rows discarded |
|---|---:|---:|---:|
| Current | 1.07 ms | 2,414 | 378 |
| Gametype IDs passed as an array | 0.78 ms | **502** | **0** |

That touches 4.8× fewer `HudCache` buffers and uses the existing `HudCache_Compound_idx`; no new index is required.

The warm-cache gain is only about 0.3 ms per aggregate, and batching has already reduced twelve aggregates to one. The change matters most when the database exceeds RAM or the cache is cold. It has therefore been documented, not implemented, pending confirmation on the production database.

The complete methodology, fixture reconstruction SQL, implementation outline, and discarded alternatives are in `HUD_DB_PERFORMANCE_PLAN.md`.

## Tests

60 tests were added. The default suite reports **6,907 passed** and the `qt` suite **478 passed** (468 before this branch).

The three remaining failures are pre-existing on `bigbang` and were confirmed independently:

- `test_backfill_database_preview`
- `test_every_runtime_dependency`
- `test_a_boardless_game_still_builds_its_pots`

`tests/test_hud_stats_batching.py` compares batched and per-hand results stat by stat on an imported corpus, including a player seated at several batched tables.