### PR TITLE
perf(hud): avoid duplicate overlay construction

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -93,6 +93,7 @@ class HUDCreationArgs:
     stat_dict: dict[str, Any]
     cards: dict[str, Any]
     hand_instance: Any = None
+    loading: bool = False
 
 
 class ZMQWorker(QThread):
@@ -1137,8 +1138,9 @@ class HudMain(QObject):
 
         self.hud_dict[args.temp_key].hud_params["new_max_seats"] = None  # trigger for seat layout change
 
-        for aw in self.hud_dict[args.temp_key].aux_windows:
-            aw.update_data(args.new_hand_id, self.db_connection)
+        if not args.loading:
+            for aw in self.hud_dict[args.temp_key].aux_windows:
+                aw.update_data(args.new_hand_id, self.db_connection)
 
         self.idle_create(args)
         log.debug("HUD for table %s created successfully.", args.temp_key)
@@ -1826,7 +1828,8 @@ class HudMain(QObject):
             stat_dict = merged_data.get("stat_dict", stat_dict)
             log.debug("Merged cached stats with fresh database stats")
 
-        self._merge_positions(stat_dict, new_hand_id)
+        if not loading:
+            self._merge_positions(stat_dict, new_hand_id)
         if not loading and not any(stat_dict[key]["screen_name"] == self.hero[site_id] for key in stat_dict):
             log.warning(
                 "HUD not created for hand %s table=%s: hero %r (site_id=%s) not among players %s",
@@ -1907,12 +1910,14 @@ class HudMain(QObject):
                 stat_dict=stat_dict,
                 cards=cards,
                 hand_instance=prepared.hand_instance if prepared is not None else None,
+                loading=loading,
             )
             self.create_HUD(args)
             if args.temp_key in self.hud_dict:
                 self.hud_dict[args.temp_key].is_loading = loading
-                self.hud_dict[args.temp_key].seat_players = self._seat_players(new_hand_id)
-                self._set_table_stats(self.hud_dict[args.temp_key], new_hand_id)
+                if not loading:
+                    self.hud_dict[args.temp_key].seat_players = self._seat_players(new_hand_id)
+                    self._set_table_stats(self.hud_dict[args.temp_key], new_hand_id)
         else:
             log.error('Table "%s" no longer exists', table_name)
 
@@ -2199,6 +2204,10 @@ class HudMain(QObject):
                 cards=args.cards,
                 hand_instance=args.hand_instance,
             )
+            if args.loading:
+                self._create_loading_indicator(self.hud_dict[args.temp_key])
+                hud_trace("idle_create loading: table=%s hand=%s", args.temp_key, args.new_hand_id)
+                return
             for aux_index, m in enumerate(self.hud_dict[args.temp_key].aux_windows):
                 try:
                     m.create()
@@ -2217,6 +2226,39 @@ class HudMain(QObject):
 
         except Exception:
             log.exception("Error creating HUD for hand %s.", args.new_hand_id)
