### PR TITLE
fix(hud): keep remote database reads off the Qt thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,10 +453,13 @@ jobs:
           sudo apt-get install -y libegl1 libgl1 libglib2.0-0 libdbus-1-3 libxkbcommon0
       - name: Install database test dependencies
         run: uv pip install --system -e ".[test-no-gui]"
-      - name: Exercise live schemas and cross-backend migration
+      - name: Exercise live schemas, HUD transactions, and cross-backend migration
         env:
           FPDB_TEST_DATABASES: postgresql,mysql
-        run: python -m pytest -q -p no:pytest-qt test/test_database_backend_integration.py
+        run: >-
+          python -m pytest -q -p no:pytest-qt
+          test/test_database_backend_integration.py
+          test/test_hud_postgresql_integration.py
 
   build:
     runs-on: ${{ matrix.os }}

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -244,6 +244,7 @@ class HudReadWorker(QThread):
                 if pending is None:
                     break
 
+            assert service is not None
             try:
                 snapshot = service.read_batch(pending, progress_callback=self.snapshot_ready.emit)
             except Exception as exc:
@@ -1166,8 +1167,8 @@ class HudMain(QObject):
 
     def _initialize_hero_data(self) -> None:
         """Initialize hero data from the configuration."""
-        self.hero: dict[int, str] = {}
-        self.hero_ids: dict[int, int] = {}
+        self.hero = {}
+        self.hero_ids = {}
         enabled_sites = self.config.get_supported_sites()
         if not enabled_sites:
             log.error("No enabled sites found")

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -27,6 +27,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from optparse import Values
 from pathlib import Path
+from queue import Empty, Queue
 from typing import Any
 
 import zmq as _zmq
@@ -42,6 +43,13 @@ from qt_material import apply_stylesheet
 
 from fpdb_3_legacy import Aux_Base, Configuration, Database, Deck, Hud, Options, db_profile
 from fpdb_3_legacy.db_reconnect import is_connection_lost
+from fpdb_3_legacy.hud_read_service import (
+    HudBatchReadRequest,
+    HudBatchSnapshot,
+    HudReadService,
+    HudReplayDatabase,
+    HudTableReadContext,
+)
 from fpdb_3_legacy.HudStatsPersistence import get_hud_stats_persistence
 from fpdb_3_legacy.loggingFpdb import get_logger, hud_trace
 from fpdb_3_legacy.SmartHudManager import RestartReason, get_smart_hud_manager
@@ -66,6 +74,10 @@ DB_RECOVERY_INTERVAL_S = 5.0
 # Keep a generous tail and reduce it to the latest hand per table once the
 # database is available again and table identities can be queried safely.
 MAX_DEFERRED_HANDS = 1000
+MAX_PENDING_HANDS = 1000
+DB_BATCH_RETRY_MS = 5000
+DB_BATCH_RETRY_BACKOFF_MS = 30000
+DB_BATCH_RETRY_BACKOFF_AFTER = 5
 
 
 @dataclass
@@ -80,6 +92,7 @@ class HUDCreationArgs:
     game_type: str
     stat_dict: dict[str, Any]
     cards: dict[str, Any]
+    hand_instance: Any = None
 
 
 class ZMQWorker(QThread):
@@ -150,6 +163,111 @@ class DbRecoveryWorker(QThread):
         # connect timeout, but shutdown must not hang on it either.
         if not self.wait(15000):
             log.warning("Database recovery worker did not stop in time")
+
+
+class HudReadWorker(QThread):
+    """Own the HUD database connection and execute read batches off the UI thread."""
+
+    ready = Signal(int)
+    snapshot_ready = Signal(object)
+    unavailable = Signal(str)
+    batch_failed = Signal(object, str)
+
+    def __init__(
+        self,
+        config: Configuration.Config,
+        parent: QObject | None = None,
+        db_factory: Callable[..., Any] = Database.Database,
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.db_factory = db_factory
+        self._requests: Queue[HudBatchReadRequest | None] = Queue()
+        self._stopping = threading.Event()
+
+    def submit(self, request: HudBatchReadRequest) -> None:
+        """Queue one immutable request from the Qt thread."""
+        self._requests.put(request)
+
+    @staticmethod
+    def _configure_session(database: Database.Database) -> None:
+        """Bound only the worker's PostgreSQL statements, never the importer."""
+        if database.backend != Database.Database.PGSQL:
+            return
+        with contextlib.suppress(Exception):
+            database.connection.rollback()
+        cursor = database.connection.cursor()
+        try:
+            cursor.execute("SET statement_timeout = 10000")
+            cursor.execute("SET lock_timeout = 2000")
+            cursor.execute("SET idle_in_transaction_session_timeout = 30000")
+            database.connection.commit()
+        finally:
+            cursor.close()
+
+    @staticmethod
+    def _close_database(database: Database.Database | None) -> None:
+        if database is None:
+            return
+        with contextlib.suppress(Exception):
+            database.close_connection()
+
+    def run(self) -> None:
+        """Connect, process one request at a time, and reconnect in this thread."""
+        database: Database.Database | None = None
+        service: HudReadService | None = None
+        pending: HudBatchReadRequest | None = None
+        unavailable_announced = False
+        while not self._stopping.is_set():
+            if database is None:
+                try:
+                    database = self.db_factory(self.config)
+                    self._configure_session(database)
+                    service = HudReadService(self.config, database)
+                except Exception as exc:
+                    self._close_database(database)
+                    database = None
+                    service = None
+                    if not unavailable_announced:
+                        self.unavailable.emit(str(exc))
+                        unavailable_announced = True
+                    self._stopping.wait(DB_RECOVERY_INTERVAL_S)
+                    continue
+                unavailable_announced = False
+                self.ready.emit(database.backend)
+
+            if pending is None:
+                try:
+                    pending = self._requests.get(timeout=0.2)
+                except Empty:
+                    continue
+                if pending is None:
+                    break
+
+            try:
+                snapshot = service.read_batch(pending, progress_callback=self.snapshot_ready.emit)
+            except Exception as exc:
+                if database is not None and is_connection_lost(database.backend, exc):
+                    if not unavailable_announced:
+                        self.unavailable.emit(str(exc))
+                        unavailable_announced = True
+                    self._close_database(database)
+                    database = None
+                    service = None
+                    continue
+                self.batch_failed.emit(pending, str(exc))
+            else:
+                self.snapshot_ready.emit(snapshot)
+            pending = None
+
+        self._close_database(database)
+
+    def stop(self) -> None:
+        """Wake the queue and wait for the bounded statement timeout."""
+        self._stopping.set()
+        self._requests.put(None)
+        if not self.wait(15000):
+            log.warning("HUD read worker did not stop in time")
 
 
 class ZMQReceiver(QObject):
@@ -397,11 +515,6 @@ class HudMain(QObject):
             getattr(options, "logging_level", "Not set"),
         )
         try:
-            # Connecting to the database
-            log.info("Connecting to database...")
-            self.db_connection = Database.Database(self.config)
-            log.info("Database connection successful")
-
             # HUD dictionary and parameters
             self.hud_dict: dict[str, Hud.Hud] = {}
             # Session-only profile choices made from an individual table menu.
@@ -414,12 +527,20 @@ class HudMain(QObject):
             # HUD exactly once, without re-running create/update on a duplicate.
             self._last_processed_hands: dict[str, str] = {}
             self.blacklist: list[Any] = []
-            # Circuit breaker around the database. Every read below runs on the
-            # UI thread, so one unreachable database would otherwise freeze the
-            # HUD once per hand for as long as the outage lasts. Once a read
-            # fails on a lost connection we stop querying entirely and hand the
-            # connection to DbRecoveryWorker until it reports the link is back.
-            self._db_available = True
+            # The real connection is created and owned by HudReadWorker.  The
+            # UI only ever sees an in-memory replay facade for completed reads.
+            empty_snapshot = HudBatchSnapshot(0, (), (), {}, {}, {}, {}, {})
+            self.db_connection = HudReplayDatabase(empty_snapshot, 0)
+            self._db_backend = 0
+            self._db_available = False
+            self._db_batch_inflight = False
+            self._db_batch_sequence = 0
+            self._last_applied_sequence = 0
+            self._last_applied_revision = -1
+            self._db_progress_refreshed: set[str] = set()
+            self._db_consecutive_failures = 0
+            self._prepared_hands: dict[str, Any] = {}
+            self._last_table_info: dict[str, tuple] = {}
             self._db_recovery_worker: DbRecoveryWorker | None = None
             # Statements counted at the end of the previous batch, so each batch
             # can report its own cost rather than the running total.
@@ -451,6 +572,13 @@ class HudMain(QObject):
             self._hand_batch_timer.setSingleShot(True)
             self._hand_batch_timer.setInterval(HAND_BATCH_INTERVAL_MS)
             self._hand_batch_timer.timeout.connect(self._drain_pending_hands)
+
+            self._db_worker: HudReadWorker | None = HudReadWorker(self.config, parent=self)
+            self._db_worker.ready.connect(self._on_db_worker_ready)
+            self._db_worker.snapshot_ready.connect(self._on_db_snapshot)
+            self._db_worker.unavailable.connect(self._on_db_worker_unavailable)
+            self._db_worker.batch_failed.connect(self._on_db_batch_failed)
+            self._db_worker.start()
 
             # Stats persistence initialization
             self.stats_persistence = get_hud_stats_persistence()
