### PR TITLE
Fix HUD creation after asynchronous preload

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -2004,9 +2004,35 @@ class HudMain(QObject):
             return None
 
         if temp_key in self.hud_dict:
-            log.debug("Updating existing HUD for temp_key: %s", temp_key)
-            if not self._update_existing_hud(new_hand_id, temp_key, game_type, site_id, num_seats):
-                return None
+            hud = self.hud_dict[temp_key]
+            if getattr(hud, "is_loading", False) is True:
+                # The identity-only snapshot deliberately creates the HUD before
+                # player seats and statistics are available.  Aux windows derive
+                # their visual-to-physical seat map in create(), so updating that
+                # empty HUD in place leaves every slot mapped to None and every
+                # player block hidden.  Recreate it once with the complete
+                # snapshot so seat rotation, player lookup, and visibility are
+                # all initialized from the same hand data.
+                log.info(
+                    "Replacing loading HUD with complete HUD for table %s and hand %s",
+                    temp_key,
+                    new_hand_id,
+                )
+                self.kill_hud(None, temp_key)
+                self._create_new_hud(
+                    new_hand_id,
+                    temp_key,
+                    table_info,
+                    site_id,
+                    num_seats,
+                    hud_site_name,
+                )
+                if temp_key not in self.hud_dict:
+                    return None
+            else:
+                log.debug("Updating existing HUD for temp_key: %s", temp_key)
+                if not self._update_existing_hud(new_hand_id, temp_key, game_type, site_id, num_seats):
+                    return None
         else:
             log.debug("Creating new HUD for temp_key: %s", temp_key)
             self._create_new_hud(new_hand_id, temp_key, table_info, site_id, num_seats, hud_site_name)

--- a/fpdb_3_legacy/hud_read_service.py
+++ b/fpdb_3_legacy/hud_read_service.py
@@ -299,6 +299,34 @@ class HudReadService:
             self._handle_read_error(exc)
             return None
 
+    def _mucked_data(self, hand_id: str, needed: bool) -> tuple[dict, list]:
+        """Best-effort aux data that must never suppress the primary HUD."""
+        if not needed:
+            return {}, []
+
+        winners = {}
+        try:
+            winners = self.database.get_winners_from_hand(hand_id)
+        except Exception as exc:
+            self._handle_read_error(exc)
+            log.warning("Could not preload HUD winners for hand %s: %s", hand_id, exc)
+
+        # Mucked.py deliberately leaves action rendering disabled until this
+        # query exists.  Calling Database.get_action_from_hand unconditionally
+        # raises KeyError on every current backend and used to invalidate the
+        # complete prepared hand, leaving only an invisible loading HUD.
+        queries = getattr(getattr(self.database, "sql", None), "query", {})
+        if "get_action_from_hand" not in queries:
+            return winners, []
+
+        try:
+            actions = self.database.get_action_from_hand(hand_id)
+        except Exception as exc:
+            self._handle_read_error(exc)
+            log.warning("Could not preload HUD actions for hand %s: %s", hand_id, exc)
+            actions = []
+        return winners, actions
+
     def _read_hand(
         self,
         hand_id: str,
@@ -318,8 +346,7 @@ class HudReadService:
             num_seats,
             poker_game=poker_game,
         )