+
+    @staticmethod
+    def _create_loading_indicator(hud: Hud.Hud) -> None:
+        """Show one cheap table overlay while the complete snapshot is loading."""
+        label: QLabel | None = None
+        try:
+            flags = Qt.WindowType.Window | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint
+            label = QLabel("Loading HUD…", None, flags)
+            label.setObjectName("hud-loading-indicator")
+            label.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+            label.setStyleSheet(
+                "QLabel { color: white; background: rgba(20, 20, 20, 210); "
+                "border: 1px solid #777; border-radius: 4px; padding: 6px 10px; }",
+            )
+            label.adjustSize()
+            table_x = hud.table.x if hud.table.x is not None else 0
+            table_y = hud.table.y if hud.table.y is not None else 0
+            table_width = hud.table.width if hud.table.width is not None else label.width()
+            table_height = hud.table.height if hud.table.height is not None else label.height()
+            x = table_x + max(0, (table_width - label.width()) // 2)
+            y = table_y + max(0, (table_height - label.height()) // 2)
+            x, y = Aux_Base.clamp_to_screen(x, y)
+            label.move(x, y)
+            label.create()
+            hud.table.topify(label)
+            label.show()
+            hud.loading_window = label
+        except Exception:
+            if label is not None:
+                label.close()
+                label.deleteLater()
+            hud.loading_window = None
+            log.exception("Could not create loading indicator for table %s", hud.table_name)
 
     def idle_update(
         self,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -2132,6 +2132,7 @@ class HudMain(QObject):
             # Real geometry change: bump the generation so block windows re-place.
             hud.geometry_generation += 1
             hud.move_table_position()
+            self._position_loading_indicator(hud)
             for aw in hud.aux_windows:
                 aw.move_windows()
         except Exception:
@@ -2143,6 +2144,7 @@ class HudMain(QObject):
             # Real geometry change: bump the generation so block windows re-place.
             hud.geometry_generation += 1
             hud.resize_windows()
+            self._position_loading_indicator(hud)
             for aw in hud.aux_windows:
                 aw.resize_windows()
         except Exception:
@@ -2241,24 +2243,32 @@ class HudMain(QObject):
                 "border: 1px solid #777; border-radius: 4px; padding: 6px 10px; }",
             )
             label.adjustSize()
-            table_x = hud.table.x if hud.table.x is not None else 0
-            table_y = hud.table.y if hud.table.y is not None else 0
-            table_width = hud.table.width if hud.table.width is not None else label.width()
-            table_height = hud.table.height if hud.table.height is not None else label.height()
-            x = table_x + max(0, (table_width - label.width()) // 2)
-            y = table_y + max(0, (table_height - label.height()) // 2)
-            x, y = Aux_Base.clamp_to_screen(x, y)
-            label.move(x, y)
+            hud.loading_window = label
+            HudMain._position_loading_indicator(hud)
             label.create()
             hud.table.topify(label)
             label.show()
-            hud.loading_window = label
         except Exception:
             if label is not None:
                 label.close()
                 label.deleteLater()
             hud.loading_window = None
             log.exception("Could not create loading indicator for table %s", hud.table_name)
+
+    @staticmethod
+    def _position_loading_indicator(hud: Hud.Hud) -> None:
+        """Keep the provisional indicator centered on the current table geometry."""
+        label = hud.loading_window
+        if label is None:
+            return
+        table_x = hud.table.x if hud.table.x is not None else 0
+        table_y = hud.table.y if hud.table.y is not None else 0
+        table_width = hud.table.width if hud.table.width is not None else label.width()
+        table_height = hud.table.height if hud.table.height is not None else label.height()
+        x = table_x + max(0, (table_width - label.width()) // 2)
+        y = table_y + max(0, (table_height - label.height()) // 2)
+        x, y = Aux_Base.clamp_to_screen(x, y)
+        label.move(x, y)
 
     def idle_update(
         self,

--- a/fpdb_3_legacy/Hud.py
+++ b/fpdb_3_legacy/Hud.py
@@ -112,6 +112,7 @@ class Hud:
         self.seat_players: dict[Any, Any] = {}
         self.hand_instance: Any = None
         self.is_loading = False
+        self.loading_window: Any = None
         self.table_name = ""
         self.tablenumber: Any = None
         self.tablehudlabel: Any = None
@@ -211,6 +212,14 @@ class Hud:
             except Exception:  # intentional broad catch: aux window callback boundary.
                 log.exception("Error killing aux window")
         self.aux_windows = []
+        if self.loading_window is not None:
+            try:
+                self.loading_window.hide()
+                self.loading_window.close()
+                self.loading_window.deleteLater()
+            except Exception:
+                log.exception("Error killing HUD loading indicator")
+            self.loading_window = None
         if self.db_hud_connection is not None:
             try:
                 self.db_hud_connection.close_connection()
@@ -347,13 +356,6 @@ class Hud:
                 self.hand_instance = None
 
         log.info("Creating hud from hand %d", hand)
-
-        # Call create on all aux windows
-        for aux in self.aux_windows:
-            try:
-                aux.create()
-            except Exception:  # intentional broad catch: aux window callback boundary.
-                log.exception("Error creating aux window")
 
     def update(
         self,

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -336,13 +336,19 @@ def test_loading_hud_builds_empty_creation_args_without_querying_stats(hud_main)
     with (
         patch.object(hud_main.db_connection, "get_stats_from_hand") as get_stats,
         patch.object(hud_main, "create_HUD") as create_hud,
+        patch.object(hud_main, "_seat_players") as seat_players,
+        patch.object(hud_main, "_set_table_stats") as set_table_stats,
     ):
+        create_hud.side_effect = lambda args: hud_main.hud_dict.__setitem__(args.temp_key, MagicMock())
         hud_main._create_new_hud("101", "table-a", table_info, 1, 6, "site", loading=True)
 
     get_stats.assert_not_called()
     args = create_hud.call_args.args[0]
     assert args.stat_dict == {}
     assert args.cards == {}
+    assert args.loading is True
+    seat_players.assert_not_called()
+    set_table_stats.assert_not_called()
 
 
 def test_complete_snapshot_recreates_loading_hud_with_player_seat_mapping(hud_main) -> None:
@@ -1131,6 +1137,104 @@ def test_idle_create(hud_main) -> None:
 
         # Check logs - the method creates a label with site and temp_key
         mock_log.debug.assert_any_call("adding label %s", f"{table.site} - {args.temp_key}")
+
+
+def test_idle_create_builds_and_updates_each_auxiliary_once(hud_main) -> None:
+    mock_hud = MagicMock()
+    first_aux = MagicMock()
+    second_aux = MagicMock()
+    mock_hud.aux_windows = [first_aux, second_aux]
+    hud_main.hud_dict = {"test_table": mock_hud}
+    hud_main.vb = MagicMock()
+    table = MagicMock(site="test_site", number=123)
+    args = HUD_main.HUDCreationArgs(
+        new_hand_id="new_hand_id",
+        table=table,
+        temp_key="test_table",
+        max_seats=9,
+        poker_game="holdem",
+        game_type="cash",
+        stat_dict={},
+        cards={},
+    )
+
+    hud_main.idle_create(args)
+
+    first_aux.create.assert_called_once_with()
+    first_aux.update_gui.assert_called_once_with(args.new_hand_id)
+    second_aux.create.assert_called_once_with()
+    second_aux.update_gui.assert_called_once_with(args.new_hand_id)
+
+
+def test_idle_create_loading_uses_one_indicator_without_building_auxiliaries(hud_main) -> None:
+    mock_hud = MagicMock()
+    auxiliary = MagicMock()
+    mock_hud.aux_windows = [auxiliary]
+    hud_main.hud_dict = {"test_table": mock_hud}
+    hud_main.vb = MagicMock()
+    table = MagicMock(site="test_site", number=123)
+    args = HUD_main.HUDCreationArgs(
+        new_hand_id="new_hand_id",
+        table=table,
+        temp_key="test_table",
+        max_seats=9,
+        poker_game="holdem",
+        game_type="cash",
+        stat_dict={},
+        cards={},
+        loading=True,
+    )
+
+    with patch.object(hud_main, "_create_loading_indicator") as create_indicator:
+        hud_main.idle_create(args)
+
+    create_indicator.assert_called_once_with(mock_hud)
+    auxiliary.create.assert_not_called()
+    auxiliary.update_gui.assert_not_called()
+
+
+def test_loading_indicator_is_topified_over_the_table(hud_main) -> None:
+    table = MagicMock(x=100, y=50, width=800, height=600)
+    mock_hud = MagicMock(table=table, table_name="test_table", loading_window=None)
+
+    hud_main._create_loading_indicator(mock_hud)
+
+    indicator = mock_hud.loading_window
+    assert indicator is not None
+    assert indicator.objectName() == "hud-loading-indicator"
+    assert indicator.isVisible()
+    table.topify.assert_called_once_with(indicator)
+    indicator.hide()
+    indicator.close()
+    indicator.deleteLater()
+
+
+def test_idle_create_continues_after_one_auxiliary_fails(hud_main) -> None:
+    mock_hud = MagicMock()
+    failing_aux = MagicMock()
+    failing_aux.create.side_effect = RuntimeError("broken auxiliary")
+    healthy_aux = MagicMock()
+    mock_hud.aux_windows = [failing_aux, healthy_aux]
+    hud_main.hud_dict = {"test_table": mock_hud}
+    hud_main.vb = MagicMock()
+    table = MagicMock(site="test_site", number=123)
+    args = HUD_main.HUDCreationArgs(
+        new_hand_id="new_hand_id",
+        table=table,
+        temp_key="test_table",
+        max_seats=9,
+        poker_game="holdem",
+        game_type="cash",
+        stat_dict={},
+        cards={},
+    )
+
+    hud_main.idle_create(args)
+
+    failing_aux.create.assert_called_once_with()
+    failing_aux.update_gui.assert_not_called()
+    healthy_aux.create.assert_called_once_with()
+    healthy_aux.update_gui.assert_called_once_with(args.new_hand_id)
 
 
 def test_idle_update_hands_the_new_hand_to_the_hud(hud_main) -> None:

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -1028,6 +1028,7 @@ def test_close_event_handler(hud_main) -> None:
 def test_idle_move(hud_main) -> None:
     mock_hud = MagicMock()
     mock_hud.aux_windows = [MagicMock()]
+    mock_hud.loading_window = None
     hud_main.idle_move(mock_hud)
 
     mock_hud.move_table_position.assert_called_once()
@@ -1039,11 +1040,23 @@ def test_idle_move(hud_main) -> None:
 def test_idle_resize(hud_main) -> None:
     mock_hud = MagicMock()
     mock_hud.aux_windows = [MagicMock()]
+    mock_hud.loading_window = None
     hud_main.idle_resize(mock_hud)
 
     mock_hud.resize_windows.assert_called_once()
     for aw in mock_hud.aux_windows:
         aw.resize_windows.assert_called_once()
+
+
+@pytest.mark.parametrize("geometry_callback", ["idle_move", "idle_resize"])
+def test_table_geometry_change_recenters_loading_indicator(hud_main, geometry_callback) -> None:
+    mock_hud = MagicMock(loading_window=MagicMock())
+    mock_hud.aux_windows = []
+
+    with patch.object(hud_main, "_position_loading_indicator") as position_indicator:
+        getattr(hud_main, geometry_callback)(mock_hud)
+
+    position_indicator.assert_called_once_with(mock_hud)
 
 
 # Checks that kill_hud removes the HUD from hud_dict and cleans up associated widgets.
@@ -1207,6 +1220,19 @@ def test_loading_indicator_is_topified_over_the_table(hud_main) -> None:
     indicator.hide()
     indicator.close()
     indicator.deleteLater()
+
+
+def test_loading_indicator_position_uses_current_table_geometry(hud_main) -> None:
+    indicator = MagicMock()
+    indicator.width.return_value = 120
+    indicator.height.return_value = 30
+    table = MagicMock(x=200, y=100, width=800, height=600)
+    mock_hud = MagicMock(table=table, loading_window=indicator)
+
+    with patch.object(HUD_main.Aux_Base, "clamp_to_screen", side_effect=lambda x, y: (x, y)):
+        hud_main._position_loading_indicator(mock_hud)
+
+    indicator.move.assert_called_once_with(540, 385)
 
 
 def test_idle_create_continues_after_one_auxiliary_fails(hud_main) -> None:

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -399,11 +399,18 @@ class TestHudMethods(unittest.TestCase):
 
     def test_kill_method(self) -> None:
         """Test kill method calls kill on all aux windows."""
+        loading_window = Mock()
+        self.hud.loading_window = loading_window
+
         self.hud.kill()
 
         # Check that kill was called on all aux windows
         self.mock_aux1.kill.assert_called_once()
         self.mock_aux2.kill.assert_called_once()
+        loading_window.hide.assert_called_once_with()
+        loading_window.close.assert_called_once_with()
+        loading_window.deleteLater.assert_called_once_with()
+        assert self.hud.loading_window is None
 
     def test_resize_windows(self) -> None:
         """Test resize_windows method."""
@@ -445,9 +452,10 @@ class TestHudMethods(unittest.TestCase):
             # Check that get_cards was called
             mock_get_cards.assert_called_once_with(hand_id)
 
-            # Check that create was called on all aux windows
-            self.mock_aux1.create.assert_called_once()
-            self.mock_aux2.create.assert_called_once()
+            # Window creation belongs to HUD_main.idle_create, which can isolate
+            # failures per auxiliary. Hud.create only prepares the hand model.
+            self.mock_aux1.create.assert_not_called()
+            self.mock_aux2.create.assert_not_called()
 
             # Verify cards were set
             assert self.hud.cards == {"hand": "cards"}
@@ -611,7 +619,8 @@ class TestHudIntegration(unittest.TestCase):
             assert len(hud.aux_windows) == 1
             assert mock_aux_instance in hud.aux_windows
 
-            # 2. Create/Update cycle
+            # 2. Prepare/update cycle. HUD_main owns native window creation so
+            # it can isolate failures and guarantee exactly one create call.
             hand_id = 12345
             stat_dict = {"player1": {"vpip": 25.0}}
 
@@ -619,7 +628,7 @@ class TestHudIntegration(unittest.TestCase):
                 mock_get_cards.return_value = {"cards": "data"}
 
                 hud.create(hand_id, mock_config, stat_dict)
-                mock_aux_instance.create.assert_called_once()
+                mock_aux_instance.create.assert_not_called()
 
                 hud.update(hand_id, mock_config)
                 mock_aux_instance.update_gui.assert_called_once_with(hand_id)


### PR DESCRIPTION
## Summary

- make `HUD_main.idle_create()` the single owner of auxiliary window creation
- replace the identity-only loading HUD's full seat/block construction with one lightweight table indicator
- skip player, position, table-stat, and auxiliary preload work while only table identity is available
- explicitly destroy the loading indicator when the provisional HUD is replaced
- add regression coverage for single creation, auxiliary failure isolation, loading-indicator lifecycle, and the loading-to-complete transition

## Root cause

`Hud.create()` called `aux.create()` for every auxiliary, then its only production caller, `HUD_main.idle_create()`, called `m.create()` on the same objects again. `Aux_Base.create()` is not idempotent: it replaces `m_windows` and rebuilds every native seat/block window without destroying the first set.

The asynchronous loading flow amplified this duplication. It built an empty loading HUD and then killed and rebuilt it when the complete snapshot arrived, resulting in up to four complete auxiliary-window construction passes for the first hand at a table, all on the Qt thread.

## Impact

The opening path now performs one complete auxiliary construction instead of four:

1. the identity snapshot shows one inexpensive native `Loading HUD…` indicator
2. the complete snapshot removes that indicator
3. the real HUD creates its seat and PT4 block windows exactly once

This reduces Qt-thread work, avoids orphaned native windows, and preserves per-auxiliary error isolation.

## Validation

- `QT_QPA_PLATFORM=offscreen python -m pytest -q test/test_HUD_main.py test/test_hud.py test/test_hud_read_service.py test/test_hud_db_outage.py test/test_hud_seat_mapping.py test/test_multiblock_hud.py -m 'qt or not qt'` — 219 passed
- `ruff check fpdb_3_legacy/Hud.py fpdb_3_legacy/HUD_main.pyw test/test_hud.py test/test_HUD_main.py` — passed

A live table test remains the final validation for perceived freeze reduction and platform-specific topification of the loading indicator.