@@ -527,6 +655,12 @@ class HudMain(QObject):
         """
         if not is_connection_lost(self.db_connection.backend, exc):
             return False
+        if getattr(self, "_db_worker", None) is not None:
+            # Runtime SQL recovery belongs exclusively to HudReadWorker. The
+            # Qt side holds only HudReplayDatabase, which cannot and must not
+            # be handed to the legacy DbRecoveryWorker.
+            log.error("Unexpected connection-style error from HUD replay data: %s", exc)
+            return False
         if self._db_available:
             log.error("Database unreachable; HUD updates are paused until it returns (%s)", exc)
             self._db_available = False
@@ -534,7 +668,10 @@ class HudMain(QObject):
         return True
 
     def _start_db_recovery(self) -> None:
-        """Hand the connection to the recovery thread for the outage."""
+        """Legacy synchronous-test recovery; runtime uses HudReadWorker."""
+        if not hasattr(self.db_connection, "recover_connection"):
+            log.error("Refusing legacy DB recovery for an in-memory HUD replay facade")
+            return
         if self._db_recovery_worker is not None and self._db_recovery_worker.isRunning():
             return
         worker = DbRecoveryWorker(self.db_connection, parent=self)
@@ -554,6 +691,217 @@ class HudMain(QObject):
             self._pending_hands.extend(deferred)
             if not self._hand_batch_timer.isActive():
                 self._hand_batch_timer.start()
+
+    def _on_db_worker_ready(self, backend: int) -> None:
+        """Resume submissions after the worker connected or reconnected."""
+        recovered = not self._db_available
+        self._db_backend = backend
+        self._db_available = True
+        if recovered:
+            log.info("HUD database worker is ready; updates resumed")
+        deferred, self._deferred_hands = self._deferred_hands, []
+        if deferred:
+            self._pending_hands.extend(deferred)
+        if self._pending_hands and not self._db_batch_inflight and not self._hand_batch_timer.isActive():
+            self._hand_batch_timer.start()
+
+    def _on_db_worker_unavailable(self, message: str) -> None:
+        """Open the UI-side breaker without touching the worker's connection."""
+        if self._db_available:
+            log.error("HUD database unavailable; updates remain responsive (%s)", message)
+        else:
+            log.debug("HUD database still unavailable: %s", message)
+        self._db_available = False
+
+    def _retry_hands(self, hand_ids: tuple[str, ...]) -> None:
+        if self._shutdown_started:
+            return
+        for hand_id in hand_ids:
+            with contextlib.suppress(ValueError):
+                self._pending_hands.remove(hand_id)
+            self._pending_hands.append(hand_id)
+        if self._db_available and not self._db_batch_inflight and not self._hand_batch_timer.isActive():
+            self._hand_batch_timer.start()
+
+    def _on_db_batch_failed(self, request: HudBatchReadRequest, message: str) -> None:
+        """Retry an ordinary timeout later while the Qt loop stays available."""
+        self._db_batch_inflight = False
+        self._db_consecutive_failures += 1
+        retry_ms = (
+            DB_BATCH_RETRY_BACKOFF_MS
+            if self._db_consecutive_failures > DB_BATCH_RETRY_BACKOFF_AFTER
+            else DB_BATCH_RETRY_MS
+        )
+        log.warning(
+            "HUD database batch %d failed (%d consecutive failure(s)); "
+            "the loading HUD stays visible and stats will retry in %d seconds: %s",
+            request.sequence,
+            self._db_consecutive_failures,
+            retry_ms // 1000,
+            message,
+        )
+        if self._db_consecutive_failures == DB_BATCH_RETRY_BACKOFF_AFTER + 1:
+            log.error(
+                "HUD database remains too slow after %d batches; reducing retries to every %d seconds",
+                self._db_consecutive_failures,
+                retry_ms // 1000,
+            )
+        QTimer.singleShot(retry_ms, lambda hands=request.hand_ids: self._retry_hands(hands))
+
+    def _table_read_contexts(self) -> tuple[HudTableReadContext, ...]:
+        contexts = []
+        for temp_key, hud in list(self.hud_dict.items()):
+            last_hand_id = self._last_processed_hands.get(temp_key)
+            if not last_hand_id:
+                continue
+            table_info = self._last_table_info.get(temp_key) or self.cache.get(last_hand_id)
+            if table_info is None:
+                continue
+            needs_mucked = any(type(aux).__module__.rsplit(".", 1)[-1] == "Mucked" for aux in hud.aux_windows)
+            contexts.append(
+                HudTableReadContext(
+                    temp_key=temp_key,
+                    last_hand_id=last_hand_id,
+                    hud_params=dict(hud.hud_params),
+                    poker_game=hud.poker_game,
+                    game_type=table_info[3],
+                    site_id=table_info[5],
+                    num_seats=table_info[7],
+                    needs_mucked_data=needs_mucked,
+                ),
+            )
+        return tuple(contexts)
+
+    def _build_batch_request(self, hand_ids: list[str]) -> HudBatchReadRequest:
+        self._db_batch_sequence += 1
+        return HudBatchReadRequest(
+            sequence=self._db_batch_sequence,
+            hand_ids=tuple(hand_ids),
+            hud_params=dict(self.hud_params),
+            tables=self._table_read_contexts(),
+        )
+
+    def _show_loading_hud(self, hand_id: str) -> str | None:
+        """Create an empty-but-visible HUD as soon as table identity is known."""
+        prepared = self._prepared_hands.get(str(hand_id))
+        if prepared is None or prepared.table_info is None:
+            return None
+        table_info = prepared.table_info
+        (
+            table_name,
+            _max_seats,
+            poker_game,
+            game_type,
+            fast,
+            site_id,
+            site_name,
+            num_seats,
+            tour_number,
+            tab_number,
+            _tourney_name,
+        ) = table_info
+        if not isinstance(table_name, str) or not table_name.strip():
+            return None
+
+        enabled_sites = self.config.get_supported_sites()
+        hud_site_name = self._resolve_hud_config_site(site_name, enabled_sites)
+        aux_disabled_sites = [
+            site for site in enabled_sites if not self.config.get_site_parameters(site)["aux_enabled"]
+        ]
+        if fast or hud_site_name in aux_disabled_sites or hud_site_name not in enabled_sites:
+            return None
+
+        temp_key = self._get_temp_key(game_type, tour_number, tab_number, table_name)
+        if temp_key in self.hud_dict:
+            return temp_key
+        if self._handle_tournament_table_changes(game_type, temp_key, tour_number):
+            return None
+        self._create_new_hud(
+            hand_id,
+            temp_key,
+            table_info,
+            site_id,
+            num_seats,
+            hud_site_name,
+            loading=True,
+        )
+        if temp_key in self.hud_dict:
+            self._last_table_info[temp_key] = table_info
+            return temp_key
+        return None
+
+    def _on_db_snapshot(self, snapshot: HudBatchSnapshot) -> None:
+        """Apply a database-free snapshot on the Qt thread."""
+        if self._shutdown_started:
+            return
+        if snapshot.sequence < self._last_applied_sequence:
+            return
+        if snapshot.sequence == self._last_applied_sequence and snapshot.revision <= self._last_applied_revision:
+            return
+        if snapshot.sequence > self._last_applied_sequence:
+            self._last_applied_sequence = snapshot.sequence
+            self._last_applied_revision = -1
+            self._db_progress_refreshed = set()
+        self._last_applied_revision = snapshot.revision
+        self.db_connection = HudReplayDatabase(snapshot, self._db_backend)
+        self._prepared_hands = snapshot.hands
+        if not snapshot.identity_only:
+            self.hero = dict(snapshot.hero)
+            self.hero_ids = dict(snapshot.hero_ids)
+
+        for prepared in snapshot.hands.values():
+            if prepared.table_info is None:
+                continue
+            self.cache[prepared.hand_id] = prepared.table_info
+            self._hand_players[("seats", prepared.hand_id)] = prepared.seat_players
+            self._hand_players[("positions", prepared.hand_id)] = prepared.positions
+
+        if snapshot.identity_only:
+            for hand_id in snapshot.primary_order:
+                self._show_loading_hud(hand_id)
+            return
+
+        refreshed = set(self._db_progress_refreshed)
+        apply_failed: list[str] = []
+        failed = set(snapshot.failed_hand_ids)
+        for hand_id in snapshot.primary_order:
+            if hand_id in failed:
+                continue
+            try:
+                served = self.read_stdin(hand_id)
+            except Exception:
+                log.exception("Error applying prepared HUD hand %s", hand_id)
+                apply_failed.append(hand_id)
+            else:
+                if served is not None:
+                    refreshed.add(served)
+                    self._db_progress_refreshed.add(served)
+                    prepared = snapshot.hands.get(str(hand_id))
+                    if prepared is not None and prepared.table_info is not None:
+                        self._last_table_info[served] = prepared.table_info
+
+        if not snapshot.final:
+            return
+
+        self._db_batch_inflight = False
+        self._db_consecutive_failures = 0
+        # A secondary read that failed must leave that HUD's previous stats on
+        # screen. Excluding it from the replay refresh prevents a missing
+        # snapshot entry from looking like a legitimate empty result.
+        unavailable_secondary = {
+            context.temp_key
+            for context in self._table_read_contexts()
+            if str(context.last_hand_id) not in snapshot.hands
+        }
+        self._refresh_other_huds(refreshed | unavailable_secondary)
+        self._report_batch_round_trips(len(snapshot.requested_hand_ids), len(self.hud_dict))
+
+        retry_hands = tuple(dict.fromkeys((*snapshot.failed_hand_ids, *apply_failed)))
+        if retry_hands:
+            QTimer.singleShot(5000, lambda hands=retry_hands: self._retry_hands(hands))
+        if self._pending_hands and self._db_available and not self._hand_batch_timer.isActive():
+            self._hand_batch_timer.start()
+        self._db_progress_refreshed = set()
 
     def _stop_db_recovery(self) -> None:
         """Stop the recovery thread, if one is running."""
@@ -599,34 +947,17 @@ class HudMain(QObject):
         log.info("HUD RECEIVED MESSAGE - hand_id: %s", hand_id)
 
         if not self._db_available:
-            # The recovery thread owns the connection while the breaker is open;
-            # touching it here would both race with it and block the UI thread.
+            # The read worker owns the real connection. Keep the notification
+            # bounded here until that worker reports a successful reconnect.
             self._defer_hands([hand_id])
             log.debug("Deferring hand %s: database unavailable", hand_id)
             return
-
-        # Defensive rollback: ensure the PostgreSQL connection is not stuck in
-        # an aborted transaction state from a previous error.  Under PostgreSQL,
-        # any single failed query permanently blocks every subsequent query on
-        # the same connection until an explicit ROLLBACK is issued.  Issuing a
-        # rollback on a clean connection is a harmless no-op.
-        try:
-            if getattr(self, "db_connection", None):
-                self.db_connection.connection.rollback()
-        except Exception:
-            log.debug("Pre-message rollback failed (connection may be closed)")
 
         try:
             self._enqueue_hand(hand_id)
             log.debug("Hand %s queued for the next batch", hand_id)
         except Exception as e:
             log.exception("Error handling message for hand_id %s: %s", hand_id, e)
-            try:
-                if getattr(self, "db_connection", None):
-                    self.db_connection.connection.rollback()
-                    log.info("Successfully rolled back database transaction after error")
-            except Exception as roll_err:
-                log.exception("Failed to rollback transaction after error: %s", roll_err)
 
     def destroy(self) -> None:
         """Destroy the application and clean up resources."""
@@ -641,6 +972,12 @@ class HudMain(QObject):
                 batch_timer.stop()
         self._pending_hands = []
         self._deferred_hands = []
+
+        db_worker = getattr(self, "_db_worker", None)
+        if db_worker is not None:
+            with contextlib.suppress(RuntimeError):
+                db_worker.stop()
+            self._db_worker = None
 
         self._stop_db_recovery()
 
@@ -805,10 +1142,27 @@ class HudMain(QObject):
         self.idle_create(args)
         log.debug("HUD for table %s created successfully.", args.temp_key)
 
-    def update_HUD(self, new_hand_id: str, table_name: str, config: Configuration.Config) -> None:
+    def update_HUD(
+        self,
+        new_hand_id: str,
+        table_name: str,
+        config: Configuration.Config,
+        *,
+        cards: dict[str, Any] | None = None,
+        hand_instance: Any = None,
+    ) -> None:
         """Update an existing HUD."""
         log.debug("Updating HUD for table %s and hand %s", table_name, new_hand_id)
-        self.idle_update(new_hand_id, table_name, config)
+        if cards is None and hand_instance is None:
+            self.idle_update(new_hand_id, table_name, config)
+        else:
+            self.idle_update(
+                new_hand_id,
+                table_name,
+                config,
+                cards=cards,
+                hand_instance=hand_instance,
+            )
 
     def _initialize_hero_data(self) -> None:
         """Initialize hero data from the configuration."""
@@ -999,10 +1353,11 @@ class HudMain(QObject):
         game_type: str,
         site_id: int,
         num_seats: int,
-    ) -> None:
+    ) -> bool:
         """Update an existing HUD with new hand data."""
         log.debug("update hud for hand %s", new_hand_id)
         hud = self.hud_dict[temp_key]
+        was_loading = bool(getattr(hud, "is_loading", False))
         self.db_connection.init_hud_stat_vars(hud.hud_params["hud_days"], hud.hud_params["h_hud_days"])
         stat_dict = self.db_connection.get_stats_from_hand(
             new_hand_id,
@@ -1014,24 +1369,58 @@ class HudMain(QObject):
         )
         log.debug("got stats for hand %s", new_hand_id)
 
+        if was_loading and not any(
+            values.get("screen_name") == self.hero.get(site_id)
+            for values in stat_dict.values()
+        ):
+            log.warning(
+                "Removing loading HUD for hand %s table=%s: hero %r is not seated",
+                new_hand_id,
+                temp_key,
+                self.hero.get(site_id),
+            )
+            self.kill_hud(None, temp_key)
+            return False
+
+        if was_loading:
+            cached_stats = self.stats_persistence.load_hud_stats(temp_key)
+            if cached_stats:
+                merged = self.stats_persistence.merge_stats(cached_stats, {"stat_dict": stat_dict})
+                stat_dict = merged.get("stat_dict", stat_dict)
+
         self._merge_positions(stat_dict, new_hand_id)
         try:
             hud.stat_dict = stat_dict
         except KeyError:
             log.exception("hud_dict[%s] was not found", temp_key)
-            return
+            return False
 
         hud.seat_players = self._seat_players(new_hand_id)
         self._set_table_stats(hud, new_hand_id)
         hud.cards = self.get_cards(new_hand_id, hud.poker_game)
         for aw in hud.aux_windows:
             aw.update_data(new_hand_id, self.db_connection)
-        self.update_HUD(new_hand_id, temp_key, self.config)
+        prepared = self._prepared_hands.get(str(new_hand_id))
+        self.update_HUD(
+            new_hand_id,
+            temp_key,
+            self.config,
+            cards=hud.cards,
+            hand_instance=prepared.hand_instance if prepared is not None else None,
+        )
+        hud.is_loading = False
         log.debug("hud updated for table %s and hand %s", temp_key, new_hand_id)
+        return True
 
     def _enqueue_hand(self, hand_id: str) -> None:
         """Hold a hand briefly so the tables dealing alongside it join the batch."""
+        with contextlib.suppress(ValueError):
+            self._pending_hands.remove(hand_id)
         self._pending_hands.append(hand_id)