-        winners = self.database.get_winners_from_hand(hand_id) if needs_mucked_data else {}
-        actions = self.database.get_action_from_hand(hand_id) if needs_mucked_data else []
+        winners, actions = self._mucked_data(hand_id, needs_mucked_data)
         loaded_fields = {
             "table_info",
             "stat_dict",
@@ -372,6 +399,7 @@ class HudReadService:
                 table_info = self.database.get_table_info(hand_id)
             except Exception as exc:
                 self._handle_read_error(exc)
+                log.exception("HUD primary preload failed for hand %s", hand_id)
                 failed.append(hand_id)
                 continue
             if table_info is None:

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -345,6 +345,37 @@ def test_loading_hud_builds_empty_creation_args_without_querying_stats(hud_main)
     assert args.cards == {}
 
 
+def test_complete_snapshot_recreates_loading_hud_with_player_seat_mapping(hud_main) -> None:
+    """An identity-only HUD cannot be upgraded in place after seats arrive."""
+    hand_id = "101"
+    table_info = ("table-a", 6, "holdem", "ring", False, 1, "site", 6, None, None, None)
+    hud_main.cache[hand_id] = table_info
+    hud_main.hud_dict["table-a"] = MagicMock(is_loading=True)
+    hud_main.config.get_supported_sites.return_value = ["site"]
+    hud_main.config.get_site_parameters.return_value = {"aux_enabled": True}
+
+    def kill_loading_hud(_event, temp_key):
+        del hud_main.hud_dict[temp_key]
+
+    def create_complete_hud(_hand_id, temp_key, *_args, **_kwargs):
+        hud_main.hud_dict[temp_key] = MagicMock(is_loading=False)
+
+    with (
+        patch.object(hud_main, "_initialize_hero_data"),
+        patch.object(hud_main, "_handle_tournament_table_changes", return_value=False),
+        patch.object(hud_main, "_handle_hud_reconfiguration", return_value=("holdem", None)),
+        patch.object(hud_main, "kill_hud", side_effect=kill_loading_hud) as kill_hud,
+        patch.object(hud_main, "_create_new_hud", side_effect=create_complete_hud) as create_hud,
+        patch.object(hud_main, "_update_existing_hud") as update_hud,
+    ):
+        assert hud_main.read_stdin(hand_id) == "table-a"
+
+    kill_hud.assert_called_once_with(None, "table-a")
+    create_hud.assert_called_once_with(hand_id, "table-a", table_info, 1, 6, "site")
+    update_hud.assert_not_called()
+    assert hud_main._last_processed_hands["table-a"] == hand_id
+
+
 def test_runtime_replay_error_cannot_start_the_legacy_recovery_worker(hud_main) -> None:
     hud_main._db_worker = MagicMock()
 

--- a/test/test_hud_read_service.py
+++ b/test/test_hud_read_service.py
@@ -113,6 +113,33 @@ def test_worker_can_publish_each_primary_table_before_the_batch_is_complete() ->
     assert database.connection.rollback.call_count == 5
 
 
+def test_missing_mucked_action_query_does_not_fail_the_primary_hud() -> None:
+    database = _database()
+    database.get_table_info.return_value = _table_info("table-a")
+    database.get_winners_from_hand.return_value = {"hero": 100}
+    database.sql.query = {}
+    config = _config()
+    config.get_supported_games_parameters.return_value = {"aux": "Mucked"}
+    config.get_aux_parameters.return_value = {"module": "Mucked"}
+    service = HudReadService(config, database, hand_factory=lambda *_args: None)
+
+    snapshot = service.read_batch(
+        HudBatchReadRequest(
+            sequence=12,
+            hand_ids=("801",),
+            hud_params={"hud_days": 30, "h_hud_days": 90},
+        ),
+    )
+
+    prepared = snapshot.hands["801"]
+    assert snapshot.failed_hand_ids == ()
+    assert prepared.stat_dict == {"hand": "801"}
+    assert prepared.seat_players == {"seat": "801"}
+    assert prepared.winners == {"hero": 100}
+    assert prepared.actions == []
+    database.get_action_from_hand.assert_not_called()
+
+
 def test_table_identity_is_emitted_before_hero_or_statistics_queries() -> None:
     order: list[str] = []
     database = _database()


### PR DESCRIPTION
## Summary

- keep optional Mucked-card action preloading from invalidating the complete HUD snapshot when the SQL query is unavailable
- recreate identity-only loading HUDs once player seats and statistics arrive
- add regression coverage for both failure modes and log primary preload failures with the affected hand ID

## Root cause

The asynchronous HUD reader treated `get_action_from_hand` as mandatory whenever the Mucked auxiliary window was enabled. The query is not defined by the current SQL backends, so the complete prepared hand was discarded and only the identity-only loading HUD remained.

That loading HUD was created before player seats were available. Auxiliary windows compute their visual-to-physical seat mapping during creation, leaving every slot mapped to `None`. Updating the loading HUD in place did not rebuild that mapping, so all player blocks stayed hidden even after valid statistics arrived.

## Impact

The HUD now appears quickly from the identity snapshot and is replaced with a correctly initialized full HUD when the complete snapshot arrives. Optional Mucked data can no longer suppress the primary statistics HUD.

## Validation

- `QT_QPA_PLATFORM=offscreen python -m pytest -q test/test_HUD_main.py test/test_hud_read_service.py test/test_hud_db_outage.py -m 'qt or not qt'` — 113 passed
- `QT_QPA_PLATFORM=offscreen python -m pytest -q test/test_hud_seat_mapping.py test/test_multiblock_hud.py -m 'qt or not qt'` — 73 passed
- `ruff check fpdb_3_legacy/HUD_main.pyw fpdb_3_legacy/hud_read_service.py test/test_HUD_main.py test/test_hud_read_service.py` — passed
- live local-database run — HUD visibility restored