+        overflow = len(self._pending_hands) - MAX_PENDING_HANDS
+        if overflow > 0:
+            del self._pending_hands[:overflow]
+            log.warning("HUD pending-hand queue reached %d; oldest notification(s) were dropped", MAX_PENDING_HANDS)
         if not self._hand_batch_timer.isActive():
             self._hand_batch_timer.start()
 
@@ -1084,6 +1473,26 @@ class HudMain(QObject):
         return latest, unresolved
 
     def _drain_pending_hands(self) -> None:
+        """Submit one batch without running a database call on the Qt thread."""
+        worker = getattr(self, "_db_worker", None)
+        if worker is None:
+            # Narrow compatibility seam for focused legacy unit tests. Runtime
+            # construction always installs HudReadWorker.
+            self._drain_pending_hands_sync()
+            return
+        if self._db_batch_inflight:
+            return
+        pending, self._pending_hands = self._pending_hands, []
+        if not pending:
+            return
+        if not self._db_available:
+            self._defer_hands(pending)
+            return
+        request = self._build_batch_request(pending)
+        self._db_batch_inflight = True
+        worker.submit(request)
+
+    def _drain_pending_hands_sync(self) -> None:
         """Process one batch of hands, then refresh every other HUD once.
 
         The refresh is what this exists for: it used to run per hand, so a
@@ -1373,6 +1782,8 @@ class HudMain(QObject):
         site_id: int,
         num_seats: int,
         hud_site_name: str | None = None,
+        *,
+        loading: bool = False,
     ) -> None:
         """Create a new HUD for a table."""
         (table_name, max_seats, poker_game, game_type, _, _, site_name, _, tour_number, tab_number, tourney_name) = (
@@ -1392,19 +1803,22 @@ class HudMain(QObject):
             return
 
         log.debug("create new hud for hand %s", new_hand_id)
-        self.db_connection.init_hud_stat_vars(self.hud_params["hud_days"], self.hud_params["h_hud_days"])
-        stat_dict = self.db_connection.get_stats_from_hand(
-            new_hand_id,
-            game_type,
-            self.hud_params,
-            self.hero_ids[site_id],
-            num_seats,
-            poker_game=hud_poker_game,
-        )
-        log.debug("got stats for hand %s", new_hand_id)
+        if loading:
+            stat_dict = {}
+        else:
+            self.db_connection.init_hud_stat_vars(self.hud_params["hud_days"], self.hud_params["h_hud_days"])
+            stat_dict = self.db_connection.get_stats_from_hand(
+                new_hand_id,
+                game_type,
+                self.hud_params,
+                self.hero_ids[site_id],
+                num_seats,
+                poker_game=hud_poker_game,
+            )
+            log.debug("got stats for hand %s", new_hand_id)
 
         # Try to load cached stats to preserve data across restarts
-        cached_stats = self.stats_persistence.load_hud_stats(temp_key)
+        cached_stats = None if loading else self.stats_persistence.load_hud_stats(temp_key)
         if cached_stats:
             log.info(f"Found cached HUD stats for table {temp_key}, merging with current data")
             merged_data = self.stats_persistence.merge_stats(cached_stats, {"stat_dict": stat_dict})
@@ -1412,7 +1826,7 @@ class HudMain(QObject):
             log.debug("Merged cached stats with fresh database stats")
 
         self._merge_positions(stat_dict, new_hand_id)
-        if not any(stat_dict[key]["screen_name"] == self.hero[site_id] for key in stat_dict):
+        if not loading and not any(stat_dict[key]["screen_name"] == self.hero[site_id] for key in stat_dict):
             log.warning(
                 "HUD not created for hand %s table=%s: hero %r (site_id=%s) not among players %s",
                 new_hand_id,
@@ -1423,7 +1837,8 @@ class HudMain(QObject):
             )
             return
 
-        cards = self.get_cards(new_hand_id, poker_game)
+        prepared = self._prepared_hands.get(str(new_hand_id))
+        cards = prepared.cards if prepared is not None else self.get_cards(new_hand_id, poker_game)
         table_kwargs = {
             "table_name": table_name,
             "tournament": tour_number,
@@ -1490,9 +1905,11 @@ class HudMain(QObject):
                 game_type=game_type,
                 stat_dict=stat_dict,
                 cards=cards,
+                hand_instance=prepared.hand_instance if prepared is not None else None,
             )
             self.create_HUD(args)
             if args.temp_key in self.hud_dict:
+                self.hud_dict[args.temp_key].is_loading = loading
                 self.hud_dict[args.temp_key].seat_players = self._seat_players(new_hand_id)
                 self._set_table_stats(self.hud_dict[args.temp_key], new_hand_id)
         else:
@@ -1571,7 +1988,6 @@ class HudMain(QObject):
         if self._last_processed_hands.get(temp_key) == new_hand_id:
             log.debug("Skipping already processed hand ID %s for table %s", new_hand_id, temp_key)
             return None
-        self._last_processed_hands[temp_key] = new_hand_id
 
         if self._handle_tournament_table_changes(game_type, temp_key, tour_number):
             return None  # Stale table was handled
@@ -1581,14 +1997,21 @@ class HudMain(QObject):
             # Re-create the HUD with the new max seats
             self.kill_hud(None, temp_key)
             self._create_new_hud(new_hand_id, temp_key, table_info, site_id, num_seats, hud_site_name)
-            return temp_key
+            if temp_key in self.hud_dict:
+                self._last_processed_hands[temp_key] = new_hand_id
+                return temp_key
+            return None
 
         if temp_key in self.hud_dict:
             log.debug("Updating existing HUD for temp_key: %s", temp_key)
-            self._update_existing_hud(new_hand_id, temp_key, game_type, site_id, num_seats)
+            if not self._update_existing_hud(new_hand_id, temp_key, game_type, site_id, num_seats):
+                return None
         else:
             log.debug("Creating new HUD for temp_key: %s", temp_key)
             self._create_new_hud(new_hand_id, temp_key, table_info, site_id, num_seats, hud_site_name)
+        if temp_key not in self.hud_dict:
+            return None
+        self._last_processed_hands[temp_key] = new_hand_id
         return temp_key
 
     def _set_table_stats(self, hud: Hud.Hud, hand_id: str) -> None:
@@ -1699,20 +2122,21 @@ class HudMain(QObject):
             if table in self.hud_dict:
                 # Save HUD stats before killing to prevent data loss
                 hud = self.hud_dict[table]
-                hud_data = {
-                    "stat_dict": getattr(hud, "stat_dict", {}),
-                    "cards": getattr(hud, "cards", {}),
-                    "poker_game": getattr(hud, "poker_game", ""),
-                    "game_type": getattr(hud, "game_type", ""),
-                    "max_seats": getattr(hud, "max", 0),
-                    "hud_params": getattr(hud, "hud_params", {}),
-                    "last_hand_id": getattr(hud, "last_hand_id", ""),
-                }
+                if not getattr(hud, "is_loading", False):
+                    hud_data = {
+                        "stat_dict": getattr(hud, "stat_dict", {}),
+                        "cards": getattr(hud, "cards", {}),
+                        "poker_game": getattr(hud, "poker_game", ""),
+                        "game_type": getattr(hud, "game_type", ""),
+                        "max_seats": getattr(hud, "max", 0),
+                        "hud_params": getattr(hud, "hud_params", {}),
+                        "last_hand_id": getattr(hud, "last_hand_id", ""),
+                    }
 
-                if self.stats_persistence.save_hud_stats(table, hud_data):
-                    log.info(f"HUD stats saved before restart for table: {table}")
-                else:
-                    log.warning(f"Failed to save HUD stats for table: {table}")
+                    if self.stats_persistence.save_hud_stats(table, hud_data):
+                        log.info(f"HUD stats saved before restart for table: {table}")
+                    else:
+                        log.warning(f"Failed to save HUD stats for table: {table}")
 
                 # Take the label out of the main window and destroy it. setParent(None)
                 # only detached it, which turns a QLabel into a top-level widget --
@@ -1740,7 +2164,14 @@ class HudMain(QObject):
 
             self.hud_dict[args.temp_key].tablehudlabel = newlabel
             self.hud_dict[args.temp_key].tablenumber = args.table.number
-            self.hud_dict[args.temp_key].create(args.new_hand_id, self.config, args.stat_dict)
+            self.hud_dict[args.temp_key].create(
+                args.new_hand_id,
+                self.config,
+                args.stat_dict,
+                prepared=str(args.new_hand_id) in self._prepared_hands,
+                cards=args.cards,
+                hand_instance=args.hand_instance,
+            )
             for aux_index, m in enumerate(self.hud_dict[args.temp_key].aux_windows):
                 try:
                     m.create()
@@ -1760,7 +2191,15 @@ class HudMain(QObject):
         except Exception:
             log.exception("Error creating HUD for hand %s.", args.new_hand_id)
 
-    def idle_update(self, new_hand_id: str, table_name: str, config: Configuration.Config) -> None:
+    def idle_update(
+        self,
+        new_hand_id: str,
+        table_name: str,
+        config: Configuration.Config,
+        *,
+        cards: dict[str, Any] | None = None,
+        hand_instance: Any = None,
+    ) -> None:
         """Show a new hand on one table.
 
         Hud.update owns the new-hand cycle: it rebuilds the hand, re-reads the
@@ -1773,7 +2212,16 @@ class HudMain(QObject):
         try:
             log.debug("idle_update entered for %s %s", table_name, new_hand_id)
             hud = self.hud_dict[table_name]
-            hud.update(new_hand_id, config)
+            if str(new_hand_id) in self._prepared_hands:
+                hud.update(
+                    new_hand_id,
+                    config,
+                    prepared=True,
+                    cards=cards,
+                    hand_instance=hand_instance,
+                )
+            else:
+                hud.update(new_hand_id, config)
             hud_trace(
                 "idle_update OK: table=%s hand=%s aux_windows=%d",
                 table_name,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -61,6 +61,12 @@ HAND_BATCH_INTERVAL_MS = 200
 # this only decides how often we ask.
 DB_RECOVERY_INTERVAL_S = 5.0
 
+# A long outage must not grow memory without bound, but dropping every hand
+# means a recovered HUD stays invisible until another hand happens to arrive.
+# Keep a generous tail and reduce it to the latest hand per table once the
+# database is available again and table identities can be queried safely.
+MAX_DEFERRED_HANDS = 1000
+
 
 @dataclass
 class HUDCreationArgs:
@@ -440,6 +446,7 @@ class HudMain(QObject):
             # batch. The window starts at the first hand rather than restarting
             # on each, so continuous traffic cannot postpone it indefinitely.
             self._pending_hands: list[str] = []
+            self._deferred_hands: list[str] = []
             self._hand_batch_timer = QTimer(self)
             self._hand_batch_timer.setSingleShot(True)
             self._hand_batch_timer.setInterval(HAND_BATCH_INTERVAL_MS)
@@ -540,10 +547,13 @@ class HudMain(QObject):
         # Runs on the UI thread (queued signal), and the worker has already
         # returned from run(), so the connection is unowned at this point.
         self._db_available = True
-        # Table info cached against the old connection is still valid -- it
-        # describes hands, not the connection -- but hands that arrived during
-        # the outage are gone, and the HUDs are repainted from the next hand.
         log.info("Database available again; HUD updates resumed")
+        deferred, self._deferred_hands = self._deferred_hands, []
+        if deferred:
+            log.info("Replaying %d hand notification(s) deferred during the outage", len(deferred))
+            self._pending_hands.extend(deferred)
+            if not self._hand_batch_timer.isActive():
+                self._hand_batch_timer.start()
 
     def _stop_db_recovery(self) -> None:
         """Stop the recovery thread, if one is running."""
@@ -591,7 +601,8 @@ class HudMain(QObject):
         if not self._db_available:
             # The recovery thread owns the connection while the breaker is open;
             # touching it here would both race with it and block the UI thread.
-            log.debug("Dropping hand %s: database unavailable", hand_id)
+            self._defer_hands([hand_id])
+            log.debug("Deferring hand %s: database unavailable", hand_id)
             return
 
         # Defensive rollback: ensure the PostgreSQL connection is not stuck in
@@ -629,6 +640,7 @@ class HudMain(QObject):
             with contextlib.suppress(RuntimeError):
                 batch_timer.stop()
         self._pending_hands = []
+        self._deferred_hands = []
 
         self._stop_db_recovery()
 
@@ -1023,6 +1035,31 @@ class HudMain(QObject):
         if not self._hand_batch_timer.isActive():
             self._hand_batch_timer.start()
 
+    def _defer_hands(self, hand_ids: list[str]) -> None:
+        """Keep recent hand notifications until the recovery worker succeeds."""
+        for hand_id in hand_ids:
+            if not hand_id:
+                continue
+            # A duplicate notification should move to the end rather than use
+            # two slots in the bounded outage queue.
+            with contextlib.suppress(ValueError):
+                self._deferred_hands.remove(hand_id)
+            self._deferred_hands.append(hand_id)
+        overflow = len(self._deferred_hands) - MAX_DEFERRED_HANDS
+        if overflow > 0:
+            del self._deferred_hands[:overflow]
+
+    def _finish_read_batch(self) -> None:
+        """Release the successful HUD read transaction and any pooled server slot."""
+        if not self._db_available:
+            # Recovery owns the connection as soon as the breaker opens.
+            return
+        try:
+            self.db_connection.connection.rollback()
+        except Exception as exc:
+            if not self.note_db_error(exc):
+                log.exception("Could not finish the HUD read transaction")
+
     def _latest_hand_per_table(self, hand_ids: list[str]) -> tuple[dict[str, str], list[str]]:
         """Reduce a batch to the last hand of each table.
 
@@ -1033,10 +1070,13 @@ class HudMain(QObject):
         """
         latest: dict[str, str] = {}
         unresolved: list[str] = []
-        for hand_id in hand_ids:
+        for index, hand_id in enumerate(hand_ids):
             table_info = self._get_table_info(hand_id)
             if table_info is None:
                 unresolved.append(hand_id)
+                if not self._db_available:
+                    unresolved.extend(hand_ids[index + 1 :])
+                    break
                 continue
             table_name, game_type = table_info[0], table_info[3]
             tour_number, tab_number = table_info[8], table_info[9]
@@ -1054,32 +1094,45 @@ class HudMain(QObject):
         if not pending:
             return
         if not self._db_available:
-            log.debug("Dropping %d pending hand(s): database unavailable", len(pending))
+            self._defer_hands(pending)
+            log.debug("Deferring %d pending hand(s): database unavailable", len(pending))
             return
 
-        with db_profile.scope("batch"):
-            latest, unresolved = self._latest_hand_per_table(pending)
-            log.debug("Draining %d hand(s) into %d table(s)", len(pending), len(latest))
+        try:
+            with db_profile.scope("batch"):
+                latest, unresolved = self._latest_hand_per_table(pending)
+                if not self._db_available:
+                    self._defer_hands(pending)
+                    log.warning("Deferring this batch: database went away during table lookup")
+                    return
+                log.debug("Draining %d hand(s) into %d table(s)", len(pending), len(latest))
 
-            refreshed: set[str] = set()
-            for hand_id in [*latest.values(), *unresolved]:
-                try:
-                    with db_profile.scope("hand"):
-                        served = self.read_stdin(hand_id)
-                except Exception as exc:
-                    if self.note_db_error(exc):
-                        log.warning("Abandoning this batch: database went away while processing hand %s", hand_id)
-                        return
-                    log.exception("Error processing hand %s", hand_id)
-                    with contextlib.suppress(Exception):
-                        self.db_connection.connection.rollback()
-                else:
-                    if served is not None:
-                        refreshed.add(served)
+                refreshed: set[str] = set()
+                for hand_id in [*latest.values(), *unresolved]:
+                    try:
+                        with db_profile.scope("hand"):
+                            served = self.read_stdin(hand_id)
+                    except Exception as exc:
+                        if self.note_db_error(exc):
+                            self._defer_hands(pending)
+                            log.warning("Deferring this batch: database went away while processing hand %s", hand_id)
+                            return
+                        log.exception("Error processing hand %s", hand_id)
+                        with contextlib.suppress(Exception):
+                            self.db_connection.connection.rollback()
+                    else:
+                        if served is not None:
+                            refreshed.add(served)
 
-            # Only the tables actually brought up to date are left out of the
-            # statistics refresh; one that failed still needs it.
-            self._refresh_other_huds(refreshed)
+                # Only the tables actually brought up to date are left out of the
+                # statistics refresh; one that failed still needs it.
+                self._refresh_other_huds(refreshed)
+                if not self._db_available:
+                    self._defer_hands(pending)
+                    log.warning("Deferring this batch: database went away during the HUD refresh")
+                    return
+        finally:
+            self._finish_read_batch()
 
         self._report_batch_round_trips(len(pending), len(self.hud_dict))
 

--- a/fpdb_3_legacy/Hud.py
+++ b/fpdb_3_legacy/Hud.py
@@ -111,6 +111,7 @@ class Hud:
         self.stat_dict: dict[Any, Any] = {}
         self.seat_players: dict[Any, Any] = {}
         self.hand_instance: Any = None
+        self.is_loading = False
         self.table_name = ""
         self.tablenumber: Any = None
         self.tablehudlabel: Any = None
@@ -210,6 +211,12 @@ class Hud:
             except Exception:  # intentional broad catch: aux window callback boundary.
                 log.exception("Error killing aux window")
         self.aux_windows = []
+        if self.db_hud_connection is not None:
+            try:
+                self.db_hud_connection.close_connection()
+            except Exception:
+                log.exception("Error closing the legacy HUD database connection")
+            self.db_hud_connection = None
 
     def resize_windows(self) -> None:
         """Resize the windows based on the table size."""
@@ -301,24 +308,37 @@ class Hud:
         #    write the layouts back to the HUD_config
         self.config.save()
 
-    def create(self, hand: int | str, config: Any, stat_dict: dict[Any, Any]) -> None:
+    def create(
+        self,
+        hand: int | str,
+        config: Any,
+        stat_dict: dict[Any, Any],
+        *,
+        prepared: bool = False,
+        cards: dict[str, Any] | None = None,
+        hand_instance: Any = None,
+    ) -> None:
         """Update this hud, to the stats and players as of "hand".
 
         hand is the hand id of the most recent hand played at this table.
         """
         self.stat_dict = stat_dict  # stat_dict from HUD_main.read_stdin is mapped here
+        if prepared:
+            self.cards = cards or {}
+            self.hand_instance = hand_instance
         # the db_connection created in HUD_Main is NOT available to the
         #  hud.py and aux handlers, so create a fresh connection in this class
         # if the db connection is made in __init__, then the sqlite db threading will fail
         #  so the db connection is made here instead.
-        if self.db_hud_connection is None:
+        elif self.db_hud_connection is None:
             try:
                 self.db_hud_connection = Database.Database(self.config)
             except Exception:  # intentional broad catch: HUD DB drivers vary by backend.
                 log.exception("Unable to initialize HUD database connection")
                 self.db_hud_connection = None
-        self.cards = self.get_cards(hand)
-        if self.db_hud_connection is not None:
+        if not prepared:
+            self.cards = self.get_cards(hand)
+        if not prepared and self.db_hud_connection is not None:
             try:
                 self.hand_instance = Hand.hand_factory(hand, config, self.db_hud_connection)
                 self.db_hud_connection.connection.rollback()
@@ -335,16 +355,28 @@ class Hud:
             except Exception:  # intentional broad catch: aux window callback boundary.
                 log.exception("Error creating aux window")
 
-    def update(self, hand: int | str, config: Any) -> None:
+    def update(
+        self,
+        hand: int | str,
+        config: Any,
+        *,
+        prepared: bool = False,
+        cards: dict[str, Any] | None = None,
+        hand_instance: Any = None,
+    ) -> None:
         """Re-load a hand instance and refresh the aux windows for ``hand``."""
+        if prepared:
+            self.hand_instance = hand_instance
+            self.cards = cards or {}
         # re-load a hand instance (factory will load correct type for this hand)
-        if self.db_hud_connection is not None:
+        elif self.db_hud_connection is not None:
             self.hand_instance = Hand.hand_factory(hand, config, self.db_hud_connection)
             log.info("hud update after hand_factory")
             self.db_hud_connection.connection.rollback()
 
         # Get updated cards
-        self.cards = self.get_cards(hand)
+        if not prepared:
+            self.cards = self.get_cards(hand)
 
         # Refresh every aux window with the new hand so the displayed stats
         # update. This is the only place they are refreshed for a new hand, so

--- a/fpdb_3_legacy/hud_read_service.py
+++ b/fpdb_3_legacy/hud_read_service.py
@@ -1,0 +1,627 @@
+"""Database-only preparation for HUD updates.
+
+The Qt HUD process used to interleave database reads and widget mutations on
+the main thread.  This module provides the other half of that boundary: it
+loads every value the GUI update path can ask for and exposes an in-memory
+database facade while the result is applied.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from fpdb_3_legacy import Database, Hand
+from fpdb_3_legacy.db_reconnect import is_connection_lost
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("hud_read_service")
+
+
+def _hand_key(value: Any) -> str:
+    return str(value)
+
+
+def _lookup(mapping: dict[str, Any], hand_id: Any, default: Any = None) -> Any:
+    return mapping.get(_hand_key(hand_id), default)
+
+
+def _snapshot_hand(prepared: HudPreparedHand) -> HudPreparedHand:
+    """Detach mutable payloads without trying to deepcopy the opaque Hand."""
+    return HudPreparedHand(
+        hand_id=prepared.hand_id,
+        table_info=prepared.table_info,
+        stat_dict=copy.deepcopy(prepared.stat_dict),
+        positions=copy.deepcopy(prepared.positions),
+        seat_players=copy.deepcopy(prepared.seat_players),
+        table_stats=copy.deepcopy(prepared.table_stats),
+        cards=copy.deepcopy(prepared.cards),
+        hand_instance=prepared.hand_instance,
+        winners=copy.deepcopy(prepared.winners),
+        actions=copy.deepcopy(prepared.actions),
+        loaded_fields=prepared.loaded_fields,
+    )
+
+
+def hud_temp_key(table_info: tuple) -> str:
+    """Return the table identity used by ``HudMain.hud_dict``."""
+    table_name, game_type = table_info[0], table_info[3]
+    tour_number, tab_number = table_info[8], table_info[9]
+    if game_type != "tour":
+        return table_name
+    try:
+        suffix = tab_number.rsplit(" ", 1)[-1]
+    except (AttributeError, ValueError):
+        return table_name
+    return f"{tour_number} Table {suffix}"
+
+
+def hud_poker_game(poker_game: str) -> str:
+    """Map imported game names to HUD layout names."""
+    return {"fusion": "holdem"}.get(poker_game, poker_game)
+
+
+@dataclass(frozen=True)
+class HudTableReadContext:
+    """Read parameters captured from one already-visible HUD."""
+
+    temp_key: str
+    last_hand_id: str
+    hud_params: dict[str, Any]
+    poker_game: str
+    game_type: str
+    site_id: int
+    num_seats: int
+    needs_mucked_data: bool = False
+
+
+@dataclass(frozen=True)
+class HudBatchReadRequest:
+    """Everything the worker needs without dereferencing a Qt object."""
+
+    sequence: int
+    hand_ids: tuple[str, ...]
+    hud_params: dict[str, Any]
+    tables: tuple[HudTableReadContext, ...] = ()
+
+
+@dataclass
+class HudPreparedHand:
+    """All database-derived state needed to paint one new hand."""
+
+    hand_id: str
+    table_info: tuple | None = None
+    stat_dict: dict[Any, Any] = field(default_factory=dict)
+    positions: dict[Any, Any] = field(default_factory=dict)
+    seat_players: dict[Any, Any] = field(default_factory=dict)
+    table_stats: dict[str, Any] = field(default_factory=dict)
+    cards: dict[str, Any] = field(default_factory=dict)
+    hand_instance: Any = None
+    winners: dict[Any, Any] = field(default_factory=dict)
+    actions: list[Any] = field(default_factory=list)
+    loaded_fields: frozenset[str] = frozenset()
+
+
+@dataclass
+class HudBatchSnapshot:
+    """A completed worker result, safe for the Qt thread to consume."""
+
+    sequence: int
+    requested_hand_ids: tuple[str, ...]
+    primary_order: tuple[str, ...]
+    hands: dict[str, HudPreparedHand]
+    site_rows: dict[str, Any]
+    player_ids: dict[tuple[str, str], int | None]
+    hero: dict[int, str]
+    hero_ids: dict[int, int]
+    failed_hand_ids: tuple[str, ...] = ()
+    revision: int = 0
+    final: bool = True
+    identity_only: bool = False
+
+
+class _NullConnection:
+    def rollback(self) -> None:
+        """The worker already ended the real transaction."""
+
+    def close(self) -> None:
+        """There is no connection on the Qt side."""
+
+
+class HudReplayDatabase:
+    """Serve a worker snapshot through the legacy Database read API."""
+
+    def __init__(self, snapshot: HudBatchSnapshot, backend: int) -> None:
+        self.snapshot = snapshot
+        self.backend = backend
+        self.connection = _NullConnection()
+
+    def _prepared(self, hand_id: Any) -> HudPreparedHand | None:
+        return _lookup(self.snapshot.hands, hand_id)
+
+    def _read(self, hand_id: Any, field_name: str, default: Any) -> Any:
+        prepared = self._prepared(hand_id)
+        if prepared is None or field_name not in prepared.loaded_fields:
+            if not self.snapshot.identity_only:
+                log.debug(
+                    "HUD replay miss: field=%s hand=%s sequence=%s revision=%s",
+                    field_name,
+                    hand_id,
+                    self.snapshot.sequence,
+                    self.snapshot.revision,
+                )
+            return copy.deepcopy(default)
+        return copy.deepcopy(getattr(prepared, field_name))
+
+    def init_hud_stat_vars(self, _hud_days: int, _hero_days: int) -> None:
+        return None
+
+    def get_site_id(self, site: str) -> Any:
+        if site not in self.snapshot.site_rows and not self.snapshot.identity_only:
+            log.debug("HUD replay miss: site=%s", site)
+        return self.snapshot.site_rows.get(site)
+
+    def get_player_id(self, _config: Any, site: str, screen_name: str) -> int | None:
+        if (site, screen_name) not in self.snapshot.player_ids and not self.snapshot.identity_only:
+            log.debug("HUD replay miss: player site=%s screen_name=%s", site, screen_name)
+        return self.snapshot.player_ids.get((site, screen_name))
+
+    def get_table_info(self, hand_id: Any) -> tuple | None:
+        return self._read(hand_id, "table_info", None)
+
+    def get_stats_from_hand(self, hand_id: Any, *_args: Any, **_kwargs: Any) -> dict:
+        return self._read(hand_id, "stat_dict", {})
+
+    def get_stats_from_hands(self, hand_ids: list[Any], *_args: Any, **_kwargs: Any) -> dict:
+        return {hand_id: self._read(hand_id, "stat_dict", {}) for hand_id in hand_ids}
+
+    def get_seat_players(self, hand_id: Any) -> dict:
+        return self._read(hand_id, "seat_players", {})
+
+    def get_hand_positions(self, hand_id: Any) -> dict:
+        return self._read(hand_id, "positions", {})
+
+    def get_table_min_stack_bb(self, hand_id: Any) -> Any:
+        table_stats = self._read(hand_id, "table_stats", {})
+        return table_stats.get("live_min_stack_bb")
+
+    def get_cards(self, hand_id: Any) -> dict:
+        cards = self._read(hand_id, "cards", {})
+        cards.pop("common", None)
+        return cards
+
+    def get_common_cards(self, hand_id: Any) -> dict:
+        cards = self._read(hand_id, "cards", {})
+        return {"common": cards.get("common", [])}
+
+    def get_winners_from_hand(self, hand_id: Any) -> dict:
+        return self._read(hand_id, "winners", {})
+
+    def get_action_from_hand(self, hand_id: Any) -> list:
+        return self._read(hand_id, "actions", [])
+
+
+class HudReadService:
+    """Load HUD batches on a connection owned by the calling worker thread."""
+
+    def __init__(
+        self,
+        config: Any,
+        database: Database.Database,
+        hand_factory: Callable[..., Any] = Hand.hand_factory,
+    ) -> None:
+        self.config = config
+        self.database = database
+        self.hand_factory = hand_factory
+        self._hero_cache: tuple[
+            dict[str, Any],
+            dict[tuple[str, str], int | None],
+            dict[int, str],
+            dict[int, int],
+        ] | None = None
+
+    @staticmethod
+    def _site_aliases(site: str) -> tuple[str, ...]:
+        if site != "PokerStars":
+            return (site,)
+        return (
+            "PokerStars",
+            "PokerStars.COM",
+            "PokerStars.FR",
+            "PokerStars.IT",
+            "PokerStars.ES",
+            "PokerStars.PT",
+            "PokerStars.EU",
+            "PokerStars.DE",
+        )
+
+    def _hero_data(self) -> tuple[dict[str, Any], dict[tuple[str, str], int | None], dict[int, str], dict[int, int]]:
+        if self._hero_cache is not None:
+            return self._hero_cache
+        site_rows: dict[str, Any] = {}
+        player_ids: dict[tuple[str, str], int | None] = {}
+        hero: dict[int, str] = {}
+        hero_ids: dict[int, int] = {}
+        configured_sites = self.config.get_supported_sites()
+        resolved_sites: set[str] = set()
+        for configured_site in configured_sites:
+            screen_name = self.config.supported_sites[configured_site].screen_name
+            for db_site in self._site_aliases(configured_site):
+                rows = self.database.get_site_id(db_site)
+                site_rows[db_site] = rows
+                if not rows:
+                    continue
+                site_id = rows[0][0]
+                player_id = self.database.get_player_id(self.config, db_site, screen_name)
+                player_ids[(db_site, screen_name)] = player_id
+                hero[site_id] = screen_name
+                hero_ids[site_id] = player_id if player_id is not None else -1
+                if player_id is not None:
+                    resolved_sites.add(configured_site)
+        result = site_rows, player_ids, hero, hero_ids
+        # The importer may create the hero after the HUD process connects. Do
+        # not make an early -1 permanent; cache only once every configured
+        # site's player row exists.
+        if not configured_sites or resolved_sites == set(configured_sites):
+            self._hero_cache = result
+        return result
+
+    def _needs_mucked_data(self, poker_game: str, game_type: str) -> bool:
+        params = self.config.get_supported_games_parameters(poker_game, game_type)
+        if not params:
+            return False
+        aux_names = params.get("aux", "")
+        if isinstance(aux_names, list):
+            aux_names = ",".join(aux_names)
+        for name in str(aux_names).split(","):
+            name = name.strip()
+            if not name:
+                continue
+            with contextlib.suppress(Exception):
+                if self.config.get_aux_parameters(name).get("module") == "Mucked":
+                    return True
+        return False
+
+    def _cards(self, hand_id: str, poker_game: str) -> dict:
+        cards = self.database.get_cards(hand_id)
+        if poker_game in {"holdem", "omahahi", "omahahilo"}:
+            cards["common"] = self.database.get_common_cards(hand_id)["common"]
+        return cards
+
+    def _hand_instance(self, hand_id: str) -> Any:
+        """Build aux-window input without making one bad hand fail the HUD."""
+        try:
+            return self.hand_factory(hand_id, self.config, self.database)
+        except Exception as exc:
+            self._handle_read_error(exc)
+            return None
+
+    def _read_hand(
+        self,
+        hand_id: str,
+        table_info: tuple,
+        hud_params: dict[str, Any],
+        poker_game: str,
+        hero_id: int,
+        needs_mucked_data: bool,
+    ) -> HudPreparedHand:
+        game_type, num_seats = table_info[3], table_info[7]
+        self.database.init_hud_stat_vars(hud_params["hud_days"], hud_params["h_hud_days"])
+        stat_dict = self.database.get_stats_from_hand(
+            hand_id,
+            game_type,
+            hud_params,
+            hero_id,
+            num_seats,
+            poker_game=poker_game,
+        )
+        winners = self.database.get_winners_from_hand(hand_id) if needs_mucked_data else {}
+        actions = self.database.get_action_from_hand(hand_id) if needs_mucked_data else []
+        loaded_fields = {
+            "table_info",
+            "stat_dict",
+            "positions",
+            "seat_players",
+            "table_stats",
+            "cards",
+            "hand_instance",
+        }
+        if needs_mucked_data:
+            loaded_fields.update({"winners", "actions"})
+        return HudPreparedHand(
+            hand_id=hand_id,
+            table_info=table_info,
+            stat_dict=stat_dict,
+            positions=self.database.get_hand_positions(hand_id),
+            seat_players=self.database.get_seat_players(hand_id),
+            table_stats={"live_min_stack_bb": self.database.get_table_min_stack_bb(hand_id)},
+            cards=self._cards(hand_id, poker_game),
+            hand_instance=self._hand_instance(hand_id),
+            winners=winners,
+            actions=actions,
+            loaded_fields=frozenset(loaded_fields),
+        )
+
+    def _handle_read_error(self, exc: BaseException) -> None:
+        # PostgreSQL statement/lock timeouts leave the connection usable after
+        # rollback, but continuing with eleven more tables could turn one
+        # bounded 10-second wait into minutes. Abort this batch and let the UI
+        # retry the latest notifications later.
+        if getattr(exc, "sqlstate", None) in {"57014", "55P03"}:
+            raise exc
+        if is_connection_lost(self.database.backend, exc):
+            raise exc
+        with contextlib.suppress(Exception):
+            self.database.connection.rollback()
+
+    def _resolve_primary_hands(
+        self,
+        request: HudBatchReadRequest,
+        hands: dict[str, HudPreparedHand],
+        failed: list[str],
+        progress_callback: Callable[[HudBatchSnapshot], None] | None,
+    ) -> tuple[dict[str, str], list[str], int]:
+        latest: dict[str, str] = {}
+        unresolved: list[str] = []
+        revision = 0
+        for hand_id in request.hand_ids:
+            try:
+                table_info = self.database.get_table_info(hand_id)
+            except Exception as exc:
+                self._handle_read_error(exc)
+                failed.append(hand_id)
+                continue
+            if table_info is None:
+                hands[_hand_key(hand_id)] = HudPreparedHand(hand_id=hand_id)
+                unresolved.append(hand_id)
+                continue
+            prepared = HudPreparedHand(
+                hand_id=hand_id,
+                table_info=table_info,
+                loaded_fields=frozenset({"table_info"}),
+            )
+            hands[_hand_key(hand_id)] = prepared
+            latest[hud_temp_key(table_info)] = hand_id
+            if progress_callback is not None:
+                revision += 1
+                with contextlib.suppress(Exception):
+                    self.database.connection.rollback()
+                progress_callback(
+                    HudBatchSnapshot(
+                        sequence=request.sequence,
+                        requested_hand_ids=request.hand_ids,
+                        primary_order=(hand_id,),
+                        hands={_hand_key(hand_id): _snapshot_hand(prepared)},
+                        site_rows={},
+                        player_ids={},
+                        hero={},
+                        hero_ids={},
+                        revision=revision,
+                        final=False,
+                        identity_only=True,
+                    ),
+                )
+        return latest, unresolved, revision
+
+    def _load_primary_hands(
+        self,
+        latest: dict[str, str],
+        request: HudBatchReadRequest,
+        contexts: dict[str, HudTableReadContext],
+        hero_ids: dict[int, int],
+        hands: dict[str, HudPreparedHand],
+        failed: list[str],
+        site_rows: dict[str, Any],
+        player_ids: dict[tuple[str, str], int | None],
+        hero: dict[int, str],
+        progress_callback: Callable[[HudBatchSnapshot], None] | None,
+        revision: int,
+    ) -> tuple[set[str], int]:
+        loaded_tables: set[str] = set()
+        for hand_id in latest.values():
+            table_info = hands[_hand_key(hand_id)].table_info
+            if table_info is None:
+                continue
+            temp_key = hud_temp_key(table_info)
+            context = contexts.get(temp_key)
+            poker_game = context.poker_game if context else hud_poker_game(table_info[2])
+            params = context.hud_params if context else request.hud_params
+            needs_mucked = (
+                context.needs_mucked_data
+                if context
+                else self._needs_mucked_data(poker_game, table_info[3])
+            )
+            try:
+                hands[_hand_key(hand_id)] = self._read_hand(
+                    hand_id,
+                    table_info,
+                    params,
+                    poker_game,
+                    hero_ids.get(table_info[5], -1),
+                    needs_mucked,
+                )
+                loaded_tables.add(temp_key)
+            except Exception as exc:
+                self._handle_read_error(exc)
+                failed.append(hand_id)
+            if progress_callback is not None:
+                revision += 1
+                # End this table's transaction before asking Qt to paint it.
+                # Besides releasing pooled slots early, this makes the emitted
+                # Python objects immutable from the worker's point of view.
+                with contextlib.suppress(Exception):
+                    self.database.connection.rollback()
+                progress_callback(
+                    HudBatchSnapshot(
+                        sequence=request.sequence,
+                        requested_hand_ids=request.hand_ids,
+                        primary_order=(hand_id,) if hand_id not in failed else (),
+                        hands={_hand_key(hand_id): _snapshot_hand(hands[_hand_key(hand_id)])},
+                        site_rows=site_rows,
+                        player_ids=player_ids,
+                        hero=hero,
+                        hero_ids=hero_ids,
+                        failed_hand_ids=(hand_id,) if hand_id in failed else (),
+                        revision=revision,
+                        final=False,
+                    ),
+                )
+        return loaded_tables, revision
+
+    def _load_secondary_hands(
+        self,
+        request: HudBatchReadRequest,
+        updated_tables: set[str],
+        hero_ids: dict[int, int],
+        hands: dict[str, HudPreparedHand],
+        failed: list[str],
+    ) -> None:
+        groups: dict[str, tuple[HudTableReadContext, int, list[HudPreparedHand]]] = {}
+        for context in request.tables:
+            if context.temp_key in updated_tables or not context.last_hand_id:
+                continue
+            try:
+                table_info = self.database.get_table_info(context.last_hand_id)
+                if table_info is None:
+                    continue
+                prepared = HudPreparedHand(
+                    hand_id=context.last_hand_id,
+                    table_info=table_info,
+                    positions=self.database.get_hand_positions(context.last_hand_id),
+                    seat_players=self.database.get_seat_players(context.last_hand_id),
+                    loaded_fields=frozenset({"table_info", "positions", "seat_players"}),
+                )
+                hands[_hand_key(context.last_hand_id)] = prepared
+                hero_id = hero_ids.get(context.site_id, -1)
+                key = repr(
+                    (
+                        sorted(context.hud_params.items(), key=str),
+                        hero_id,
+                        context.num_seats,
+                        context.poker_game,
+                        context.game_type,
+                    ),
+                )
+                if key not in groups:
+                    groups[key] = (context, hero_id, [])
+                groups[key][2].append(prepared)
+            except Exception as exc:
+                self._handle_read_error(exc)
+                failed.append(context.last_hand_id)
+
+        for context, hero_id, prepared_hands in groups.values():
+            hand_ids = [prepared.hand_id for prepared in prepared_hands]
+            try:
+                self.database.init_hud_stat_vars(
+                    context.hud_params["hud_days"],
+                    context.hud_params["h_hud_days"],
+                )
+                stats = self.database.get_stats_from_hands(
+                    hand_ids,
+                    context.game_type,
+                    context.hud_params,
+                    hero_id,
+                    context.num_seats,
+                    poker_game=context.poker_game,
+                )
+            except Exception as exc:
+                self._handle_read_error(exc)
+                self._load_secondary_stats_individually(
+                    context,
+                    hero_id,
+                    prepared_hands,
+                    hands,
+                    failed,
+                )
+                continue
+
+            stats_by_key = {_hand_key(hand_id): value for hand_id, value in stats.items()}
+            for prepared in prepared_hands:
+                prepared.stat_dict = stats_by_key.get(_hand_key(prepared.hand_id), {})
+                prepared.loaded_fields = prepared.loaded_fields | {"stat_dict"}
+
+    def _load_secondary_stats_individually(
+        self,
+        context: HudTableReadContext,
+        hero_id: int,
+        prepared_hands: list[HudPreparedHand],
+        hands: dict[str, HudPreparedHand],
+        failed: list[str],
+    ) -> None:
+        """Preserve the old best-effort fallback when a grouped query fails."""
+        for prepared in prepared_hands:
+            try:
+                self.database.init_hud_stat_vars(
+                    context.hud_params["hud_days"],
+                    context.hud_params["h_hud_days"],
+                )
+                prepared.stat_dict = self.database.get_stats_from_hand(
+                    prepared.hand_id,
+                    context.game_type,
+                    context.hud_params,
+                    hero_id,
+                    context.num_seats,
+                    poker_game=context.poker_game,
+                )
+                prepared.loaded_fields = prepared.loaded_fields | {"stat_dict"}
+            except Exception as exc:
+                self._handle_read_error(exc)
+                hands.pop(_hand_key(prepared.hand_id), None)
+                failed.append(prepared.hand_id)
+
+    def read_batch(
+        self,
+        request: HudBatchReadRequest,
+        progress_callback: Callable[[HudBatchSnapshot], None] | None = None,
+    ) -> HudBatchSnapshot:
+        """Read one coalesced batch and release its transaction before returning."""
+        contexts = {context.temp_key: context for context in request.tables}
+        hands: dict[str, HudPreparedHand] = {}
+        failed: list[str] = []
+        site_rows: dict[str, Any] = {}
+        player_ids: dict[tuple[str, str], int | None] = {}
+        hero: dict[int, str] = {}
+        hero_ids: dict[int, int] = {}
+
+        try:
+            latest, unresolved, revision = self._resolve_primary_hands(
+                request,
+                hands,
+                failed,
+                progress_callback,
+            )
+            site_rows, player_ids, hero, hero_ids = self._hero_data()
+            primary_order = [*latest.values(), *unresolved]
+            updated_tables, revision = self._load_primary_hands(
+                latest,
+                request,
+                contexts,
+                hero_ids,
+                hands,
+                failed,
+                site_rows,
+                player_ids,
+                hero,
+                progress_callback,
+                revision,
+            )
+            self._load_secondary_hands(request, updated_tables, hero_ids, hands, failed)
+        finally:
+            with contextlib.suppress(Exception):
+                self.database.connection.rollback()
+
+        return HudBatchSnapshot(
+            sequence=request.sequence,
+            requested_hand_ids=request.hand_ids,
+            primary_order=tuple(primary_order),
+            hands=hands,
+            site_rows=site_rows,
+            player_ids=player_ids,
+            hero=hero,
+            hero_ids=hero_ids,
+            failed_hand_ids=tuple(dict.fromkeys(failed)),
+            revision=revision + 1 if progress_callback is not None else 0,
+        )

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -2,6 +2,8 @@ import contextlib
 import importlib.machinery
 import importlib.util
 import sys
+import threading
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -9,6 +11,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 pytestmark = pytest.mark.qt
+from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QApplication
 
 # import zmq
@@ -61,7 +64,7 @@ def hud_main(app):
     with (
         patch("HUD_main.Configuration.Config") as mock_config,
         patch("HUD_main.Configuration.set_logfile"),
-        patch("HUD_main.Database.Database"),
+        patch("HUD_main.Database.Database") as mock_database,
         patch("HUD_main.Deck.Deck"),
         patch("HUD_main.ZMQReceiver"),
         patch("HUD_main.ZMQWorker"),
@@ -90,6 +93,14 @@ def hud_main(app):
         mock_config_instance.get_layout.return_value = "some_layout"
 
         hm = HUD_main.HudMain(options, db_name=options.dbname)
+        # The focused HudMain tests exercise the legacy synchronous seam with a
+        # controllable Database mock. Runtime construction uses HudReadWorker,
+        # whose connection intentionally lives on its own thread.
+        hm._db_worker.stop()
+        app.processEvents()
+        hm._db_worker = None
+        hm.db_connection = mock_database.return_value
+        hm._db_available = True
         yield hm
 
         hm.main_window.close()
@@ -133,6 +144,254 @@ def test_handle_message(hud_main) -> None:
     assert not mock_read_stdin.called
     assert hud_main._pending_hands == ["test_hand_id"]
     assert hud_main._hand_batch_timer.isActive()
+
+
+def test_async_drain_only_submits_work_to_the_database_thread(hud_main) -> None:
+    worker = MagicMock()
+    hud_main._db_worker = worker
+    hud_main._pending_hands = ["101", "102"]
+
+    with patch.object(hud_main, "_build_batch_request") as build_request:
+        request = HUD_main.HudBatchReadRequest(1, ("101", "102"), {})
+        build_request.return_value = request
+        hud_main._drain_pending_hands()
+
+    worker.submit.assert_called_once_with(request)
+    assert hud_main._pending_hands == []
+    assert hud_main._db_batch_inflight is True
+    assert not hud_main.db_connection.get_table_info.called
+
+
+def test_slow_database_worker_does_not_block_the_qt_event_loop(qtbot) -> None:
+    main_thread = threading.get_ident()
+    factory_threads: list[int] = []
+    database = MagicMock(backend=0)
+
+    def database_factory(_config):
+        factory_threads.append(threading.get_ident())
+        return database
+
+    class SlowService:
+        def __init__(self, _config, _database) -> None:
+            pass
+
+        def read_batch(self, request, progress_callback=None):
+            time.sleep(0.35)
+            return HUD_main.HudBatchSnapshot(
+                request.sequence,
+                request.hand_ids,
+                (),
+                {},
+                {},
+                {},
+                {},
+                {},
+            )
+
+    worker = HUD_main.HudReadWorker(MagicMock(), db_factory=database_factory)
+    ticks: list[float] = []
+    heartbeat = QTimer()
+    heartbeat.setInterval(10)
+    heartbeat.timeout.connect(lambda: ticks.append(time.monotonic()))
+
+    try:
+        with patch("HUD_main.HudReadService", SlowService):
+            with qtbot.waitSignal(worker.ready, timeout=1000):
+                worker.start()
+            heartbeat.start()
+            started = time.monotonic()
+            with qtbot.waitSignal(worker.snapshot_ready, timeout=1500):
+                worker.submit(HUD_main.HudBatchReadRequest(1, ("101",), {}))
+            elapsed = time.monotonic() - started
+    finally:
+        heartbeat.stop()
+        worker.stop()
+
+    assert factory_threads and factory_threads[0] != main_thread
+    assert elapsed >= 0.3
+    assert len(ticks) >= 15
+    assert max(b - a for a, b in zip(ticks, ticks[1:], strict=False)) < 0.15
+
+
+def test_postgresql_worker_bounds_its_own_session_queries() -> None:
+    database = MagicMock(backend=HUD_main.Database.Database.PGSQL)
+    cursor = database.connection.cursor.return_value
+
+    HUD_main.HudReadWorker._configure_session(database)
+
+    assert cursor.execute.call_args_list == [
+        call("SET statement_timeout = 10000"),
+        call("SET lock_timeout = 2000"),
+        call("SET idle_in_transaction_session_timeout = 30000"),
+    ]
+    database.connection.commit.assert_called_once_with()
+    cursor.close.assert_called_once_with()
+
+
+def test_partial_snapshot_keeps_batch_inflight_until_final_snapshot(hud_main) -> None:
+    hud_main._db_worker = MagicMock()
+    hud_main._db_batch_inflight = True
+    partial = HUD_main.HudBatchSnapshot(
+        5,
+        ("101",),
+        ("101",),
+        {},
+        {},
+        {},
+        {},
+        {},
+        revision=1,
+        final=False,
+    )
+    final = HUD_main.HudBatchSnapshot(
+        5,
+        ("101",),
+        (),
+        {},
+        {},
+        {},
+        {},
+        {},
+        revision=2,
+    )
+
+    with (
+        patch.object(hud_main, "read_stdin", return_value="table-a"),
+        patch.object(hud_main, "_refresh_other_huds") as refresh_other,
+    ):
+        hud_main._on_db_snapshot(partial)
+        assert hud_main._db_batch_inflight is True
+        refresh_other.assert_not_called()
+
+        hud_main._on_db_snapshot(final)
+
+    assert hud_main._db_batch_inflight is False
+    refresh_other.assert_called_once()
+
+
+def test_identity_snapshot_requests_a_loading_hud_before_stats_arrive(hud_main) -> None:
+    prepared = MagicMock()
+    prepared.hand_id = "101"
+    prepared.table_info = ("table-a", 6, "holdem", "ring", False, 1, "site", 6, None, None, None)
+    prepared.positions = {}
+    prepared.seat_players = {}
+    snapshot = HUD_main.HudBatchSnapshot(
+        6,
+        ("101",),
+        ("101",),
+        {"101": prepared},
+        {},
+        {},
+        {},
+        {},
+        revision=1,
+        final=False,
+        identity_only=True,
+    )
+    hud_main._db_worker = MagicMock()
+    hud_main._db_batch_inflight = True
+
+    with patch.object(hud_main, "_show_loading_hud") as show_loading:
+        hud_main._on_db_snapshot(snapshot)
+
+    show_loading.assert_called_once_with("101")
+    assert hud_main._db_batch_inflight is True
+
+
+def test_loading_hud_creation_does_not_require_statistics(hud_main) -> None:
+    table_info = ("table-a", 6, "holdem", "ring", False, 1, "site", 6, None, None, None)
+    hud_main._prepared_hands = {"101": MagicMock(table_info=table_info)}
+    hud_main.config.get_supported_sites.return_value = ["site"]
+    hud_main.config.get_site_parameters.return_value = {"aux_enabled": True}
+
+    with patch.object(hud_main, "_create_new_hud") as create_new_hud:
+        hud_main._show_loading_hud("101")
+
+    create_new_hud.assert_called_once_with(
+        "101",
+        "table-a",
+        table_info,
+        1,
+        6,
+        "site",
+        loading=True,
+    )
+
+
+def test_loading_hud_builds_empty_creation_args_without_querying_stats(hud_main) -> None:
+    table_info = ("table-a", 6, "holdem", "ring", False, 1, "site", 6, None, None, None)
+    prepared = MagicMock(cards={}, hand_instance=None)
+    hud_main._prepared_hands = {"101": prepared}
+    hud_main.config.get_supported_games_parameters.return_value = {"aux": ""}
+    hud_main.Tables = MagicMock()
+    hud_main.Tables.Table.return_value = MagicMock(
+        number=12,
+        title="table-a",
+        x=0,
+        y=0,
+        width=800,
+        height=600,
+    )
+
+    with (
+        patch.object(hud_main.db_connection, "get_stats_from_hand") as get_stats,
+        patch.object(hud_main, "create_HUD") as create_hud,
+    ):
+        hud_main._create_new_hud("101", "table-a", table_info, 1, 6, "site", loading=True)
+
+    get_stats.assert_not_called()
+    args = create_hud.call_args.args[0]
+    assert args.stat_dict == {}
+    assert args.cards == {}
+
+
+def test_runtime_replay_error_cannot_start_the_legacy_recovery_worker(hud_main) -> None:
+    hud_main._db_worker = MagicMock()
+
+    with patch.object(hud_main, "_start_db_recovery") as start_recovery:
+        assert hud_main.note_db_error(RuntimeError("connection reset by peer")) is False
+
+    start_recovery.assert_not_called()
+
+
+def test_pending_hand_queue_keeps_only_its_bounded_latest_tail(hud_main) -> None:
+    saved = HUD_main.MAX_PENDING_HANDS
+    HUD_main.MAX_PENDING_HANDS = 3
+    try:
+        for hand_id in ("1", "2", "3", "4"):
+            hud_main._enqueue_hand(hand_id)
+    finally:
+        HUD_main.MAX_PENDING_HANDS = saved
+
+    assert hud_main._pending_hands == ["2", "3", "4"]
+
+
+def test_repeated_batch_timeouts_are_counted_and_reported(hud_main) -> None:
+    request = HUD_main.HudBatchReadRequest(7, ("101",), {})
+
+    with (
+        patch("HUD_main.QTimer.singleShot"),
+        patch("HUD_main.log.warning") as warning,
+    ):
+        hud_main._on_db_batch_failed(request, "statement timeout")
+        hud_main._on_db_batch_failed(request, "statement timeout")
+
+    assert hud_main._db_consecutive_failures == 2
+    assert warning.call_args_list[-1].args[2] == 2
+
+
+def test_batch_retry_backs_off_once_after_five_consecutive_failures(hud_main) -> None:
+    request = HUD_main.HudBatchReadRequest(8, ("101",), {})
+
+    with (
+        patch("HUD_main.QTimer.singleShot") as single_shot,
+        patch("HUD_main.log.error") as error,
+    ):
+        for _ in range(7):
+            hud_main._on_db_batch_failed(request, "statement timeout")
+
+    assert [item.args[0] for item in single_shot.call_args_list] == [5000] * 5 + [30000] * 2
+    error.assert_called_once()
 
 
 # Checks that the destroy method properly closes connections and stops processes.
@@ -904,6 +1163,17 @@ def test_idle_kill_widget_removal(hud_main) -> None:
 
     # Assert HUD is removed from the dictionary
     assert "test_table" not in hud_main.hud_dict
+
+
+def test_loading_hud_does_not_overwrite_persisted_stats_when_killed(hud_main) -> None:
+    mock_hud = MagicMock(is_loading=True)
+    hud_main.hud_dict["test_table"] = mock_hud
+    hud_main.vb = MagicMock()
+
+    with patch.object(hud_main.stats_persistence, "save_hud_stats") as save_stats:
+        hud_main.idle_kill("test_table")
+
+    save_stats.assert_not_called()
 
 
 # Ensures that check_tables calls the correct methods for different table statuses.

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -1165,7 +1165,9 @@ def test_one_failing_hand_does_not_stop_the_batch(hud_main) -> None:
         hud_main._drain_pending_hands()
 
     assert read_stdin.call_args_list == [call("h-bad"), call("h-good")]
-    hud_main.db_connection.connection.rollback.assert_called_once_with()
+    # Once to clear the ordinary statement error before continuing, then once
+    # to release the successful read transaction at the end of the batch.
+    assert hud_main.db_connection.connection.rollback.call_count == 2
     # The table that failed is *not* excluded: it never got its new hand, so
     # it still needs the statistics refresh.
     refresh_other.assert_called_once_with({"table-b"})

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -149,6 +149,7 @@ class TestHudInitialization(unittest.TestCase):
             assert hud.game_type == "ring"
             assert hud.max == 6
             assert hud.site == "PokerStars"
+            assert hud.is_loading is False
 
             # Check that hud_params is a copy, not reference
             assert hud.hud_params == self.mock_parent.hud_params

--- a/test/test_hud_db_outage.py
+++ b/test/test_hud_db_outage.py
@@ -75,6 +75,9 @@ def make_hud_main(**attrs):
     hud._db_available = True
     hud._db_recovery_worker = None
     hud._pending_hands = []
+    hud._deferred_hands = []
+    hud._hand_batch_timer = MagicMock()
+    hud._hand_batch_timer.isActive.return_value = False
     hud.hud_dict = {}
     hud.cache = {}
     hud.started_recovery = 0
@@ -124,30 +127,87 @@ def test_table_info_reports_the_outage_instead_of_swallowing_it() -> None:
     hud.db_connection.connection.rollback.assert_not_called()
 
 
-def test_hands_arriving_during_an_outage_are_dropped_not_queried() -> None:
+def test_hands_arriving_during_an_outage_are_deferred_not_queried() -> None:
     hud = make_hud_main(_db_available=False)
 
     hud.handle_message("456")
 
     assert hud._pending_hands == []
+    assert hud._deferred_hands == ["456"]
     hud.db_connection.connection.rollback.assert_not_called()
 
 
-def test_a_pending_batch_is_dropped_rather_than_run_against_a_dead_link() -> None:
+def test_a_pending_batch_is_deferred_rather_than_run_against_a_dead_link() -> None:
     hud = make_hud_main(_db_available=False, _pending_hands=["1", "2", "3"])
 
     hud._drain_pending_hands()
 
     assert hud._pending_hands == []
+    assert hud._deferred_hands == ["1", "2", "3"]
     hud.db_connection.get_table_info.assert_not_called()
 
 
 def test_recovery_closes_the_breaker() -> None:
-    hud = make_hud_main(_db_available=False)
+    hud = make_hud_main(_db_available=False, _deferred_hands=["41", "42"])
 
     hud._on_db_recovered()
 
     assert hud._db_available is True
+    assert hud._deferred_hands == []
+    assert hud._pending_hands == ["41", "42"]
+    hud._hand_batch_timer.start.assert_called_once_with()
+
+
+def test_deferred_hands_are_deduplicated_and_bounded() -> None:
+    hud = make_hud_main(_deferred_hands=["1", "2", "3"])
+
+    saved = HUD_main.MAX_DEFERRED_HANDS
+    HUD_main.MAX_DEFERRED_HANDS = 3
+    try:
+        hud._defer_hands(["2", "4"])
+    finally:
+        HUD_main.MAX_DEFERRED_HANDS = saved
+
+    assert hud._deferred_hands == ["3", "2", "4"]
+
+
+def test_a_successful_read_batch_ends_its_transaction() -> None:
+    hud = make_hud_main(_pending_hands=["1"])
+    hud._get_table_info = MagicMock(
+        return_value=("table", 6, "holdem", "ring", False, 1, "Site", 6, None, None, None),
+    )
+    hud.read_stdin = MagicMock(return_value="table")
+    hud._refresh_other_huds = MagicMock()
+
+    hud._drain_pending_hands()
+
+    hud.db_connection.connection.rollback.assert_called_once_with()
+
+
+def test_a_connection_lost_during_lookup_defers_the_batch_without_racing_recovery() -> None:
+    hud = make_hud_main(_pending_hands=["1", "2"])
+    hud.db_connection.get_table_info.side_effect = lost_connection_error()
+
+    hud._drain_pending_hands()
+
+    assert hud._db_available is False
+    assert hud._deferred_hands == ["1", "2"]
+    # Once the breaker opens, the recovery worker owns the connection.
+    hud.db_connection.connection.rollback.assert_not_called()
+
+
+def test_a_connection_lost_during_refresh_defers_the_batch() -> None:
+    hud = make_hud_main(_pending_hands=["1"])
+    hud._get_table_info = MagicMock(
+        return_value=("table", 6, "holdem", "ring", False, 1, "Site", 6, None, None, None),
+    )
+    hud.read_stdin = MagicMock(return_value="table")
+    hud._refresh_other_huds = MagicMock(side_effect=lambda _refreshed: setattr(hud, "_db_available", False))
+
+    hud._drain_pending_hands()
+
+    assert hud._deferred_hands == ["1"]
+    hud.db_connection.connection.rollback.assert_not_called()
 
 
 def test_recovery_worker_stops_at_the_first_success() -> None:

--- a/test/test_hud_postgresql_integration.py
+++ b/test/test_hud_postgresql_integration.py
@@ -1,0 +1,52 @@
+"""Live PostgreSQL checks for the HUD's read-transaction boundary."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from fpdb_3_legacy.Database import Database
+from test.test_database_backend_integration import _connection, _enabled_backends
+
+pytestmark = pytest.mark.integration
+
+
+def _load_hud_main():
+    source = Path(__file__).parent.parent / "fpdb_3_legacy" / "HUD_main.pyw"
+    loader = importlib.machinery.SourceFileLoader("HUD_main_postgresql_integration", str(source))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def _backend_state(observer, backend_pid: int) -> str:
+    with observer.cursor() as cursor:
+        cursor.execute("SELECT state FROM pg_stat_activity WHERE pid = %s", (backend_pid,))
+        return cursor.fetchone()[0]
+
+
+def test_hud_read_batch_returns_postgresql_connection_to_idle() -> None:
+    """A remote pool must be able to reuse the server slot between HUD batches."""
+    if "postgresql" not in _enabled_backends():
+        pytest.skip("live PostgreSQL service not requested")
+
+    hud_module = _load_hud_main()
+    with _connection("postgresql") as hud_connection, _connection("postgresql") as observer:
+        observer.autocommit = True
+        with hud_connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+
+        assert _backend_state(observer, hud_connection.info.backend_pid) == "idle in transaction"
+
+        hud = hud_module.HudMain.__new__(hud_module.HudMain)
+        hud._db_available = True
+        hud.db_connection = SimpleNamespace(connection=hud_connection, backend=Database.PGSQL)
+        hud._finish_read_batch()
+
+        assert _backend_state(observer, hud_connection.info.backend_pid) == "idle"

--- a/test/test_hud_read_service.py
+++ b/test/test_hud_read_service.py
@@ -1,0 +1,286 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fpdb_3_legacy import hud_read_service
+from fpdb_3_legacy.hud_read_service import (
+    HudBatchReadRequest,
+    HudBatchSnapshot,
+    HudPreparedHand,
+    HudReadService,
+    HudReplayDatabase,
+    HudTableReadContext,
+)
+
+
+def _table_info(table: str, site_id: int = 1) -> tuple:
+    return (table, 6, "holdem", "ring", False, site_id, "site", 6, None, None, None)
+
+
+def _config() -> MagicMock:
+    config = MagicMock()
+    config.get_supported_sites.return_value = []
+    config.get_supported_games_parameters.return_value = {}
+    return config
+
+
+def _database() -> MagicMock:
+    database = MagicMock()
+    database.backend = 0
+    database.get_hand_positions.side_effect = lambda hand_id: {"position": str(hand_id)}
+    database.get_seat_players.side_effect = lambda hand_id: {"seat": str(hand_id)}
+    database.get_table_min_stack_bb.return_value = 25
+    database.get_cards.return_value = {"hero": [1, 2]}
+    database.get_common_cards.return_value = {"common": [3, 4, 5]}
+    database.get_stats_from_hand.side_effect = lambda hand_id, *_args, **_kwargs: {"hand": str(hand_id)}
+    return database
+
+
+def test_read_batch_keeps_only_latest_primary_hand_and_finishes_transaction() -> None:
+    database = _database()
+    database.get_table_info.side_effect = lambda hand_id: _table_info("table-a")
+    service = HudReadService(_config(), database, hand_factory=lambda hand_id, *_args: f"hand-{hand_id}")
+
+    snapshot = service.read_batch(
+        HudBatchReadRequest(
+            sequence=7,
+            hand_ids=("101", "102"),
+            hud_params={"hud_days": 30, "h_hud_days": 90},
+        ),
+    )
+
+    assert snapshot.primary_order == ("102",)
+    assert snapshot.hands["102"].hand_instance == "hand-102"
+    assert snapshot.hands["102"].cards["common"] == [3, 4, 5]
+    database.get_stats_from_hand.assert_called_once()
+    database.connection.rollback.assert_called_once()
+
+
+def test_secondary_huds_share_one_batched_stats_query_and_normalize_ids() -> None:
+    database = _database()
+    database.get_table_info.side_effect = lambda hand_id: _table_info(f"table-{hand_id}")
+    database.get_stats_from_hands.return_value = {
+        201: {"value": "a"},
+        202: {"value": "b"},
+    }
+    service = HudReadService(_config(), database)
+    params = {"hud_days": 30, "h_hud_days": 90}
+    contexts = tuple(
+        HudTableReadContext(
+            temp_key=f"table-{hand_id}",
+            last_hand_id=str(hand_id),
+            hud_params=params,
+            poker_game="holdem",
+            game_type="ring",
+            site_id=1,
+            num_seats=6,
+        )
+        for hand_id in (201, 202)
+    )
+
+    snapshot = service.read_batch(HudBatchReadRequest(3, (), params, contexts))
+
+    database.get_stats_from_hands.assert_called_once()
+    assert snapshot.hands["201"].stat_dict == {"value": "a"}
+    assert snapshot.hands["202"].stat_dict == {"value": "b"}
+
+
+def test_worker_can_publish_each_primary_table_before_the_batch_is_complete() -> None:
+    database = _database()
+    database.get_table_info.side_effect = lambda hand_id: _table_info(f"table-{hand_id}")
+    service = HudReadService(_config(), database, hand_factory=lambda *_args: None)
+    progress = []
+
+    final = service.read_batch(
+        HudBatchReadRequest(
+            sequence=8,
+            hand_ids=("211", "212"),
+            hud_params={"hud_days": 30, "h_hud_days": 90},
+        ),
+        progress_callback=progress.append,
+    )
+
+    assert [snapshot.primary_order for snapshot in progress] == [
+        ("211",),
+        ("212",),
+        ("211",),
+        ("212",),
+    ]
+    assert [snapshot.identity_only for snapshot in progress] == [True, True, False, False]
+    assert [snapshot.final for snapshot in progress] == [False, False, False, False]
+    assert final.final is True
+    assert final.revision == 5
+    assert database.connection.rollback.call_count == 5
+
+
+def test_table_identity_is_emitted_before_hero_or_statistics_queries() -> None:
+    order: list[str] = []
+    database = _database()
+    database.get_table_info.side_effect = lambda _hand_id: (order.append("table_info") or _table_info("table-a"))
+    database.get_stats_from_hand.side_effect = lambda *_args, **_kwargs: (order.append("stats") or {})
+    config = _config()
+    config.get_supported_sites.side_effect = lambda: (order.append("hero") or [])
+    service = HudReadService(config, database, hand_factory=lambda *_args: None)
+
+    def on_progress(snapshot: HudBatchSnapshot) -> None:
+        if snapshot.identity_only:
+            order.append("identity")
+
+    service.read_batch(
+        HudBatchReadRequest(10, ("601",), {"hud_days": 30, "h_hud_days": 90}),
+        progress_callback=on_progress,
+    )
+
+    assert order[:4] == ["table_info", "identity", "hero", "stats"]
+
+
+def test_progress_snapshot_does_not_deepcopy_the_opaque_hand_instance() -> None:
+    class OpaqueHand:
+        def __deepcopy__(self, _memo):
+            raise AssertionError("Hand instances are not required to support deepcopy")
+
+    opaque_hand = OpaqueHand()
+    database = _database()
+    database.get_table_info.return_value = _table_info("table-a")
+    service = HudReadService(_config(), database, hand_factory=lambda *_args: opaque_hand)
+    progress = []
+
+    service.read_batch(
+        HudBatchReadRequest(11, ("701",), {"hud_days": 30, "h_hud_days": 90}),
+        progress_callback=progress.append,
+    )
+
+    full_snapshot = next(snapshot for snapshot in progress if not snapshot.identity_only)
+    assert full_snapshot.hands["701"].hand_instance is opaque_hand
+
+
+def test_hero_lookup_is_cached_across_worker_batches() -> None:
+    database = _database()
+    config = _config()
+    service = HudReadService(config, database)
+    request = HudBatchReadRequest(1, (), {"hud_days": 30, "h_hud_days": 90})
+
+    service.read_batch(request)
+    service.read_batch(request)
+
+    config.get_supported_sites.assert_called_once()
+    assert database.connection.rollback.call_count == 2
+
+
+def test_missing_hero_is_retried_instead_of_cached_forever() -> None:
+    database = _database()
+    database.get_site_id.return_value = [(1,)]
+    database.get_player_id.side_effect = [None, 42]
+    config = _config()
+    config.get_supported_sites.return_value = ["Site"]
+    config.supported_sites = {"Site": MagicMock(screen_name="hero")}
+    service = HudReadService(config, database)
+    request = HudBatchReadRequest(1, (), {"hud_days": 30, "h_hud_days": 90})
+
+    first = service.read_batch(request)
+    second = service.read_batch(request)
+
+    assert first.hero_ids == {1: -1}
+    assert second.hero_ids == {1: 42}
+    assert database.get_player_id.call_count == 2
+
+
+def test_failed_primary_read_preloads_its_previous_secondary_hand() -> None:
+    database = _database()
+    database.get_table_info.side_effect = lambda hand_id: _table_info("table-a")
+    database.get_stats_from_hand.side_effect = RuntimeError("primary failed")
+    database.get_stats_from_hands.return_value = {401: {"old": True}}
+    service = HudReadService(_config(), database)
+    params = {"hud_days": 30, "h_hud_days": 90}
+    context = HudTableReadContext(
+        temp_key="table-a",
+        last_hand_id="401",
+        hud_params=params,
+        poker_game="holdem",
+        game_type="ring",
+        site_id=1,
+        num_seats=6,
+    )
+
+    snapshot = service.read_batch(HudBatchReadRequest(4, ("402",), params, (context,)))
+
+    assert snapshot.failed_hand_ids == ("402",)
+    assert snapshot.hands["401"].stat_dict == {"old": True}
+
+
+def test_statement_timeout_aborts_the_batch_instead_of_timing_out_every_table() -> None:
+    class StatementTimeout(RuntimeError):
+        sqlstate = "57014"
+
+    database = _database()
+    database.get_table_info.return_value = _table_info("table-a")
+    database.get_stats_from_hand.side_effect = StatementTimeout("statement timeout")
+    service = HudReadService(_config(), database)
+
+    progress = []
+    with pytest.raises(StatementTimeout):
+        service.read_batch(
+            HudBatchReadRequest(
+                9,
+                ("501", "502"),
+                {"hud_days": 30, "h_hud_days": 90},
+            ),
+            progress_callback=progress.append,
+        )
+
+    database.get_stats_from_hand.assert_called_once()
+    assert len(progress) == 2
+    assert all(snapshot.identity_only for snapshot in progress)
+
+
+def test_replay_database_accepts_string_input_for_integer_database_ids() -> None:
+    prepared = HudPreparedHand(
+        hand_id="301",
+        stat_dict={"value": 9},
+        loaded_fields=frozenset({"stat_dict"}),
+    )
+    snapshot = HudBatchSnapshot(1, (), (), {"301": prepared}, {}, {}, {}, {})
+    replay = HudReplayDatabase(snapshot, backend=0)
+
+    assert replay.get_stats_from_hand(301) == {"value": 9}
+    assert replay.get_stats_from_hands([301]) == {301: {"value": 9}}
+
+
+def test_replay_database_logs_a_missing_preload_instead_of_failing_silently() -> None:
+    prepared = HudPreparedHand(
+        hand_id="302",
+        table_info=_table_info("table-a"),
+        loaded_fields=frozenset({"table_info"}),
+    )
+    replay = HudReplayDatabase(HudBatchSnapshot(1, (), (), {"302": prepared}, {}, {}, {}, {}), backend=0)
+
+    with patch.object(hud_read_service.log, "debug") as debug:
+        assert replay.get_action_from_hand("302") == []
+
+    debug.assert_called_once()
+
+
+def test_expected_identity_misses_are_not_logged() -> None:
+    prepared = HudPreparedHand(
+        hand_id="303",
+        table_info=_table_info("table-a"),
+        loaded_fields=frozenset({"table_info"}),
+    )
+    snapshot = HudBatchSnapshot(
+        1,
+        (),
+        (),
+        {"303": prepared},
+        {},
+        {},
+        {},
+        {},
+        identity_only=True,
+    )
+    replay = HudReplayDatabase(snapshot, backend=0)
+
+    with patch.object(hud_read_service.log, "debug") as debug:
+        assert replay.get_seat_players("303") == {}
+        assert replay.get_table_min_stack_bb("303") is None
+
+    debug.assert_not_called()


### PR DESCRIPTION
## Summary

- move every HUD database read to a worker-owned connection so a slow or unreachable remote database cannot block the Qt paint thread
- emit table identity immediately after `get_table_info()` and create an empty loading HUD after one database round trip
- replay completed database snapshots through an in-memory facade on the Qt thread
- close each read transaction promptly, reconnect in the worker, bound queued hands, and back off repeated timeouts
- stop opening one extra database connection per HUD table and close legacy per-table connections during teardown

## Root cause

The HUD performed several sequential SQL reads directly on the Qt thread. A slow but live VPN therefore blocked painting for the duration of the entire read batch. Successful PostgreSQL reads also left the non-autocommit connection `idle in transaction`, which can retain a PgBouncer transaction-pool slot or block DDL.

The connection-loss circuit breaker could only react after an exception. It could not help while the network remained connected but slow.

## Implementation

`HudReadWorker` now exclusively owns the real database connection. It applies session-local PostgreSQL statement, lock, and idle-transaction timeouts after every connection or reconnection.

`HudReadService` emits an identity snapshot immediately after the table lookup, before hero and statistics queries. The Qt thread uses this snapshot to attach an empty loading HUD. Full statistics, positions, seats, cards, hand data, and optional mucked-card data arrive later as detached snapshots.

The Qt path reads those snapshots through `HudReplayDatabase`; it no longer executes SQL. Missing preloaded fields are distinguishable from legitimate empty values and are logged outside the expected identity-only phase.

Repeated query failures keep the loading HUD visible. Retries run every five seconds for the first five failures, then back off to thirty seconds with one explicit error. Pending and deferred hand queues are deduplicated and bounded.

## Controlled reproduction

- Direct PostgreSQL importer DML was not blocked by the old idle transaction, but DDL requiring `ACCESS EXCLUSIVE` was.
- With PgBouncer transaction pooling and a server pool size of one, the importer waited for the HUD transaction slot and resumed when the HUD process stopped.
- With 250 ms latency in each direction, the old synchronous path blocked the Qt heartbeat for several seconds.
- The worker test now holds the database read for 350 ms while the Qt heartbeat continues at roughly 10 ms intervals.

## Validation

- full Qt suite: 493 passed, 1 expected xpass
- focused HUD worker, replay, outage, and `Hud` tests pass
- Ruff passes across the repository
- Pyright reports zero errors
- live PostgreSQL integration covers the read-transaction boundary when the service is enabled

## Post-merge deployment check

The affected VPN installation will be tested after merge. Expected behavior is that the loading HUD appears after the table-info round trip and fills with statistics later. Consecutive batch failures, replay misses outside the identity phase, and repeated `hero is not seated` removals are logged explicitly for diagnosis.
