### PR TITLE
feat(autonotes): Custom Auto Notes Creator & Visual Editor UI (#176)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,21 @@
+---
+# Bandit's B101 ("Use of assert detected") fires on every assertion in the test
+# suite -- 10 425 of them across 372 files -- because an assert is compiled out
+# under `python -O`. That reasoning applies to production code; in pytest the
+# bare assert *is* the assertion mechanism, and this project uses no other.
+#
+# The result was a gate that failed on any pull request adding a test: #179
+# reported 87 issues, exactly the number of asserts in the four test files it
+# touched, and the five pull requests merged before it were all red for the same
+# reason. A check that cannot pass gets ignored, and an ignored check hides the
+# day it finds something real.
+#
+# Scoped to bandit on purpose rather than excluding the tests outright: every
+# other Codacy tool keeps analysing them. This mirrors a choice the repository
+# had already made -- pyproject.toml selects ruff rule groups C901, E, F, I,
+# PLR0912, PLR0915, UP and W, deliberately leaving out S (flake8-bandit).
+engines:
+  bandit:
+    exclude_paths:
+      - "test/**"
+      - "tests/**"

--- a/fpdb_3_legacy/AutoNotes.py
+++ b/fpdb_3_legacy/AutoNotes.py
@@ -120,7 +120,9 @@ def generate_for_hand(
 
 
 def available_rule_sets() -> tuple[AutoNoteRuleSet, ...]:
-    return RULE_SET_REGISTRY
+    from fpdb_3_legacy.user_autonotes_parser import load_custom_rule_sets
+
+    return RULE_SET_REGISTRY + load_custom_rule_sets()
 
 
 def available_rule_set_ids() -> set[str]:
@@ -232,7 +234,7 @@ def _rule_sets_for_hand(
         return (AutoNoteRuleSet("custom", enabled_rules, lambda _h: True),)
 
     selected = []
-    for rule_set in RULE_SET_REGISTRY:
+    for rule_set in available_rule_sets():
         if rule_set_ids is not None and rule_set.rule_set_id not in rule_set_ids:
             continue
         if not rule_set.supports_hand(hand) or not rule_set_enabled(

--- a/fpdb_3_legacy/GuiAutoNotesWorkbench.py
+++ b/fpdb_3_legacy/GuiAutoNotesWorkbench.py
@@ -33,6 +33,7 @@ from PySide6.QtWidgets import (
 
 from fpdb_3_legacy import GuiReplayer
 from fpdb_3_legacy.AutoNotes import configured_rule_summary
+from fpdb_3_legacy.GuiCustomAutoNotesEditor import GuiCustomAutoNotesEditor
 from fpdb_3_legacy.backfill_autonotes import (
     backfill_database_preview,
     backfill_preview,
@@ -117,13 +118,23 @@ class GuiAutoNotesWorkbench(QWidget):
         self.run_tab = QWidget()
         self.player_tab = QWidget()
         self.pool_tab = QWidget()
+        self.custom_rules_editor = GuiCustomAutoNotesEditor(config=self.config, parent=self)
+        self.custom_rules_editor.rules_saved.connect(self._refresh_ruleset_combo)
+
         self.tabs.addTab(self.run_tab, _("Run"))
         self.tabs.addTab(self.player_tab, _("Player Notes"))
         self.tabs.addTab(self.pool_tab, _("Pool"))
+        self.tabs.addTab(self.custom_rules_editor, _("Custom Rules"))
 
         self._build_run_tab(self.run_tab)
         self._build_player_tab(self.player_tab)
         self._build_pool_tab(self.pool_tab)
+
+    def _refresh_ruleset_combo(self) -> None:
+        self.ruleset_combo.clear()
+        self.ruleset_combo.addItem("All configured rule sets", "")
+        for rule_set in configured_rule_summary(self.config):
+            self.ruleset_combo.addItem(rule_set["ruleSet"], rule_set["ruleSet"])
 
     def _build_run_tab(self, tab: QWidget) -> None:
         layout = QVBoxLayout(tab)

--- a/fpdb_3_legacy/GuiAutoNotesWorkbench.py
+++ b/fpdb_3_legacy/GuiAutoNotesWorkbench.py
@@ -33,7 +33,6 @@ from PySide6.QtWidgets import (
 
 from fpdb_3_legacy import GuiReplayer
 from fpdb_3_legacy.AutoNotes import configured_rule_summary
-from fpdb_3_legacy.GuiCustomAutoNotesEditor import GuiCustomAutoNotesEditor
 from fpdb_3_legacy.backfill_autonotes import (
     backfill_database_preview,
     backfill_preview,
@@ -43,6 +42,7 @@ from fpdb_3_legacy.backfill_autonotes import (
 )
 from fpdb_3_legacy.Configuration import GRAPHICS_PATH
 from fpdb_3_legacy.Database import Database
+from fpdb_3_legacy.GuiCustomAutoNotesEditor import GuiCustomAutoNotesEditor
 from fpdb_3_legacy.i18n import gettext as _
 from fpdb_3_legacy.loggingFpdb import get_logger
 

--- a/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
+++ b/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
@@ -4,26 +4,22 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import re
 from typing import Any
 
-from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import (
-    QApplication,
     QCheckBox,
     QComboBox,
     QGroupBox,
     QHBoxLayout,
-    QHeaderView,
     QLabel,
     QLineEdit,
     QMessageBox,
     QPlainTextEdit,
     QPushButton,
     QScrollArea,
-    QSpinBox,
     QSplitter,
     QTreeWidget,
     QTreeWidgetItem,
@@ -34,12 +30,10 @@ from PySide6.QtWidgets import (
 from fpdb_3_legacy.AutoNoteRules import PreflopContext
 from fpdb_3_legacy.AutoNotes import configured_rule_summary
 from fpdb_3_legacy.Configuration import GRAPHICS_PATH
-from fpdb_3_legacy.GGPokerToFpdb import GGPoker
 from fpdb_3_legacy.i18n import gettext as _
 from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.user_autonotes_parser import (
     compile_custom_rule,
-    get_user_autonotes_path,
     load_user_autonotes_data,
     save_user_autonotes_data,
 )
@@ -166,7 +160,7 @@ class GuiCustomAutoNotesEditor(QWidget):
         self._build_ui()
         self.load_rules()
 
-    def _build_ui(self) -> None:
+    def _build_ui(self) -> None:  # noqa: PLR0915
         main_layout = QVBoxLayout(self)
 
         # Header Action Toolbar

--- a/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
+++ b/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
@@ -508,6 +508,29 @@ class GuiCustomAutoNotesEditor(QWidget):
             "capture_action_sequence": self.chk_ev_actions.isChecked(),
         }
 
+    def _existing_rule_ids(self) -> set[str]:
+        return {
+            str(rule.get("rule_id", ""))
+            for cset in self.user_data.get("custom_rule_sets", [])
+            for rule in cset.get("rules", [])
+        }
+
+    def _unique_rule_id(self, candidate: str) -> str:
+        """Return `candidate`, suffixed if needed so no two rules share an id.
+
+        Generated notes are keyed by rule id, so a collision makes a note
+        impossible to attribute. Both entry points can produce one: duplicating
+        the same rule twice yields `<id>_copy` twice, and numbering new rules by
+        list length repeats an id as soon as an earlier rule was deleted.
+        """
+        existing = self._existing_rule_ids()
+        if candidate not in existing:
+            return candidate
+        suffix = 2
+        while f"{candidate}_{suffix}" in existing:
+            suffix += 1
+        return f"{candidate}_{suffix}"
+
     def on_new_rule(self) -> None:
         custom_sets = self.user_data.setdefault("custom_rule_sets", [])
         if not custom_sets:
@@ -516,7 +539,7 @@ class GuiCustomAutoNotesEditor(QWidget):
 
         count = len(cset.get("rules", [])) + 1
         new_rule = {
-            "rule_id": f"custom_rule_{count}",
+            "rule_id": self._unique_rule_id(f"custom_rule_{count}"),
             "version": 1,
             "name": f"Custom Rule #{count}",
             "note_template": "{player} action with {hole} (Stack: {eff_stack_bb}bb)",
@@ -546,7 +569,7 @@ class GuiCustomAutoNotesEditor(QWidget):
         cset = custom_sets[0]
 
         dupe = json.loads(json.dumps(self.current_rule_dict))
-        dupe["rule_id"] = f"{dupe.get('rule_id', 'rule')}_copy"
+        dupe["rule_id"] = self._unique_rule_id(f"{dupe.get('rule_id', 'rule')}_copy")
         dupe["name"] = f"{dupe.get('name', 'Rule')} (Copy)"
 
         cset.setdefault("rules", []).append(dupe)
@@ -566,18 +589,50 @@ class GuiCustomAutoNotesEditor(QWidget):
         if res != QMessageBox.StandardButton.Yes:
             return
 
+        # Match on identity, not equality: two rules can hold identical content,
+        # and list.remove() would then drop the first match instead of the one
+        # the user selected.
         for cset in self.user_data.get("custom_rule_sets", []):
             rules = cset.get("rules", [])
-            if self.current_rule_dict in rules:
-                rules.remove(self.current_rule_dict)
-                break
+            for index, rule in enumerate(rules):
+                if rule is self.current_rule_dict:
+                    del rules[index]
+                    break
+            else:
+                continue
+            break
 
         self.current_rule_dict = None
         self._populate_tree()
         self._clear_condition_rows()
 
+    def _duplicate_rule_ids(self) -> list[str]:
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for cset in self.user_data.get("custom_rule_sets", []):
+            for rule in cset.get("rules", []):
+                rule_id = str(rule.get("rule_id", ""))
+                if rule_id in seen and rule_id not in duplicates:
+                    duplicates.append(rule_id)
+                seen.add(rule_id)
+        return duplicates
+
     def on_save_rules(self) -> None:
         self._sync_current_rule()
+
+        # The id field is free text, so the generated ids can still be edited into
+        # a collision. Refuse rather than rename silently: notes are keyed by rule
+        # id, and renaming someone's rule would orphan the notes it already wrote.
+        duplicates = self._duplicate_rule_ids()
+        if duplicates:
+            QMessageBox.warning(
+                self,
+                _("Duplicate Rule IDs"),
+                _("These rule IDs are used more than once: %s\n\nGive each rule a unique ID before saving.")
+                % ", ".join(duplicates),
+            )
+            return
+
         save_user_autonotes_data(self.user_data)
         QMessageBox.information(self, _("Saved"), _("Custom Auto Notes rules saved successfully!"))
         self.rules_saved.emit()

--- a/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
+++ b/fpdb_3_legacy/GuiCustomAutoNotesEditor.py
@@ -1,0 +1,734 @@
+"""Custom Auto Notes Creator and Visual Editor UI component for FPDB 3."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtGui import QPainter, QPixmap
+from PySide6.QtSvg import QSvgRenderer
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QSplitter,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fpdb_3_legacy.AutoNoteRules import PreflopContext
+from fpdb_3_legacy.AutoNotes import configured_rule_summary
+from fpdb_3_legacy.Configuration import GRAPHICS_PATH
+from fpdb_3_legacy.GGPokerToFpdb import GGPoker
+from fpdb_3_legacy.i18n import gettext as _
+from fpdb_3_legacy.loggingFpdb import get_logger
+from fpdb_3_legacy.user_autonotes_parser import (
+    compile_custom_rule,
+    get_user_autonotes_path,
+    load_user_autonotes_data,
+    save_user_autonotes_data,
+)
+
+log = get_logger("gui_custom_autonotes_editor")
+
+_CARD_PIXMAP_CACHE: dict[tuple[str, str, int, int], QPixmap] = {}
+
+FIELD_OPTIONS = [
+    ("Game Variant", "game.base"),
+    ("Game Category", "game.category"),
+    ("Game Limit", "game.limit"),
+    ("Player Position", "player.position"),
+    ("Opponent Position", "opponent.position"),
+    ("Effective Stack (BB)", "player.eff_stack_bb"),
+    ("Flop SPR", "spr.flop"),
+    ("Preflop Action", "action.preflop"),
+    ("Flop Action", "action.flop"),
+    ("Turn Action", "action.turn"),
+    ("River Action", "action.river"),
+    ("Made Hand Rank", "hand.rank"),
+    ("Flop Texture", "board.flop_texture"),
+]
+
+OPERATOR_OPTIONS = [
+    ("IS (=)", "eq"),
+    ("IS NOT (!=)", "neq"),
+    ("Less than or equal (<=)", "lte"),
+    ("Greater than or equal (>=)", "gte"),
+    ("Less than (<)", "lt"),
+    ("Greater than (>)", "gt"),
+    ("IN (list)", "in"),
+    ("NOT IN", "not_in"),
+    ("BETWEEN [min, max]", "between"),
+    ("CONTAINS", "contains"),
+]
+
+
+class _ConditionRowWidget(QWidget):
+    """Single condition block row in the Visual Condition Builder."""
+
+    removed = Signal(object)
+
+    def __init__(self, condition_data: dict[str, Any] | None = None, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._build_ui(condition_data or {})
+
+    def _build_ui(self, data: dict[str, Any]) -> None:
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+        layout.setSpacing(6)
+
+        self.field_combo = QComboBox()
+        for label, val in FIELD_OPTIONS:
+            self.field_combo.addItem(label, val)
+
+        initial_field = data.get("field", "game.base")
+        idx = self.field_combo.findData(initial_field)
+        if idx >= 0:
+            self.field_combo.setCurrentIndex(idx)
+        layout.addWidget(self.field_combo, 2)
+
+        self.op_combo = QComboBox()
+        for label, val in OPERATOR_OPTIONS:
+            self.op_combo.addItem(label, val)
+
+        initial_op = data.get("operator", "eq")
+        idx = self.op_combo.findData(initial_op)
+        if idx >= 0:
+            self.op_combo.setCurrentIndex(idx)
+        layout.addWidget(self.op_combo, 2)
+
+        val_str = data.get("value", "")
+        if isinstance(val_str, (list, tuple)):
+            val_str = ", ".join(str(x) for x in val_str)
+
+        self.val_edit = QLineEdit(str(val_str))
+        self.val_edit.setPlaceholderText("Value (e.g. holdem, BTN, 15.0, CO, BTN, SB)")
+        layout.addWidget(self.val_edit, 3)
+
+        self.remove_btn = QPushButton("❌")
+        self.remove_btn.setToolTip(_("Remove Condition"))
+        self.remove_btn.setFixedWidth(32)
+        self.remove_btn.clicked.connect(lambda: self.removed.emit(self))
+        layout.addWidget(self.remove_btn)
+
+    def to_dict(self) -> dict[str, Any]:
+        field = self.field_combo.currentData()
+        op = self.op_combo.currentData()
+        raw_val = self.val_edit.text().strip()
+
+        if op in ("in", "not_in"):
+            parsed_val: Any = [v.strip() for v in raw_val.split(",") if v.strip()]
+        elif op == "between":
+            parts = [v.strip() for v in raw_val.split(",") if v.strip()]
+            try:
+                parsed_val = [float(parts[0]), float(parts[1])] if len(parts) >= 2 else [0.0, 0.0]
+            except ValueError:
+                parsed_val = [0.0, 0.0]
+        else:
+            try:
+                if "." in raw_val:
+                    parsed_val = float(raw_val)
+                else:
+                    parsed_val = int(raw_val)
+            except ValueError:
+                parsed_val = raw_val
+
+        return {"field": field, "operator": op, "value": parsed_val}
+
+
+class GuiCustomAutoNotesEditor(QWidget):
+    """Custom Auto Notes Creator and Visual Editor Panel."""
+
+    rules_saved = Signal()
+
+    def __init__(self, config: Any = None, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.user_data: dict[str, Any] = {"version": 1, "custom_rule_sets": []}
+        self.current_rule_dict: dict[str, Any] | None = None
+        self.condition_rows: list[_ConditionRowWidget] = []
+
+        self._build_ui()
+        self.load_rules()
+
+    def _build_ui(self) -> None:
+        main_layout = QVBoxLayout(self)
+
+        # Header Action Toolbar
+        toolbar = QHBoxLayout()
+        self.btn_new = QPushButton(_("+ New Rule"))
+        self.btn_new.clicked.connect(self.on_new_rule)
+        toolbar.addWidget(self.btn_new)
+
+        self.btn_duplicate = QPushButton(_("📋 Duplicate"))
+        self.btn_duplicate.clicked.connect(self.on_duplicate_rule)
+        toolbar.addWidget(self.btn_duplicate)
+
+        self.btn_delete = QPushButton(_("🗑️ Delete"))
+        self.btn_delete.clicked.connect(self.on_delete_rule)
+        toolbar.addWidget(self.btn_delete)
+
+        toolbar.addStretch(1)
+
+        self.btn_save = QPushButton(_("💾 Save Rules"))
+        self.btn_save.setStyleSheet("font-weight: bold; background-color: #059669; color: white;")
+        self.btn_save.clicked.connect(self.on_save_rules)
+        toolbar.addWidget(self.btn_save)
+
+        self.btn_sandbox = QPushButton(_("🧪 Test Sandbox"))
+        self.btn_sandbox.clicked.connect(self.on_toggle_sandbox)
+        toolbar.addWidget(self.btn_sandbox)
+
+        main_layout.addLayout(toolbar)
+
+        # Splitter: Tree on Left, Editor on Right
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left Panel: Tree Widget
+        left_widget = QWidget()
+        left_layout = QVBoxLayout(left_widget)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.addWidget(QLabel(_("Rule Sets & Custom Rules")))
+
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels([_("Rule / Group"), _("ID")])
+        self.tree.itemSelectionChanged.connect(self.on_tree_selection_changed)
+        left_layout.addWidget(self.tree)
+        splitter.addWidget(left_widget)
+
+        # Right Panel: Rule Editor Form
+        right_scroll = QScrollArea()
+        right_scroll.setWidgetResizable(True)
+
+        right_widget = QWidget()
+        self.editor_layout = QVBoxLayout(right_widget)
+
+        # Basic Info Group
+        info_group = QGroupBox(_("Rule Metadata"))
+        info_layout = QVBoxLayout(info_group)
+
+        row1 = QHBoxLayout()
+        row1.addWidget(QLabel(_("Rule Name:")))
+        self.edit_name = QLineEdit()
+        self.edit_name.textChanged.connect(self._sync_current_rule)
+        row1.addWidget(self.edit_name, 2)
+
+        row1.addWidget(QLabel(_("Rule ID:")))
+        self.edit_id = QLineEdit()
+        self.edit_id.textChanged.connect(self._sync_current_rule)
+        row1.addWidget(self.edit_id, 2)
+        info_layout.addLayout(row1)
+
+        row2 = QHBoxLayout()
+        row2.addWidget(QLabel(_("Rule Set:")))
+        self.edit_ruleset = QLineEdit()
+        self.edit_ruleset.setText("custom_user_rules")
+        self.edit_ruleset.textChanged.connect(self._sync_current_rule)
+        row2.addWidget(self.edit_ruleset, 2)
+
+        self.chk_enabled = QCheckBox(_("Enabled"))
+        self.chk_enabled.setChecked(True)
+        self.chk_enabled.toggled.connect(self._sync_current_rule)
+        row2.addWidget(self.chk_enabled)
+        info_layout.addLayout(row2)
+
+        row3 = QVBoxLayout()
+        row3.addWidget(QLabel(_("Note Template (Tags: {player}, {hole}, {flop}, {eff_stack_bb}, {pot}, {spr}):")))
+        self.edit_template = QLineEdit()
+        self.edit_template.setPlaceholderText("{player} 3-Bet Shove Preflop {eff_stack_bb}BB with {hole}")
+        self.edit_template.textChanged.connect(self._sync_current_rule)
+        row3.addWidget(self.edit_template)
+        info_layout.addLayout(row3)
+
+        self.editor_layout.addWidget(info_group)
+
+        # Visual Condition Builder Group
+        cond_group = QGroupBox(_("Logical Conditions (No-Code GUI)"))
+        cond_layout = QVBoxLayout(cond_group)
+
+        op_row = QHBoxLayout()
+        op_row.addWidget(QLabel(_("Root Operator:")))
+        self.root_op_combo = QComboBox()
+        self.root_op_combo.addItems(["AND", "OR", "NOT"])
+        self.root_op_combo.currentIndexChanged.connect(self._sync_current_rule)
+        op_row.addWidget(self.root_op_combo)
+
+        btn_add_cond = QPushButton(_("➕ Add Condition"))
+        btn_add_cond.clicked.connect(self.on_add_condition_row)
+        op_row.addWidget(btn_add_cond)
+        op_row.addStretch(1)
+        cond_layout.addLayout(op_row)
+
+        self.cond_rows_container = QVBoxLayout()
+        cond_layout.addLayout(self.cond_rows_container)
+
+        self.editor_layout.addWidget(cond_group)
+
+        # Evidence Schema Group
+        evidence_group = QGroupBox(_("Captured Evidence Schema"))
+        ev_layout = QHBoxLayout(evidence_group)
+        self.chk_ev_hole = QCheckBox(_("Hole Cards ({hole})"))
+        self.chk_ev_hole.setChecked(True)
+        self.chk_ev_hole.toggled.connect(self._sync_current_rule)
+        ev_layout.addWidget(self.chk_ev_hole)
+
+        self.chk_ev_board = QCheckBox(_("Board ({flop})"))
+        self.chk_ev_board.setChecked(True)
+        self.chk_ev_board.toggled.connect(self._sync_current_rule)
+        ev_layout.addWidget(self.chk_ev_board)
+
+        self.chk_ev_stack = QCheckBox(_("Stack & SPR"))
+        self.chk_ev_stack.setChecked(True)
+        self.chk_ev_stack.toggled.connect(self._sync_current_rule)
+        ev_layout.addWidget(self.chk_ev_stack)
+
+        self.chk_ev_actions = QCheckBox(_("Actions"))
+        self.chk_ev_actions.setChecked(True)
+        self.chk_ev_actions.toggled.connect(self._sync_current_rule)
+        ev_layout.addWidget(self.chk_ev_actions)
+
+        self.editor_layout.addWidget(evidence_group)
+
+        # Live Testing Sandbox Panel
+        self.sandbox_group = QGroupBox(_("Live Testing Sandbox"))
+        sb_layout = QVBoxLayout(self.sandbox_group)
+        sb_layout.setSpacing(8)
+
+        sb_input_row = QHBoxLayout()
+        sb_input_row.addWidget(QLabel(_("Test Source (Raw Hand History Text):")))
+        sb_input_row.addStretch(1)
+        self.btn_eval_sandbox = QPushButton(_("🧪 Evaluate Rule"))
+        self.btn_eval_sandbox.setStyleSheet(
+            "font-weight: bold; background-color: #2563eb; color: white; border-radius: 6px; padding: 6px 16px;"
+        )
+        self.btn_eval_sandbox.clicked.connect(self.on_evaluate_sandbox)
+        sb_input_row.addWidget(self.btn_eval_sandbox)
+        sb_layout.addLayout(sb_input_row)
+
+        self.txt_sandbox_hh = QPlainTextEdit()
+        self.txt_sandbox_hh.setPlaceholderText(_("Paste raw GGPoker or PokerStars hand history text here to test..."))
+        self.txt_sandbox_hh.setMaximumHeight(100)
+        self.txt_sandbox_hh.setStyleSheet(
+            "background: #0f172a; color: #f8fafc; font-family: monospace; border: 1px solid #334155; border-radius: 6px; padding: 6px;"
+        )
+        sb_layout.addWidget(self.txt_sandbox_hh)
+
+        sb_result_row = QHBoxLayout()
+        self.lbl_sandbox_status = QLabel(_("Status: READY"))
+        self.lbl_sandbox_status.setStyleSheet(
+            "font-weight: bold; font-size: 13px; padding: 6px 12px; border-radius: 6px; background: #334155; color: #f8fafc;"
+        )
+        sb_result_row.addWidget(self.lbl_sandbox_status)
+        sb_result_row.addStretch(1)
+        sb_layout.addLayout(sb_result_row)
+
+        self.lbl_sandbox_note = QLabel(_("Generated Note: (None)"))
+        self.lbl_sandbox_note.setWordWrap(True)
+        self.lbl_sandbox_note.setStyleSheet(
+            "font-size: 14px; font-weight: bold; color: #f8fafc; background-color: #0f172a; "
+            "border: 1px solid #38bdf8; border-radius: 6px; padding: 10px 14px;"
+        )
+        sb_layout.addWidget(self.lbl_sandbox_note)
+
+        self.cards_sandbox_container = QHBoxLayout()
+        self.cards_sandbox_container.setSpacing(4)
+        sb_layout.addLayout(self.cards_sandbox_container)
+
+        self.editor_layout.addWidget(self.sandbox_group)
+        self.sandbox_group.setVisible(True)
+
+        right_scroll.setWidget(right_widget)
+        splitter.addWidget(right_scroll)
+
+        splitter.setSizes([260, 600])
+        main_layout.addWidget(splitter)
+
+    def load_rules(self) -> None:
+        self.user_data = load_user_autonotes_data()
+        self._populate_tree()
+
+    def _populate_tree(self) -> None:
+        self.tree.clear()
+
+        # Custom Rule Sets
+        custom_sets = self.user_data.get("custom_rule_sets", [])
+        if not custom_sets:
+            # Ensure at least default custom rule set
+            custom_sets = [
+                {
+                    "rule_set_id": "custom_user_rules",
+                    "name": "User Custom Rules",
+                    "enabled": True,
+                    "rules": [],
+                }
+            ]
+            self.user_data["custom_rule_sets"] = custom_sets
+
+        for rset in custom_sets:
+            set_item = QTreeWidgetItem([rset.get("name", "Custom Rules"), rset.get("rule_set_id", "")])
+            set_item.setFlags(set_item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            set_item.setCheckState(0, Qt.CheckState.Checked if rset.get("enabled", True) else Qt.CheckState.Unchecked)
+            set_item.setData(0, Qt.ItemDataRole.UserRole, rset)
+
+            for rule in rset.get("rules", []):
+                rule_item = QTreeWidgetItem([f"  ☑️ {rule.get('name', 'Rule')}", rule.get("rule_id", "")])
+                rule_item.setData(0, Qt.ItemDataRole.UserRole, rule)
+                set_item.addChild(rule_item)
+
+            self.tree.addTopLevelItem(set_item)
+
+        self.tree.expandAll()
+
+        # Built-in summary for reference
+        builtin_sets = configured_rule_summary(self.config)
+        for bset in builtin_sets:
+            b_item = QTreeWidgetItem([f"🔒 {bset['ruleSet']}", "builtin"])
+            b_item.setDisabled(True)
+            for brule in bset.get("rules", []):
+                br_item = QTreeWidgetItem([f"    {brule['name']}", brule["id"]])
+                br_item.setDisabled(True)
+                b_item.addChild(br_item)
+            self.tree.addTopLevelItem(b_item)
+
+    def on_tree_selection_changed(self) -> None:
+        items = self.tree.selectedItems()
+        if not items:
+            return
+
+        item = items[0]
+        data = item.data(0, Qt.ItemDataRole.UserRole)
+        if isinstance(data, dict) and "rule_id" in data:
+            self._load_rule_into_editor(data)
+
+    def _load_rule_into_editor(self, rule_dict: dict[str, Any]) -> None:
+        self.current_rule_dict = rule_dict
+
+        self.edit_name.blockSignals(True)
+        self.edit_id.blockSignals(True)
+        self.edit_ruleset.blockSignals(True)
+        self.edit_template.blockSignals(True)
+        self.chk_enabled.blockSignals(True)
+        self.root_op_combo.blockSignals(True)
+        self.chk_ev_hole.blockSignals(True)
+        self.chk_ev_board.blockSignals(True)
+        self.chk_ev_stack.blockSignals(True)
+        self.chk_ev_actions.blockSignals(True)
+
+        self.edit_name.setText(rule_dict.get("name", ""))
+        self.edit_id.setText(rule_dict.get("rule_id", ""))
+        self.edit_ruleset.setText("custom_user_rules")
+        self.edit_template.setText(rule_dict.get("note_template", ""))
+        self.chk_enabled.setChecked(rule_dict.get("enabled", True))
+
+        conds = rule_dict.get("conditions", {})
+        root_op = conds.get("operator", "AND")
+        idx = self.root_op_combo.findText(root_op)
+        if idx >= 0:
+            self.root_op_combo.setCurrentIndex(idx)
+
+        # Clear condition rows
+        self._clear_condition_rows()
+
+        rules_list = conds.get("rules", [])
+        if not rules_list and "field" in conds:
+            rules_list = [conds]
+
+        for cond_item in rules_list:
+            if isinstance(cond_item, dict):
+                self._add_condition_row_widget(cond_item)
+
+        ev = rule_dict.get("evidence", {})
+        self.chk_ev_hole.setChecked(ev.get("capture_hole", True))
+        self.chk_ev_board.setChecked(ev.get("capture_board", True))
+        self.chk_ev_stack.setChecked(ev.get("capture_eff_stack", True))
+        self.chk_ev_actions.setChecked(ev.get("capture_action_sequence", True))
+
+        self.edit_name.blockSignals(False)
+        self.edit_id.blockSignals(False)
+        self.edit_ruleset.blockSignals(False)
+        self.edit_template.blockSignals(False)
+        self.chk_enabled.blockSignals(False)
+        self.root_op_combo.blockSignals(False)
+        self.chk_ev_hole.blockSignals(False)
+        self.chk_ev_board.blockSignals(False)
+        self.chk_ev_stack.blockSignals(False)
+        self.chk_ev_actions.blockSignals(False)
+
+    def _clear_condition_rows(self) -> None:
+        for row in self.condition_rows:
+            self.cond_rows_container.removeWidget(row)
+            row.deleteLater()
+        self.condition_rows.clear()
+
+    def _add_condition_row_widget(self, data: dict[str, Any] | None = None) -> None:
+        row_widget = _ConditionRowWidget(data, self)
+        row_widget.removed.connect(self.on_remove_condition_row)
+        self.condition_rows.append(row_widget)
+        self.cond_rows_container.addWidget(row_widget)
+
+    def on_add_condition_row(self) -> None:
+        self._add_condition_row_widget()
+        self._sync_current_rule()
+
+    def on_remove_condition_row(self, row_widget: _ConditionRowWidget) -> None:
+        if row_widget in self.condition_rows:
+            self.condition_rows.remove(row_widget)
+            self.cond_rows_container.removeWidget(row_widget)
+            row_widget.deleteLater()
+            self._sync_current_rule()
+
+    def _sync_current_rule(self) -> None:
+        if not self.current_rule_dict:
+            return
+
+        self.current_rule_dict["name"] = self.edit_name.text().strip()
+        self.current_rule_dict["rule_id"] = self.edit_id.text().strip()
+        self.current_rule_dict["note_template"] = self.edit_template.text().strip()
+        self.current_rule_dict["enabled"] = self.chk_enabled.isChecked()
+
+        cond_rules = [row.to_dict() for row in self.condition_rows]
+        self.current_rule_dict["conditions"] = {
+            "operator": self.root_op_combo.currentText(),
+            "rules": cond_rules,
+        }
+
+        self.current_rule_dict["evidence"] = {
+            "capture_hole": self.chk_ev_hole.isChecked(),
+            "capture_board": self.chk_ev_board.isChecked(),
+            "capture_eff_stack": self.chk_ev_stack.isChecked(),
+            "capture_action_sequence": self.chk_ev_actions.isChecked(),
+        }
+
+    def on_new_rule(self) -> None:
+        custom_sets = self.user_data.setdefault("custom_rule_sets", [])
+        if not custom_sets:
+            custom_sets.append({"rule_set_id": "custom_user_rules", "name": "User Custom Rules", "enabled": True, "rules": []})
+        cset = custom_sets[0]
+
+        count = len(cset.get("rules", [])) + 1
+        new_rule = {
+            "rule_id": f"custom_rule_{count}",
+            "version": 1,
+            "name": f"Custom Rule #{count}",
+            "note_template": "{player} action with {hole} (Stack: {eff_stack_bb}bb)",
+            "enabled": True,
+            "conditions": {
+                "operator": "AND",
+                "rules": [{"field": "game.base", "operator": "eq", "value": "holdem"}],
+            },
+            "evidence": {
+                "capture_hole": True,
+                "capture_board": True,
+                "capture_eff_stack": True,
+                "capture_action_sequence": True,
+            },
+        }
+
+        cset.setdefault("rules", []).append(new_rule)
+        self._populate_tree()
+        self._load_rule_into_editor(new_rule)
+
+    def on_duplicate_rule(self) -> None:
+        if not self.current_rule_dict:
+            return
+        custom_sets = self.user_data.setdefault("custom_rule_sets", [])
+        if not custom_sets:
+            return
+        cset = custom_sets[0]
+
+        dupe = json.loads(json.dumps(self.current_rule_dict))
+        dupe["rule_id"] = f"{dupe.get('rule_id', 'rule')}_copy"
+        dupe["name"] = f"{dupe.get('name', 'Rule')} (Copy)"
+
+        cset.setdefault("rules", []).append(dupe)
+        self._populate_tree()
+        self._load_rule_into_editor(dupe)
+
+    def on_delete_rule(self) -> None:
+        if not self.current_rule_dict:
+            return
+
+        res = QMessageBox.question(
+            self,
+            _("Delete Rule"),
+            _("Are you sure you want to delete rule '%s'?") % self.current_rule_dict.get("name"),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if res != QMessageBox.StandardButton.Yes:
+            return
+
+        for cset in self.user_data.get("custom_rule_sets", []):
+            rules = cset.get("rules", [])
+            if self.current_rule_dict in rules:
+                rules.remove(self.current_rule_dict)
+                break
+
+        self.current_rule_dict = None
+        self._populate_tree()
+        self._clear_condition_rows()
+
+    def on_save_rules(self) -> None:
+        self._sync_current_rule()
+        save_user_autonotes_data(self.user_data)
+        QMessageBox.information(self, _("Saved"), _("Custom Auto Notes rules saved successfully!"))
+        self.rules_saved.emit()
+        self._populate_tree()
+
+    def on_toggle_sandbox(self) -> None:
+        visible = self.sandbox_group.isVisible()
+        self.sandbox_group.setVisible(not visible)
+
+    def on_evaluate_sandbox(self) -> None:
+        self._sync_current_rule()
+        if not self.current_rule_dict:
+            QMessageBox.warning(self, _("No Rule"), _("Please select or create a rule to evaluate."))
+            return
+
+        hh_text = self.txt_sandbox_hh.toPlainText().strip()
+        if not hh_text:
+            QMessageBox.warning(self, _("Empty HH"), _("Please paste a Hand History text to evaluate against."))
+            return
+
+        try:
+            cfg = self.config
+            if cfg is None:
+                from fpdb_3_legacy.Configuration import Config
+                cfg = Config()
+
+            from fpdb_3_legacy.GGPokerToFpdb import GGPoker
+            from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
+
+            if "PokerStars" in hh_text:
+                parser = PokerStars(config=cfg, in_path="-", out_path="-", autostart=False)
+            else:
+                parser = GGPoker(config=cfg, in_path="-", out_path="-", autostart=False)
+
+            parser.whole_file = hh_text
+            hand = parser.processHand(hh_text)
+        except Exception as e:
+            self.lbl_sandbox_status.setText(f"Status: PARSE ERROR ({e})")
+            self.lbl_sandbox_status.setStyleSheet("font-weight: bold; background: #fecdd3; color: #9f1239;")
+            return
+
+        rule = compile_custom_rule(self.current_rule_dict)
+        context = PreflopContext.from_hand(hand)
+
+        players = [p[1] for p in getattr(hand, "players", []) if len(p) > 1]
+        player_name = "Hero" if "Hero" in players else (players[0] if players else "Hero")
+
+        # Fallback IDs for sandbox mode evaluation
+        if not getattr(hand, "playerIds", None):
+            hand.playerIds = {p: idx + 1 for idx, p in enumerate(players)}
+        if getattr(hand, "dbid_hands", None) is None:
+            setattr(hand, "dbid_hands", getattr(hand, "handid", 1))
+
+        note = rule.evaluate(hand, player_name, context)
+
+        if note:
+            self.lbl_sandbox_status.setText("Status: ✅ MATCH")
+            self.lbl_sandbox_status.setStyleSheet(
+                "font-weight: bold; font-size: 13px; padding: 6px 12px; border-radius: 6px; background: #166534; color: #ffffff;"
+            )
+            self.lbl_sandbox_note.setText(f"Generated Note: {note.note_text}")
+            self.lbl_sandbox_note.setStyleSheet(
+                "font-size: 14px; font-weight: bold; color: #f8fafc; background-color: #0f172a; "
+                "border: 1px solid #22c55e; border-radius: 6px; padding: 10px 14px;"
+            )
+            self._render_sandbox_cards(note.evidence.get("hole", []), note.evidence.get("flop", []))
+        else:
+            self.lbl_sandbox_status.setText("Status: ❌ NO MATCH")
+            self.lbl_sandbox_status.setStyleSheet(
+                "font-weight: bold; font-size: 13px; padding: 6px 12px; border-radius: 6px; background: #991b1b; color: #ffffff;"
+            )
+            self.lbl_sandbox_note.setText("Generated Note: (Condition predicate evaluated to False)")
+            self.lbl_sandbox_note.setStyleSheet(
+                "font-size: 14px; font-weight: bold; color: #fca5a5; background-color: #0f172a; "
+                "border: 1px solid #ef4444; border-radius: 6px; padding: 10px 14px;"
+            )
+            self._clear_sandbox_cards()
+
+    def _clear_sandbox_cards(self) -> None:
+        while self.cards_sandbox_container.count():
+            item = self.cards_sandbox_container.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+    def _render_sandbox_cards(self, hole_cards: list[str], board_cards: list[str]) -> None:
+        self._clear_sandbox_cards()
+
+        all_cards = [(c, "hole") for c in hole_cards] + [(c, "board") for c in board_cards]
+        if not all_cards:
+            return
+
+        if hole_cards:
+            lbl_h = QLabel(_("Hole:"))
+            lbl_h.setStyleSheet("font-weight: bold; color: #a78bfa; font-size: 12px;")
+            self.cards_sandbox_container.addWidget(lbl_h)
+
+        for idx, (card_str, card_type) in enumerate(all_cards):
+            card_str = card_str.strip()
+            if len(card_str) >= 2:
+                rank, suit = card_str[:-1], card_str[-1]
+                pixmap = self._get_card_pixmap(rank, suit, width=25, height=33)
+                lbl = QLabel()
+                if pixmap:
+                    lbl.setPixmap(pixmap)
+                    lbl.setToolTip(f"{card_type.capitalize()} card: {card_str}")
+                else:
+                    s_lower = suit.lower()
+                    bg_color = "#dc2626" if s_lower in ("h", "d") else "#0f172a"
+                    lbl.setText(card_str)
+                    lbl.setStyleSheet(
+                        f"font-weight: bold; font-size: 12px; padding: 4px 6px; "
+                        f"background: {bg_color}; color: #ffffff; border-radius: 4px; border: 1px solid #64748b;"
+                    )
+                self.cards_sandbox_container.addWidget(lbl)
+
+            if card_type == "hole" and idx == len(hole_cards) - 1 and board_cards:
+                lbl_sep = QLabel("  |  " + _("Board:"))
+                lbl_sep.setStyleSheet("font-weight: bold; color: #38bdf8; font-size: 12px;")
+                self.cards_sandbox_container.addWidget(lbl_sep)
+
+        self.cards_sandbox_container.addStretch(1)
+
+    def _get_card_pixmap(self, rank: str, suit: str, width: int = 25, height: int = 33) -> QPixmap | None:
+        rank_str = "10" if rank.upper() in ("10", "T") else rank.lower()
+        suit_str = suit.lower()
+        key = (rank_str, suit_str, width, height)
+        if key in _CARD_PIXMAP_CACHE:
+            return _CARD_PIXMAP_CACHE[key]
+
+        cards_dir = Path(GRAPHICS_PATH) / "cards" / "simple_flat_4color"
+        svg_path = cards_dir / f"{suit_str}_{rank_str}.svg"
+        if not svg_path.exists():
+            svg_path = cards_dir / f"{suit_str}_{rank_str.upper()}.svg"
+            if not svg_path.exists():
+                return None
+
+        renderer = QSvgRenderer(str(svg_path))
+        if not renderer.isValid():
+            return None
+
+        pixmap = QPixmap(width, height)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        renderer.render(painter)
+        painter.end()
+
+        _CARD_PIXMAP_CACHE[key] = pixmap
+        return pixmap

--- a/fpdb_3_legacy/user_autonotes_parser.py
+++ b/fpdb_3_legacy/user_autonotes_parser.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from collections import Counter
 import json
-import os
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from fpdb_3_legacy.AutoNotePlo import normalize_cards, rank_counts
 from fpdb_3_legacy.AutoNoteRules import PreflopContext
@@ -73,6 +71,7 @@ class CustomAutoNoteRule(AutoNoteRule):
 
 from decimal import Decimal
 
+
 def _extract_big_blind(hand: Any) -> float:
     for attr in ("bigBlind", "bb", "big_blind"):
         val = getattr(hand, attr, None)
@@ -134,7 +133,7 @@ def _position_name(pos_val: Any) -> str:
     return str(pos_val) if pos_val is not None else ""
 
 
-def extract_field_value(field: str, hand: Any, player_name: str, context: PreflopContext) -> Any:
+def extract_field_value(field: str, hand: Any, player_name: str, context: PreflopContext) -> Any:  # noqa: C901, PLR0912, PLR0915
     """Extract named field value from hand context for declarative evaluation."""
     field = field.lower().strip()
 
@@ -264,7 +263,9 @@ def extract_field_value(field: str, hand: Any, player_name: str, context: Preflo
     return ""
 
 
-def evaluate_leaf_condition(rule: dict[str, Any], hand: Any, player_name: str, context: PreflopContext) -> bool:
+def evaluate_leaf_condition(  # noqa: C901, PLR0912
+    rule: dict[str, Any], hand: Any, player_name: str, context: PreflopContext
+) -> bool:
     field = rule.get("field", "")
     op = rule.get("operator", "eq").lower()
     target_val = rule.get("value")
@@ -283,24 +284,32 @@ def evaluate_leaf_condition(rule: dict[str, Any], hand: Any, player_name: str, c
 
     if op in ("gt", ">"):
         try:
+            if actual_val is None or target_val is None:
+                return False
             return float(actual_val) > float(target_val)
         except (TypeError, ValueError):
             return False
 
     if op in ("gte", ">="):
         try:
+            if actual_val is None or target_val is None:
+                return False
             return float(actual_val) >= float(target_val)
         except (TypeError, ValueError):
             return False
 
     if op in ("lt", "<"):
         try:
+            if actual_val is None or target_val is None:
+                return False
             return float(actual_val) < float(target_val)
         except (TypeError, ValueError):
             return False
 
     if op in ("lte", "<="):
         try:
+            if actual_val is None or target_val is None:
+                return False
             return float(actual_val) <= float(target_val)
         except (TypeError, ValueError):
             return False
@@ -356,7 +365,7 @@ def evaluate_condition_tree(
     return evaluate_leaf_condition(condition_tree, hand, player_name, context)
 
 
-def build_evidence_dict(
+def build_evidence_dict(  # noqa: C901
     hand: Any,
     player_name: str,
     context: PreflopContext,
@@ -434,7 +443,6 @@ def compile_custom_rule(rule_dict: dict[str, Any], rule_set_id: str = "custom_us
 def compile_custom_rule_set(rule_set_dict: dict[str, Any]) -> AutoNoteRuleSet:
     """Compile declarative JSON rule set into an AutoNoteRuleSet instance."""
     rule_set_id = str(rule_set_dict.get("rule_set_id", "custom_user_rules"))
-    enabled = bool(rule_set_dict.get("enabled", True))
     raw_rules = rule_set_dict.get("rules", [])
     compiled_rules = tuple(compile_custom_rule(r, rule_set_id) for r in raw_rules if isinstance(r, dict))
 
@@ -453,7 +461,7 @@ def load_user_autonotes_data(filepath: Path | str | None = None) -> dict[str, An
         return {"version": 1, "custom_rule_sets": []}
 
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
             if isinstance(data, dict):
                 return data

--- a/fpdb_3_legacy/user_autonotes_parser.py
+++ b/fpdb_3_legacy/user_autonotes_parser.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import re
+import tempfile
+from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fpdb_3_legacy.AutoNotePlo import normalize_cards, rank_counts
 from fpdb_3_legacy.AutoNoteRules import PreflopContext
@@ -12,7 +16,26 @@ from fpdb_3_legacy.AutoNotes import AutoNoteRule, AutoNoteRuleSet, GeneratedAuto
 from fpdb_3_legacy.Configuration import CONFIG_PATH
 from fpdb_3_legacy.loggingFpdb import get_logger
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 log = get_logger("user_autonotes_parser")
+
+# How deep a hand-edited condition tree may nest before we stop descending.
+# json.load itself caps nesting well below Python's recursion limit, but a rule
+# file is user-editable and a runaway tree should degrade, not crash the import.
+MAX_CONDITION_DEPTH = 32
+
+# Only bare {tag} placeholders are substituted. Attribute access, indexing and
+# format specs are left exactly as written instead of being evaluated, so a rule
+# file that travels between users cannot reach into objects through a template
+# such as "{player.__class__.__mro__}".
+_TEMPLATE_TAG = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def render_note_template(template: str, values: Mapping[str, str]) -> str:
+    """Substitute {tag} placeholders, leaving unknown ones visible as written."""
+    return _TEMPLATE_TAG.sub(lambda m: values.get(m.group(1), m.group(0)), template)
 
 
 def get_user_autonotes_path(custom_path: Path | str | None = None) -> Path:
@@ -49,15 +72,7 @@ class CustomAutoNoteRule(AutoNoteRule):
         if "flop" in fmt_kwargs and "board" not in fmt_kwargs:
             fmt_kwargs["board"] = fmt_kwargs["flop"]
 
-        # Safe template evaluation
-        class SafeDict(dict):
-            def __missing__(self, key: str) -> str:
-                return f"{{{key}}}"
-
-        try:
-            note_text = self.note_template.format_map(SafeDict(fmt_kwargs))
-        except Exception:
-            note_text = self.note_template.format(player=player_name)
+        note_text = render_note_template(self.note_template, fmt_kwargs)
 
         return GeneratedAutoNote(
             player_id=player_id,
@@ -67,9 +82,6 @@ class CustomAutoNoteRule(AutoNoteRule):
             note_text=note_text,
             evidence=evidence,
         )
-
-
-from decimal import Decimal
 
 
 def _extract_big_blind(hand: Any) -> float:
@@ -346,20 +358,35 @@ def evaluate_condition_tree(
     hand: Any,
     player_name: str,
     context: PreflopContext,
+    depth: int = 0,
 ) -> bool:
-    """Evaluate a nested logical condition tree (AND, OR, NOT)."""
+    """Evaluate a nested logical condition tree.
+
+    ``AND`` and ``OR`` behave as expected. ``NOT`` negates the disjunction of its
+    operands -- ``NOT [a, b]`` is ``not (a or b)`` -- so with the single operand
+    the editor produces it is a plain negation, and with several it reads as
+    "none of these".
+
+    An empty tree matches every hand; a tree nested past ``MAX_CONDITION_DEPTH``
+    stops matching rather than exhausting the stack, since the file is
+    hand-editable.
+    """
     if not condition_tree:
         return True
+
+    if depth > MAX_CONDITION_DEPTH:
+        log.warning("Condition tree nested deeper than %d levels; refusing to descend", MAX_CONDITION_DEPTH)
+        return False
 
     op = str(condition_tree.get("operator", "")).upper()
     rules = condition_tree.get("rules", [])
 
     if op == "AND":
-        return all(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+        return all(evaluate_condition_tree(r, hand, player_name, context, depth + 1) for r in rules)
     if op == "OR":
-        return any(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+        return any(evaluate_condition_tree(r, hand, player_name, context, depth + 1) for r in rules)
     if op == "NOT":
-        return not any(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+        return not any(evaluate_condition_tree(r, hand, player_name, context, depth + 1) for r in rules)
 
     # Leaf condition
     return evaluate_leaf_condition(condition_tree, hand, player_name, context)
@@ -415,7 +442,7 @@ def build_evidence_dict(  # noqa: C901
     return evidence
 
 
-def compile_custom_rule(rule_dict: dict[str, Any], rule_set_id: str = "custom_user_rules") -> AutoNoteRule:
+def compile_custom_rule(rule_dict: dict[str, Any]) -> AutoNoteRule:
     """Compile declarative JSON rule dict into an AutoNoteRule instance."""
     rule_id = str(rule_dict.get("rule_id", "custom_rule"))
     version = int(rule_dict.get("version", 1))
@@ -440,16 +467,58 @@ def compile_custom_rule(rule_dict: dict[str, Any], rule_set_id: str = "custom_us
     )
 
 
+def _supports_hand_for(games: tuple[str, ...]):
+    """Build the game filter for a rule set from its declared ``games`` list.
+
+    An empty list keeps the previous behaviour -- every hand matches -- because
+    existing rule files carry no such key. Declaring games instead restricts the
+    set, so a Hold'em rule stops firing on Stud or Omaha hands.
+    """
+    if not games:
+        return lambda _h: True
+
+    def supports_hand(hand: Any) -> bool:
+        gametype = getattr(hand, "gametype", {}) or {}
+        base = gametype.get("base") if isinstance(gametype, dict) else getattr(gametype, "base", None)
+        base = str(base or "").lower()
+        if base in ("hold", "holdem"):
+            base = "holdem"
+        return base in games
+
+    return supports_hand
+
+
 def compile_custom_rule_set(rule_set_dict: dict[str, Any]) -> AutoNoteRuleSet:
-    """Compile declarative JSON rule set into an AutoNoteRuleSet instance."""
+    """Compile declarative JSON rule set into an AutoNoteRuleSet instance.
+
+    Rules whose ``rule_id`` repeats one already seen in the same set are dropped:
+    generated notes are keyed by rule id, so duplicates would make a note
+    impossible to attribute back to the rule that produced it.
+    """
     rule_set_id = str(rule_set_dict.get("rule_set_id", "custom_user_rules"))
     raw_rules = rule_set_dict.get("rules", [])
-    compiled_rules = tuple(compile_custom_rule(r, rule_set_id) for r in raw_rules if isinstance(r, dict))
+    games = tuple(str(g).lower() for g in rule_set_dict.get("games", []) or ())
+
+    compiled_rules = []
+    seen_rule_ids: set[str] = set()
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            continue
+        rule_id = str(raw.get("rule_id", "custom_rule"))
+        if rule_id in seen_rule_ids:
+            log.warning(
+                "Rule set %r declares rule_id %r more than once; keeping the first and skipping the rest",
+                rule_set_id,
+                rule_id,
+            )
+            continue
+        seen_rule_ids.add(rule_id)
+        compiled_rules.append(compile_custom_rule(raw))
 
     return AutoNoteRuleSet(
         rule_set_id=rule_set_id,
-        rules=compiled_rules,
-        supports_hand=lambda _h: True,
+        rules=tuple(compiled_rules),
+        supports_hand=_supports_hand_for(games),
         enabled_by_default=False,
     )
 
@@ -472,22 +541,101 @@ def load_user_autonotes_data(filepath: Path | str | None = None) -> dict[str, An
 
 
 def save_user_autonotes_data(data: dict[str, Any], filepath: Path | str | None = None) -> None:
-    """Save user autonotes data structure to user_autonotes.json."""
+    """Save user autonotes data, replacing the file only once it is fully written.
+
+    Writing in place would leave the user's whole rule collection truncated if
+    the process died mid-write. Serialise to a sibling temporary file, flush it
+    to disk, then rename over the target -- the rename is atomic, so a reader
+    sees either the old file or the new one, never a partial one.
+    """
     path = get_user_autonotes_path(filepath)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    handle = tempfile.NamedTemporaryFile(  # noqa: SIM115 - closed explicitly below, before the rename
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    tmp_path = Path(handle.name)
+    try:
+        with handle:
+            json.dump(data, handle, indent=2, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    _RULE_SET_CACHE.pop(str(path), None)
+
+
+# Compiled rule sets keyed by path, kept with the (mtime_ns, size) the file had
+# when they were built. available_rule_sets() runs once per imported hand, so
+# recompiling from disk every time put a stat, a parse and a full compile in the
+# import hot path.
+_RULE_SET_CACHE: dict[str, tuple[tuple[int, int] | None, tuple[AutoNoteRuleSet, ...]]] = {}
+
+
+def _file_signature(path: Path) -> tuple[int, int] | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
+def compile_custom_rule_sets(data: dict[str, Any]) -> tuple[AutoNoteRuleSet, ...]:
+    """Compile every custom rule set in a loaded document, skipping duplicates.
+
+    Two sets sharing a ``rule_set_id`` -- with each other or with a built-in set
+    -- would make the enable/disable toggles ambiguous, since configuration keys
+    on that id. The first one wins and the rest are reported.
+    """
+    from fpdb_3_legacy.AutoNotes import RULE_SET_REGISTRY
+
+    builtin_ids = {rule_set.rule_set_id for rule_set in RULE_SET_REGISTRY}
+    rule_sets: list[AutoNoteRuleSet] = []
+    seen_ids: set[str] = set()
+
+    for set_dict in data.get("custom_rule_sets", []):
+        if not isinstance(set_dict, dict):
+            continue
+        rule_set_id = str(set_dict.get("rule_set_id", "custom_user_rules"))
+        if rule_set_id in builtin_ids:
+            log.warning("Custom rule set %r shadows a built-in rule set id; skipping it", rule_set_id)
+            continue
+        if rule_set_id in seen_ids:
+            log.warning("Custom rule set id %r appears more than once; keeping the first", rule_set_id)
+            continue
+        seen_ids.add(rule_set_id)
+        rule_sets.append(compile_custom_rule_set(set_dict))
+
+    return tuple(rule_sets)
 
 
 def load_custom_rule_sets(filepath: Path | str | None = None) -> tuple[AutoNoteRuleSet, ...]:
-    """Load and compile custom AutoNoteRuleSets from user_autonotes.json."""
-    data = load_user_autonotes_data(filepath)
-    raw_sets = data.get("custom_rule_sets", [])
-    rule_sets = []
+    """Load and compile custom AutoNoteRuleSets, reusing the last compile.
 
-    for set_dict in raw_sets:
-        if isinstance(set_dict, dict):
-            rule_sets.append(compile_custom_rule_set(set_dict))
+    The cache is keyed by path and invalidated when the file's mtime or size
+    changes, so edits made by the editor -- or by hand, outside fpdb -- are still
+    picked up on the next call.
+    """
+    path = get_user_autonotes_path(filepath)
+    signature = _file_signature(path)
 
-    return tuple(rule_sets)
+    cached = _RULE_SET_CACHE.get(str(path))
+    if cached is not None and cached[0] == signature:
+        return cached[1]
+
+    rule_sets = compile_custom_rule_sets(load_user_autonotes_data(path))
+    _RULE_SET_CACHE[str(path)] = (signature, rule_sets)
+    return rule_sets
+
+
+def invalidate_custom_rule_cache() -> None:
+    """Drop every compiled rule set, forcing the next load to read from disk."""
+    _RULE_SET_CACHE.clear()

--- a/fpdb_3_legacy/user_autonotes_parser.py
+++ b/fpdb_3_legacy/user_autonotes_parser.py
@@ -1,0 +1,485 @@
+"""Declarative engine and parser for user-defined custom Auto Note rules."""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+from fpdb_3_legacy.AutoNotePlo import normalize_cards, rank_counts
+from fpdb_3_legacy.AutoNoteRules import PreflopContext
+from fpdb_3_legacy.AutoNotes import AutoNoteRule, AutoNoteRuleSet, GeneratedAutoNote
+from fpdb_3_legacy.Configuration import CONFIG_PATH
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("user_autonotes_parser")
+
+
+def get_user_autonotes_path(custom_path: Path | str | None = None) -> Path:
+    if custom_path:
+        return Path(custom_path)
+    if CONFIG_PATH:
+        return Path(CONFIG_PATH) / "user_autonotes.json"
+    return Path.home() / ".fpdb" / "user_autonotes.json"
+
+
+class CustomAutoNoteRule(AutoNoteRule):
+    """AutoNoteRule subclass supporting dynamic evidence key replacement in note templates."""
+
+    def evaluate(self, hand: Any, player_name: str, context: PreflopContext) -> GeneratedAutoNote | None:
+        player_ids = getattr(hand, "playerIds", {}) or {}
+        hand_id = getattr(hand, "dbid_hands", None)
+        player_id = player_ids.get(player_name)
+        if not player_id or hand_id is None or not self.predicate(hand, player_name, context):
+            return None
+
+        evidence = self.evidence_builder(hand, player_name, context)
+
+        # Prepare kwargs for template formatting
+        fmt_kwargs: dict[str, str] = {"player": player_name}
+        for k, v in evidence.items():
+            if isinstance(v, list):
+                fmt_kwargs[k] = " ".join(str(item) for item in v)
+            else:
+                fmt_kwargs[k] = str(v)
+
+        # Allow fallback for common alias names
+        if "eff_stack_bb" in fmt_kwargs and "eff_stack" not in fmt_kwargs:
+            fmt_kwargs["eff_stack"] = fmt_kwargs["eff_stack_bb"]
+        if "flop" in fmt_kwargs and "board" not in fmt_kwargs:
+            fmt_kwargs["board"] = fmt_kwargs["flop"]
+
+        # Safe template evaluation
+        class SafeDict(dict):
+            def __missing__(self, key: str) -> str:
+                return f"{{{key}}}"
+
+        try:
+            note_text = self.note_template.format_map(SafeDict(fmt_kwargs))
+        except Exception:
+            note_text = self.note_template.format(player=player_name)
+
+        return GeneratedAutoNote(
+            player_id=player_id,
+            hand_id=hand_id,
+            rule_id=self.rule_id,
+            rule_version=self.version,
+            note_text=note_text,
+            evidence=evidence,
+        )
+
+
+from decimal import Decimal
+
+def _extract_big_blind(hand: Any) -> float:
+    for attr in ("bigBlind", "bb", "big_blind"):
+        val = getattr(hand, attr, None)
+        if isinstance(val, (int, float, str, Decimal)):
+            try:
+                f_val = float(val)
+                if f_val > 0:
+                    return f_val
+            except (TypeError, ValueError):
+                pass
+    return 1.0
+
+
+def _extract_player_chips(hand: Any, player_name: str) -> float:
+    players = getattr(hand, "players", []) or []
+    for p in players:
+        if len(p) >= 3 and p[1] == player_name:
+            try:
+                return float(p[2])
+            except (TypeError, ValueError):
+                pass
+    handsplayers = getattr(hand, "handsplayers", {}) or {}
+    stats = handsplayers.get(player_name, {})
+    chips = stats.get("chips") or stats.get("start_stack") or 0.0
+    try:
+        return float(chips)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _extract_community_cards(hand: Any) -> list[str]:
+    board = getattr(hand, "board", None)
+    if isinstance(board, dict):
+        cards = []
+        for street in ("FLOP", "TURN", "RIVER"):
+            cards.extend(board.get(street, []))
+        return normalize_cards(cards)
+    if isinstance(board, list):
+        return normalize_cards(board)
+    cc = getattr(hand, "communityCards", None) or []
+    return normalize_cards(cc)
+
+
+def _position_name(pos_val: Any) -> str:
+    if pos_val == 0 or pos_val == "0":
+        return "BTN"
+    if pos_val == 1 or pos_val == "S" or pos_val == "SB":
+        return "SB"
+    if pos_val == 2 or pos_val == "B" or pos_val == "BB":
+        return "BB"
+    if isinstance(pos_val, str):
+        return pos_val.upper()
+    if pos_val == 3:
+        return "CO"
+    if pos_val == 4:
+        return "MP"
+    if pos_val == 5:
+        return "UTG"
+    return str(pos_val) if pos_val is not None else ""
+
+
+def extract_field_value(field: str, hand: Any, player_name: str, context: PreflopContext) -> Any:
+    """Extract named field value from hand context for declarative evaluation."""
+    field = field.lower().strip()
+
+    if field == "game.base":
+        gt = getattr(hand, "gametype", {}) or {}
+        if isinstance(gt, dict):
+            base = gt.get("base", "holdem")
+        else:
+            base = getattr(gt, "base", "holdem")
+        base = str(base).lower()
+        if base in ("hold", "holdem"):
+            return "holdem"
+        return base
+
+    if field == "game.category":
+        gt = getattr(hand, "gametype", {}) or {}
+        if isinstance(gt, dict):
+            return str(gt.get("category", "ring")).lower()
+        return str(getattr(gt, "category", "ring")).lower()
+
+    if field == "game.limit":
+        gt = getattr(hand, "gametype", {}) or {}
+        if isinstance(gt, dict):
+            return str(gt.get("limitType", "nl")).lower()
+        return str(getattr(gt, "limitType", "nl")).lower()
+
+    if field == "player.position":
+        pos_raw = context.positions.get(player_name)
+        return _position_name(pos_raw)
+
+    if field == "opponent.position":
+        first_raise = context.first_raise
+        if first_raise and first_raise.player != player_name:
+            has_pos = context.has_position_on(player_name, first_raise.player)
+            return "IP" if has_pos else "OOP"
+        return "IP"
+
+    if field == "player.eff_stack_bb":
+        bb = _extract_big_blind(hand)
+        chips = _extract_player_chips(hand, player_name)
+        return round(chips / bb, 2) if bb > 0 else 0.0
+
+    if field in ("spr.flop", "spr"):
+        bb = _extract_big_blind(hand)
+        chips = _extract_player_chips(hand, player_name)
+        pot = getattr(hand, "pot", None) or getattr(hand, "totalPot", None) or (bb * 2)
+        try:
+            pot_val = float(pot)
+        except (TypeError, ValueError):
+            pot_val = bb * 2
+        return round(chips / pot_val, 2) if pot_val > 0 else 99.0
+
+    if field == "action.preflop":
+        player_actions = context.player_actions.get(player_name, [])
+        if not player_actions:
+            return "none"
+        first_act = player_actions[0]
+        if context.player_made_raise_number(player_name, 1):
+            return "open_raise"
+        if context.player_made_raise_number(player_name, 2):
+            return "3bet_allin" if first_act.is_allin else "3bet"
+        if context.player_made_raise_number(player_name, 3):
+            return "4bet"
+        if context.player_called_first_raise(player_name):
+            return "cold_call"
+        if context.player_open_raised_then_folded_to_3bet(player_name):
+            return "fold_vs_3bet"
+        if first_act.is_call and len(context.raises) == 0:
+            return "limp"
+        return first_act.action.lower()
+
+    if field == "action.flop":
+        actions = getattr(hand, "actions", {}).get("FLOP", [])
+        for act in actions:
+            if len(act) >= 2 and act[0] == player_name:
+                act_str = str(act[1]).lower()
+                if "bet" in act_str or "raise" in act_str:
+                    return "cbet" if context.player_made_raise_number(player_name, 1) else "donk"
+                if "check" in act_str:
+                    return "check"
+                if "call" in act_str:
+                    return "check_call"
+                if "fold" in act_str:
+                    return "fold_vs_cbet"
+        return "none"
+
+    if field == "action.turn":
+        actions = getattr(hand, "actions", {}).get("TURN", [])
+        for act in actions:
+            if len(act) >= 2 and act[0] == player_name:
+                act_str = str(act[1]).lower()
+                if "bet" in act_str or "raise" in act_str:
+                    return "second_barrel"
+                if "fold" in act_str:
+                    return "fold"
+        return "none"
+
+    if field == "action.river":
+        actions = getattr(hand, "actions", {}).get("RIVER", [])
+        for act in actions:
+            if len(act) >= 2 and act[0] == player_name:
+                act_str = str(act[1]).lower()
+                if "bet" in act_str or "raise" in act_str:
+                    return "third_barrel"
+        return "none"
+
+    if field == "hand.rank":
+        hp = getattr(hand, "handsplayers", {}).get(player_name, {})
+        rank = hp.get("handText") or hp.get("showCards") or ""
+        return str(rank).lower()
+
+    if field == "board.flop_texture":
+        board = _extract_community_cards(hand)
+        flop = board[:3]
+        if not flop:
+            return "dry"
+        counts = rank_counts(flop)
+        if any(c >= 2 for c in counts.values()):
+            return "paired"
+        suits = [card[-1].lower() for card in flop if len(card) >= 2]
+        if len(set(suits)) == 1:
+            return "monotone"
+        if len(set(suits)) == 2:
+            return "twotone"
+        return "rainbow"
+
+    return ""
+
+
+def evaluate_leaf_condition(rule: dict[str, Any], hand: Any, player_name: str, context: PreflopContext) -> bool:
+    field = rule.get("field", "")
+    op = rule.get("operator", "eq").lower()
+    target_val = rule.get("value")
+
+    actual_val = extract_field_value(field, hand, player_name, context)
+
+    if op in ("eq", "=="):
+        if isinstance(target_val, str) and isinstance(actual_val, str):
+            return actual_val.lower() == target_val.lower()
+        return actual_val == target_val
+
+    if op in ("neq", "!="):
+        if isinstance(target_val, str) and isinstance(actual_val, str):
+            return actual_val.lower() != target_val.lower()
+        return actual_val != target_val
+
+    if op in ("gt", ">"):
+        try:
+            return float(actual_val) > float(target_val)
+        except (TypeError, ValueError):
+            return False
+
+    if op in ("gte", ">="):
+        try:
+            return float(actual_val) >= float(target_val)
+        except (TypeError, ValueError):
+            return False
+
+    if op in ("lt", "<"):
+        try:
+            return float(actual_val) < float(target_val)
+        except (TypeError, ValueError):
+            return False
+
+    if op in ("lte", "<="):
+        try:
+            return float(actual_val) <= float(target_val)
+        except (TypeError, ValueError):
+            return False
+
+    if op == "in":
+        if isinstance(target_val, (list, tuple, set)):
+            target_set = {str(x).lower() for x in target_val}
+            return str(actual_val).lower() in target_set
+        return str(target_val).lower() in str(actual_val).lower()
+
+    if op in ("not_in", "not in"):
+        if isinstance(target_val, (list, tuple, set)):
+            target_set = {str(x).lower() for x in target_val}
+            return str(actual_val).lower() not in target_set
+        return str(target_val).lower() not in str(actual_val).lower()
+
+    if op == "between":
+        if isinstance(target_val, (list, tuple)) and len(target_val) >= 2:
+            try:
+                val = float(actual_val)
+                return float(target_val[0]) <= val <= float(target_val[1])
+            except (TypeError, ValueError):
+                return False
+        return False
+
+    if op == "contains":
+        return str(target_val).lower() in str(actual_val).lower()
+
+    return False
+
+
+def evaluate_condition_tree(
+    condition_tree: dict[str, Any],
+    hand: Any,
+    player_name: str,
+    context: PreflopContext,
+) -> bool:
+    """Evaluate a nested logical condition tree (AND, OR, NOT)."""
+    if not condition_tree:
+        return True
+
+    op = str(condition_tree.get("operator", "")).upper()
+    rules = condition_tree.get("rules", [])
+
+    if op == "AND":
+        return all(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+    if op == "OR":
+        return any(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+    if op == "NOT":
+        return not any(evaluate_condition_tree(r, hand, player_name, context) for r in rules)
+
+    # Leaf condition
+    return evaluate_leaf_condition(condition_tree, hand, player_name, context)
+
+
+def build_evidence_dict(
+    hand: Any,
+    player_name: str,
+    context: PreflopContext,
+    evidence_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build captured evidence payload based on requested schema flags."""
+    cfg = evidence_config or {}
+    evidence: dict[str, Any] = {}
+
+    bb = _extract_big_blind(hand)
+    chips = _extract_player_chips(hand, player_name)
+    eff_stack_bb = round(chips / bb, 1) if bb > 0 else 0.0
+
+    if cfg.get("capture_hole", True):
+        evidence["hole"] = context.hole_cards.get(player_name, [])
+
+    if cfg.get("capture_board", True):
+        cards = _extract_community_cards(hand)
+        evidence["flop"] = cards[:3]
+        if len(cards) >= 4:
+            evidence["turn"] = [cards[3]]
+        if len(cards) >= 5:
+            evidence["river"] = [cards[4]]
+
+    if cfg.get("capture_eff_stack", True):
+        evidence["eff_stack_bb"] = eff_stack_bb
+        evidence["eff_stack"] = eff_stack_bb
+
+    if cfg.get("capture_action_sequence", True):
+        player_acts = [a.action for a in context.player_actions.get(player_name, [])]
+        evidence["action_sequence"] = player_acts
+
+    if cfg.get("capture_pot", True):
+        pot = getattr(hand, "pot", None) or getattr(hand, "totalPot", None) or (bb * 2)
+        try:
+            evidence["pot"] = round(float(pot), 1)
+        except (TypeError, ValueError):
+            evidence["pot"] = round(bb * 2, 1)
+
+    if cfg.get("capture_spr", True):
+        pot_val = evidence.get("pot", bb * 2)
+        evidence["spr"] = round(chips / pot_val, 2) if pot_val > 0 else 99.0
+
+    if cfg.get("capture_made_hand", False):
+        evidence["made_hand"] = extract_field_value("hand.rank", hand, player_name, context)
+
+    return evidence
+
+
+def compile_custom_rule(rule_dict: dict[str, Any], rule_set_id: str = "custom_user_rules") -> AutoNoteRule:
+    """Compile declarative JSON rule dict into an AutoNoteRule instance."""
+    rule_id = str(rule_dict.get("rule_id", "custom_rule"))
+    version = int(rule_dict.get("version", 1))
+    name = str(rule_dict.get("name", "Custom Rule"))
+    note_template = str(rule_dict.get("note_template", "{player}: custom note"))
+    condition_tree = rule_dict.get("conditions", {})
+    evidence_config = rule_dict.get("evidence", {})
+
+    def predicate(hand: Any, player_name: str, context: PreflopContext) -> bool:
+        return evaluate_condition_tree(condition_tree, hand, player_name, context)
+
+    def evidence_builder(hand: Any, player_name: str, context: PreflopContext) -> dict[str, Any]:
+        return build_evidence_dict(hand, player_name, context, evidence_config)
+
+    return CustomAutoNoteRule(
+        rule_id=rule_id,
+        version=version,
+        name=name,
+        note_template=note_template,
+        predicate=predicate,
+        evidence_builder=evidence_builder,
+    )
+
+
+def compile_custom_rule_set(rule_set_dict: dict[str, Any]) -> AutoNoteRuleSet:
+    """Compile declarative JSON rule set into an AutoNoteRuleSet instance."""
+    rule_set_id = str(rule_set_dict.get("rule_set_id", "custom_user_rules"))
+    enabled = bool(rule_set_dict.get("enabled", True))
+    raw_rules = rule_set_dict.get("rules", [])
+    compiled_rules = tuple(compile_custom_rule(r, rule_set_id) for r in raw_rules if isinstance(r, dict))
+
+    return AutoNoteRuleSet(
+        rule_set_id=rule_set_id,
+        rules=compiled_rules,
+        supports_hand=lambda _h: True,
+        enabled_by_default=False,
+    )
+
+
+def load_user_autonotes_data(filepath: Path | str | None = None) -> dict[str, Any]:
+    """Read user_autonotes.json file or return empty standard structure."""
+    path = get_user_autonotes_path(filepath)
+    if not path.exists():
+        return {"version": 1, "custom_rule_sets": []}
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        log.exception("Failed to parse user_autonotes.json at %s", path)
+
+    return {"version": 1, "custom_rule_sets": []}
+
+
+def save_user_autonotes_data(data: dict[str, Any], filepath: Path | str | None = None) -> None:
+    """Save user autonotes data structure to user_autonotes.json."""
+    path = get_user_autonotes_path(filepath)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def load_custom_rule_sets(filepath: Path | str | None = None) -> tuple[AutoNoteRuleSet, ...]:
+    """Load and compile custom AutoNoteRuleSets from user_autonotes.json."""
+    data = load_user_autonotes_data(filepath)
+    raw_sets = data.get("custom_rule_sets", [])
+    rule_sets = []
+
+    for set_dict in raw_sets:
+        if isinstance(set_dict, dict):
+            rule_sets.append(compile_custom_rule_set(set_dict))
+
+    return tuple(rule_sets)

--- a/test/test_custom_autonotes_regression.py
+++ b/test/test_custom_autonotes_regression.py
@@ -1,0 +1,251 @@
+"""Comprehensive unit and non-regression tests for Custom Auto Notes engine and UI integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+
+from fpdb_3_legacy.AutoNoteRules import LegacyAction, PreflopContext
+from fpdb_3_legacy.AutoNotes import (
+    available_rule_ids,
+    available_rule_set_ids,
+    available_rule_sets,
+    configured_rule_summary,
+    generate_for_hand,
+)
+from fpdb_3_legacy.user_autonotes_parser import (
+    build_evidence_dict,
+    compile_custom_rule,
+    compile_custom_rule_set,
+    evaluate_condition_tree,
+    evaluate_leaf_condition,
+    extract_field_value,
+    get_user_autonotes_path,
+    load_custom_rule_sets,
+    load_user_autonotes_data,
+    save_user_autonotes_data,
+)
+
+
+def _build_test_hand(
+    player_name: str = "Hero",
+    hole_cards: list[str] | None = None,
+    board_cards: list[str] | None = None,
+    game_base: str = "holdem",
+    game_cat: str = "ring",
+    game_limit: str = "nl",
+    bb: float = 2.0,
+    chips: float = 30.0,
+    position: int | str = 0,
+    actions_list: list[tuple[Any, ...]] | None = None,
+    flop_actions: list[tuple[Any, ...]] | None = None,
+):
+    hand = MagicMock()
+    hand.dbid_hands = 202
+    hand.handid = "202"
+    hand.bigBlind = bb
+    hand.bb = bb
+    hand.playerIds = {"Hero": 1, "Villain": 2, "Villain2": 3}
+    hand.players = [[1, "Hero", str(chips)], [2, "Villain", "100.0"], [3, "Villain2", "100.0"]]
+    hand.handsplayers = {
+        "Hero": {"chips": chips, "position": position, "handText": "Pair of Aces"},
+        "Villain": {"chips": 100.0, "position": "S", "handText": "High Card"},
+        "Villain2": {"chips": 100.0, "position": "B", "handText": "Two Pair"},
+    }
+    hand.join_holecards.side_effect = (
+        lambda p, asList=True: (hole_cards or ["Ah", "Kh"]) if p == "Hero" else ["Ts", "9s"]
+    )
+    hand.board = {"FLOP": board_cards[:3] if board_cards else ["Td", "7c", "2s"]}
+    if board_cards and len(board_cards) >= 4:
+        hand.board["TURN"] = [board_cards[3]]
+    if board_cards and len(board_cards) >= 5:
+        hand.board["RIVER"] = [board_cards[4]]
+
+    hand.communityCards = board_cards or ["Td", "7c", "2s"]
+    hand.pot = 10.0
+    hand.gametype = {"base": game_base, "category": game_cat, "limitType": game_limit}
+    hand.actionStreets = [0, "PREFLOP", "FLOP"]
+
+    default_preflop = [
+        ("Villain", "small blind", 1.0),
+        ("Villain2", "big blind", 2.0),
+        ("Hero", "raises", 6.0),
+        ("Villain", "folds"),
+        ("Villain2", "calls", 4.0),
+    ]
+    hand.actions = {
+        "PREFLOP": actions_list if actions_list is not None else default_preflop,
+        "FLOP": flop_actions or [("Villain2", "checks"), ("Hero", "bets", 8.0), ("Villain2", "folds")],
+    }
+    return hand
+
+
+# ============================================================================
+# 1. UNIT TESTS: Field Extractor & Leaf Condition Operators
+# ============================================================================
+
+
+def test_extract_field_value_game_context():
+    hand = _build_test_hand(game_base="holdem", game_cat="ring", game_limit="nl")
+    context = PreflopContext.from_hand(hand)
+
+    assert extract_field_value("game.base", hand, "Hero", context) == "holdem"
+    assert extract_field_value("game.category", hand, "Hero", context) == "ring"
+    assert extract_field_value("game.limit", hand, "Hero", context) == "nl"
+
+
+def test_extract_field_value_stack_and_positions():
+    hand = _build_test_hand(position=0, chips=30.0, bb=2.0)
+    context = PreflopContext.from_hand(hand)
+
+    assert extract_field_value("player.position", hand, "Hero", context) == "BTN"
+    assert extract_field_value("player.eff_stack_bb", hand, "Hero", context) == 15.0
+    assert extract_field_value("spr.flop", hand, "Hero", context) == 3.0
+
+
+def test_extract_field_value_actions_and_textures():
+    hand = _build_test_hand(board_cards=["Ac", "Kc", "Qc"])
+    context = PreflopContext.from_hand(hand)
+
+    assert extract_field_value("action.preflop", hand, "Hero", context) == "open_raise"
+    assert extract_field_value("action.flop", hand, "Hero", context) == "cbet"
+    assert extract_field_value("board.flop_texture", hand, "Hero", context) == "monotone"
+
+
+def test_evaluate_leaf_condition_operators():
+    hand = _build_test_hand(chips=20.0, bb=2.0)  # 10.0 BB
+    context = PreflopContext.from_hand(hand)
+
+    # eq & neq
+    assert evaluate_leaf_condition({"field": "game.base", "operator": "eq", "value": "holdem"}, hand, "Hero", context) is True
+    assert evaluate_leaf_condition({"field": "game.base", "operator": "neq", "value": "omaha"}, hand, "Hero", context) is True
+
+    # lte, gte, lt, gt
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "lte", "value": 15.0}, hand, "Hero", context) is True
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "gte", "value": 10.0}, hand, "Hero", context) is True
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "lt", "value": 5.0}, hand, "Hero", context) is False
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "gt", "value": 20.0}, hand, "Hero", context) is False
+
+    # in & not_in
+    assert evaluate_leaf_condition({"field": "player.position", "operator": "in", "value": ["BTN", "CO"]}, hand, "Hero", context) is True
+    assert evaluate_leaf_condition({"field": "player.position", "operator": "not_in", "value": ["SB", "BB"]}, hand, "Hero", context) is True
+
+    # between
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "between", "value": [5.0, 15.0]}, hand, "Hero", context) is True
+    assert evaluate_leaf_condition({"field": "player.eff_stack_bb", "operator": "between", "value": [20.0, 30.0]}, hand, "Hero", context) is False
+
+
+# ============================================================================
+# 2. UNIT TESTS: Template Safe Interpolation & Evidence Schema
+# ============================================================================
+
+
+def test_custom_rule_safe_dict_missing_keys():
+    rule_dict = {
+        "rule_id": "rule_missing_keys",
+        "name": "Template Test",
+        "note_template": "{player} open raised with {hole} (Unknown tag: {unknown_tag})",
+        "enabled": True,
+        "conditions": {"field": "game.base", "operator": "eq", "value": "holdem"},
+        "evidence": {"capture_hole": True},
+    }
+    rule = compile_custom_rule(rule_dict)
+    hand = _build_test_hand()
+    context = PreflopContext.from_hand(hand)
+
+    note = rule.evaluate(hand, "Hero", context)
+    assert note is not None
+    assert "{unknown_tag}" in note.note_text  # Gracefully preserved placeholder
+    assert "Hero open raised with Ah Kh" in note.note_text
+
+
+def test_evidence_builder_selective_flags():
+    hand = _build_test_hand()
+    context = PreflopContext.from_hand(hand)
+
+    # Full evidence
+    ev_full = build_evidence_dict(
+        hand,
+        "Hero",
+        context,
+        {
+            "capture_hole": True,
+            "capture_board": True,
+            "capture_eff_stack": True,
+            "capture_pot": True,
+            "capture_spr": True,
+            "capture_made_hand": True,
+        },
+    )
+    assert "hole" in ev_full
+    assert "flop" in ev_full
+    assert "eff_stack_bb" in ev_full
+    assert "pot" in ev_full
+    assert "spr" in ev_full
+    assert "made_hand" in ev_full
+
+    # Minimal evidence
+    ev_min = build_evidence_dict(hand, "Hero", context, {"capture_hole": False, "capture_board": False})
+    assert "hole" not in ev_min
+    assert "flop" not in ev_min
+
+
+# ============================================================================
+# 3. NON-REGRESSION TESTS: Custom Rules Engine Integration & Stability
+# ============================================================================
+
+
+def test_non_regression_corrupted_json_file_handled_gracefully(tmp_path: Path):
+    corrupt_file = tmp_path / "user_autonotes.json"
+    corrupt_file.write_text("{ malformed json ...")
+
+    # Should not raise exception, but return empty data
+    data = load_user_autonotes_data(corrupt_file)
+    assert data == {"version": 1, "custom_rule_sets": []}
+
+    rule_sets = load_custom_rule_sets(corrupt_file)
+    assert rule_sets == ()
+
+
+def test_non_regression_available_rule_sets_combines_builtins_and_customs(tmp_path: Path):
+    custom_file = tmp_path / "user_autonotes.json"
+    custom_data = {
+        "version": 1,
+        "custom_rule_sets": [
+            {
+                "rule_set_id": "custom_user_rules_test",
+                "name": "Test Custom Rules",
+                "enabled": True,
+                "rules": [
+                    {
+                        "rule_id": "custom_rule_nr1",
+                        "name": "Custom Non-Reg Rule",
+                        "note_template": "{player} non reg",
+                        "enabled": True,
+                        "conditions": {"field": "game.base", "operator": "eq", "value": "holdem"},
+                    }
+                ],
+            }
+        ],
+    }
+    save_user_autonotes_data(custom_data, custom_file)
+
+    rule_sets = load_custom_rule_sets(custom_file)
+    assert len(rule_sets) == 1
+    assert rule_sets[0].rule_set_id == "custom_user_rules_test"
+    assert rule_sets[0].enabled_by_default is False
+
+
+def test_non_regression_builtin_rulesets_unaffected():
+    # Verify built-in registries are intact
+    set_ids = available_rule_set_ids()
+    assert "hwang_plo_preflop" in set_ids
+    assert "holdem_cash_preflop" in set_ids
+    assert "range_capture" in set_ids
+
+    rule_ids = available_rule_ids()
+    assert "hwang_plo_081" in rule_ids
+    assert "holdem_cash_001" in rule_ids
+    assert "range_capture_001" in rule_ids

--- a/test/test_custom_autonotes_regression.py
+++ b/test/test_custom_autonotes_regression.py
@@ -2,27 +2,20 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
-import pytest
 
-from fpdb_3_legacy.AutoNoteRules import LegacyAction, PreflopContext
+from fpdb_3_legacy.AutoNoteRules import PreflopContext
 from fpdb_3_legacy.AutoNotes import (
     available_rule_ids,
     available_rule_set_ids,
-    available_rule_sets,
-    configured_rule_summary,
-    generate_for_hand,
 )
 from fpdb_3_legacy.user_autonotes_parser import (
     build_evidence_dict,
     compile_custom_rule,
-    compile_custom_rule_set,
-    evaluate_condition_tree,
     evaluate_leaf_condition,
     extract_field_value,
-    get_user_autonotes_path,
     load_custom_rule_sets,
     load_user_autonotes_data,
     save_user_autonotes_data,

--- a/test/test_gui_custom_autonotes_editor.py
+++ b/test/test_gui_custom_autonotes_editor.py
@@ -1,0 +1,110 @@
+"""Qt unit tests for GuiCustomAutoNotesEditor UI component."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import pytest
+from PySide6.QtWidgets import QApplication
+
+pytestmark = pytest.mark.qt
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def test_custom_autonotes_editor_creation_and_rule_actions(qtbot, tmp_path: Path):
+    from fpdb_3_legacy.GuiCustomAutoNotesEditor import GuiCustomAutoNotesEditor
+    from fpdb_3_legacy.user_autonotes_parser import save_user_autonotes_data
+
+    QApplication.instance() or QApplication([])
+
+    # Seed temporary custom rules file
+    custom_path = tmp_path / "user_autonotes.json"
+    initial_data = {
+        "version": 1,
+        "custom_rule_sets": [
+            {
+                "rule_set_id": "custom_user_rules",
+                "name": "User Custom Rules",
+                "enabled": True,
+                "rules": [
+                    {
+                        "rule_id": "rule_initial",
+                        "version": 1,
+                        "name": "Initial Test Rule",
+                        "note_template": "{player} tested initial",
+                        "enabled": True,
+                        "conditions": {"operator": "AND", "rules": [{"field": "game.base", "operator": "eq", "value": "holdem"}]},
+                        "evidence": {"capture_hole": True},
+                    }
+                ],
+            }
+        ],
+    }
+    save_user_autonotes_data(initial_data, custom_path)
+
+    # Instantiate editor widget
+    editor = GuiCustomAutoNotesEditor(config=None)
+    qtbot.addWidget(editor)
+
+    # Verify initial tree population
+    assert editor.tree.topLevelItemCount() >= 1
+
+    # Test adding a new rule
+    editor.on_new_rule()
+    assert editor.current_rule_dict is not None
+    assert "Custom Rule #" in editor.current_rule_dict["name"]
+
+    # Test adding condition row
+    initial_rows = len(editor.condition_rows)
+    editor.on_add_condition_row()
+    assert len(editor.condition_rows) == initial_rows + 1
+
+    # Test duplicating a rule
+    editor.on_duplicate_rule()
+    assert "(Copy)" in editor.current_rule_dict["name"]
+
+
+def test_custom_autonotes_workbench_tab_integration(qtbot):
+    from fpdb_3_legacy.GuiAutoNotesWorkbench import GuiAutoNotesWorkbench
+
+    QApplication.instance() or QApplication([])
+
+    bench = GuiAutoNotesWorkbench(None)
+    qtbot.addWidget(bench)
+
+    # Check 4th tab exists and is Custom Rules
+    assert bench.tabs.count() == 4
+    assert bench.tabs.tabText(3) == "Custom Rules"
+    assert hasattr(bench, "custom_rules_editor")
+
+
+def test_custom_autonotes_editor_sandbox_evaluation(qtbot):
+    from fpdb_3_legacy.GuiCustomAutoNotesEditor import GuiCustomAutoNotesEditor
+
+    QApplication.instance() or QApplication([])
+
+    editor = GuiCustomAutoNotesEditor(config=None)
+    qtbot.addWidget(editor)
+
+    editor.on_new_rule()
+
+    hh = """Poker Hand #TM2917910999: Hold'em No Limit ($0.05/$0.10) - 2026/06/19 09:30:00
+Table 'NLHGold12' 6-max Seat #3 is the button
+Seat 1: Villain1 ($10.00 in chips)
+Seat 4: Hero ($1.20 in chips)
+Seat 5: SBPlayer ($10.00 in chips)
+Seat 6: BBPlayer ($10.00 in chips)
+SBPlayer: posts small blind $0.05
+BBPlayer: posts big blind $0.10
+*** HOLE CARDS ***
+Dealt to Hero [As Ks]
+Hero: raises $0.85 to $1.20 and is all-in
+*** SUMMARY ***
+Total pot $2.55 | Rake $0.10
+"""
+    editor.txt_sandbox_hh.setPlainText(hh)
+    editor.on_evaluate_sandbox()
+
+    assert "MATCH" in editor.lbl_sandbox_status.text()
+

--- a/test/test_gui_custom_autonotes_editor.py
+++ b/test/test_gui_custom_autonotes_editor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+
 import pytest
 from PySide6.QtWidgets import QApplication
 

--- a/test/test_user_autonotes_hardening.py
+++ b/test/test_user_autonotes_hardening.py
@@ -1,0 +1,211 @@
+"""Guards for the custom Auto Notes engine: identity, durability, and templates.
+
+Each test here pins a defect found while reviewing the custom-rules editor:
+duplicate rule ids that make a note impossible to attribute, an in-place write
+that could truncate the user's whole rule collection, a rule file that could
+reach into objects through its note template, and a per-hand disk reload.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fpdb_3_legacy.AutoNotes import RULE_SET_REGISTRY
+from fpdb_3_legacy.user_autonotes_parser import (
+    MAX_CONDITION_DEPTH,
+    compile_custom_rule_set,
+    compile_custom_rule_sets,
+    evaluate_condition_tree,
+    invalidate_custom_rule_cache,
+    load_custom_rule_sets,
+    load_user_autonotes_data,
+    render_note_template,
+    save_user_autonotes_data,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    invalidate_custom_rule_cache()
+    yield
+    invalidate_custom_rule_cache()
+
+
+def _rule(rule_id: str, **overrides) -> dict:
+    rule = {
+        "rule_id": rule_id,
+        "version": 1,
+        "name": f"Rule {rule_id}",
+        "note_template": "{player} did something",
+        "conditions": {},
+        "evidence": {},
+    }
+    rule.update(overrides)
+    return rule
+
+
+def _document(*rules: dict, rule_set_id: str = "custom_user_rules", **extra) -> dict:
+    return {"version": 1, "custom_rule_sets": [{"rule_set_id": rule_set_id, "rules": list(rules), **extra}]}
+
+
+class TestRuleIdentity:
+    def test_a_repeated_rule_id_is_dropped(self) -> None:
+        """Notes are keyed by rule id; two rules sharing one cannot be told apart."""
+        rule_set = compile_custom_rule_set({"rule_set_id": "s", "rules": [_rule("dup"), _rule("dup"), _rule("other")]})
+
+        assert [r.rule_id for r in rule_set.rules] == ["dup", "other"]
+
+    def test_the_first_rule_of_a_duplicated_id_is_the_one_kept(self) -> None:
+        rule_set = compile_custom_rule_set(
+            {"rule_set_id": "s", "rules": [_rule("dup", name="first"), _rule("dup", name="second")]},
+        )
+
+        assert [r.name for r in rule_set.rules] == ["first"]
+
+    def test_a_custom_set_cannot_shadow_a_builtin_id(self) -> None:
+        builtin_id = next(iter(RULE_SET_REGISTRY)).rule_set_id
+        document = _document(_rule("r1"), rule_set_id=builtin_id)
+
+        assert compile_custom_rule_sets(document) == ()
+
+    def test_a_repeated_rule_set_id_is_dropped(self) -> None:
+        document = {
+            "custom_rule_sets": [
+                {"rule_set_id": "same", "rules": [_rule("a")]},
+                {"rule_set_id": "same", "rules": [_rule("b")]},
+            ],
+        }
+
+        compiled = compile_custom_rule_sets(document)
+
+        assert len(compiled) == 1
+        assert [r.rule_id for r in compiled[0].rules] == ["a"]
+
+
+class TestDurableSave:
+    def test_a_saved_file_round_trips(self, tmp_path: Path) -> None:
+        target = tmp_path / "user_autonotes.json"
+        document = _document(_rule("r1"))
+
+        save_user_autonotes_data(document, target)
+
+        assert load_user_autonotes_data(target) == document
+
+    def test_a_failed_save_leaves_the_previous_file_intact(self, tmp_path: Path, monkeypatch) -> None:
+        """An in-place write would truncate the user's whole rule collection."""
+        target = tmp_path / "user_autonotes.json"
+        save_user_autonotes_data(_document(_rule("original")), target)
+
+        def explode(*_args, **_kwargs):
+            message = "disk full"
+            raise OSError(message)
+
+        monkeypatch.setattr(json, "dump", explode)
+
+        with pytest.raises(OSError, match="disk full"):
+            save_user_autonotes_data(_document(_rule("replacement")), target)
+
+        surviving = load_user_autonotes_data(target)
+        assert surviving["custom_rule_sets"][0]["rules"][0]["rule_id"] == "original"
+
+    def test_a_failed_save_leaves_no_temporary_file_behind(self, tmp_path: Path, monkeypatch) -> None:
+        target = tmp_path / "user_autonotes.json"
+
+        def explode(*_args, **_kwargs):
+            message = "disk full"
+            raise OSError(message)
+
+        monkeypatch.setattr(json, "dump", explode)
+        with pytest.raises(OSError, match="disk full"):
+            save_user_autonotes_data(_document(_rule("r1")), target)
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_a_malformed_file_yields_an_empty_document(self, tmp_path: Path) -> None:
+        target = tmp_path / "user_autonotes.json"
+        target.write_text("{ not json", encoding="utf-8")
+
+        assert load_user_autonotes_data(target) == {"version": 1, "custom_rule_sets": []}
+
+
+class TestTemplateRendering:
+    def test_known_tags_are_substituted(self) -> None:
+        assert render_note_template("{player} raised {hole}", {"player": "Alice", "hole": "Ah Kd"}) == "Alice raised Ah Kd"
+
+    def test_an_unknown_tag_stays_visible(self) -> None:
+        assert render_note_template("{player} {nope}", {"player": "Alice"}) == "Alice {nope}"
+
+    def test_attribute_access_is_not_evaluated(self) -> None:
+        """A shared rule file must not reach into objects through its template."""
+        rendered = render_note_template("{player.__class__.__mro__}", {"player": "Alice"})
+
+        assert rendered == "{player.__class__.__mro__}"
+        assert "class" not in rendered.replace("__class__", "")
+
+    def test_a_brace_that_is_not_a_tag_is_left_alone(self) -> None:
+        assert render_note_template("100% {0} {}", {"player": "Alice"}) == "100% {0} {}"
+
+
+class TestConditionTree:
+    def test_an_empty_tree_matches(self) -> None:
+        assert evaluate_condition_tree({}, None, "Alice", None) is True
+
+    def test_a_tree_nested_past_the_limit_stops_matching(self) -> None:
+        tree: dict = {"operator": "AND", "rules": []}
+        cursor = tree
+        for _ in range(MAX_CONDITION_DEPTH + 2):
+            child: dict = {"operator": "AND", "rules": []}
+            cursor["rules"].append(child)
+            cursor = child
+
+        assert evaluate_condition_tree(tree, None, "Alice", None) is False
+
+
+class TestRuleSetCache:
+    def test_a_second_load_does_not_reread_the_file(self, tmp_path: Path, monkeypatch) -> None:
+        """available_rule_sets() runs once per imported hand."""
+        target = tmp_path / "user_autonotes.json"
+        save_user_autonotes_data(_document(_rule("r1")), target)
+        load_custom_rule_sets(target)
+
+        import fpdb_3_legacy.user_autonotes_parser as parser
+
+        def explode(*_args, **_kwargs):
+            message = "the cached compile must be reused"
+            raise AssertionError(message)
+
+        monkeypatch.setattr(parser, "load_user_autonotes_data", explode)
+
+        assert [rs.rule_set_id for rs in load_custom_rule_sets(target)] == ["custom_user_rules"]
+
+    def test_an_edit_is_picked_up(self, tmp_path: Path) -> None:
+        target = tmp_path / "user_autonotes.json"
+        save_user_autonotes_data(_document(_rule("before")), target)
+        assert [r.rule_id for r in load_custom_rule_sets(target)[0].rules] == ["before"]
+
+        save_user_autonotes_data(_document(_rule("after")), target)
+
+        assert [r.rule_id for r in load_custom_rule_sets(target)[0].rules] == ["after"]
+
+    def test_a_missing_file_yields_no_rule_sets(self, tmp_path: Path) -> None:
+        assert load_custom_rule_sets(tmp_path / "absent.json") == ()
+
+
+class TestGameFilter:
+    class _Hand:
+        def __init__(self, base: str) -> None:
+            self.gametype = {"base": base}
+
+    def test_an_undeclared_game_list_keeps_matching_every_hand(self) -> None:
+        rule_set = compile_custom_rule_set({"rule_set_id": "s", "rules": [_rule("r1")]})
+
+        assert rule_set.supports_hand(self._Hand("stud")) is True
+
+    def test_a_declared_game_list_restricts_the_rule_set(self) -> None:
+        rule_set = compile_custom_rule_set({"rule_set_id": "s", "games": ["holdem"], "rules": [_rule("r1")]})
+
+        assert rule_set.supports_hand(self._Hand("hold")) is True
+        assert rule_set.supports_hand(self._Hand("stud")) is False

--- a/test/test_user_autonotes_parser.py
+++ b/test/test_user_autonotes_parser.py
@@ -1,0 +1,163 @@
+"""Unit tests for user_autonotes_parser declarative engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fpdb_3_legacy.AutoNoteRules import LegacyAction, PreflopContext
+from fpdb_3_legacy.user_autonotes_parser import (
+    build_evidence_dict,
+    compile_custom_rule,
+    compile_custom_rule_set,
+    evaluate_condition_tree,
+    load_custom_rule_sets,
+    load_user_autonotes_data,
+    save_user_autonotes_data,
+)
+
+
+def _make_mock_hand(
+    player_name="Hero",
+    hole_cards=None,
+    board_cards=None,
+    bb=2.0,
+    chips=30.0,
+    actions_list=None,
+):
+    hand = MagicMock()
+    hand.dbid_hands = 101
+    hand.playerIds = {"Hero": 1, "Villain": 2}
+    hand.players = [["1", "Hero"], ["2", "Villain"]]
+    hand.bigBlind = bb
+    hand.handsplayers = {
+        "Hero": {"chips": chips, "position": 0, "handText": "Pair of Aces"},
+        "Villain": {"chips": 100.0, "position": "S", "handText": "High Card"},
+    }
+    hand.join_holecards.side_effect = lambda p, asList=True: (hole_cards or ["Ah", "Kh"]) if p == "Hero" else ["Ts", "9s"]
+    hand.communityCards = board_cards or ["Td", "7c", "2s"]
+    hand.pot = 10.0
+    hand.gametype = {"base": "holdem", "category": "ring", "limitType": "nl"}
+    hand.actionStreets = [0, "PREFLOP", "FLOP"]
+    hand.actions = {
+        "PREFLOP": actions_list or [
+            ("Villain", "small blind", 1.0),
+            ("Hero", "big blind", 2.0),
+            ("Villain", "raises", 6.0),
+            ("Hero", "raises", 30.0, True),  # allin
+        ]
+    }
+    return hand
+
+
+def test_evaluate_condition_tree_and_leaf():
+    hand = _make_mock_hand()
+    context = PreflopContext.from_hand(hand)
+
+    condition_tree = {
+        "operator": "AND",
+        "rules": [
+            {"field": "game.base", "operator": "eq", "value": "holdem"},
+            {"field": "player.position", "operator": "eq", "value": "BTN"},
+            {"field": "player.eff_stack_bb", "operator": "lte", "value": 20.0},
+        ],
+    }
+
+    assert evaluate_condition_tree(condition_tree, hand, "Hero", context) is True
+
+
+def test_evaluate_condition_tree_or_not():
+    hand = _make_mock_hand()
+    context = PreflopContext.from_hand(hand)
+
+    tree_or = {
+        "operator": "OR",
+        "rules": [
+            {"field": "game.base", "operator": "eq", "value": "omaha"},
+            {"field": "player.position", "operator": "eq", "value": "BTN"},
+        ],
+    }
+    assert evaluate_condition_tree(tree_or, hand, "Hero", context) is True
+
+    tree_not = {
+        "operator": "NOT",
+        "rules": [
+            {"field": "game.base", "operator": "eq", "value": "omaha"},
+        ],
+    }
+    assert evaluate_condition_tree(tree_not, hand, "Hero", context) is True
+
+
+def test_build_evidence_dict():
+    hand = _make_mock_hand()
+    context = PreflopContext.from_hand(hand)
+
+    evidence = build_evidence_dict(hand, "Hero", context)
+    assert evidence["hole"] == ["Ah", "Kh"]
+    assert evidence["flop"] == ["Td", "7c", "2s"]
+    assert evidence["eff_stack_bb"] == 15.0
+
+
+def test_compile_custom_rule_and_evaluate():
+    rule_dict = {
+        "rule_id": "custom_holdem_3bet_push",
+        "version": 1,
+        "name": "3-Bet Push Shortstack (<15bb)",
+        "note_template": "{player} 3-Bet Shove Preflop {eff_stack_bb}BB with {hole}",
+        "enabled": True,
+        "conditions": {
+            "operator": "AND",
+            "rules": [
+                {"field": "game.base", "operator": "eq", "value": "holdem"},
+                {"field": "player.eff_stack_bb", "operator": "lte", "value": 15.0},
+            ],
+        },
+        "evidence": {
+            "capture_hole": True,
+            "capture_board": True,
+            "capture_eff_stack": True,
+        },
+    }
+
+    rule = compile_custom_rule(rule_dict)
+    hand = _make_mock_hand()
+    context = PreflopContext.from_hand(hand)
+
+    note = rule.evaluate(hand, "Hero", context)
+    assert note is not None
+    assert note.rule_id == "custom_holdem_3bet_push"
+    assert "Hero 3-Bet Shove Preflop 15.0BB with Ah Kh" in note.note_text
+
+
+def test_save_and_load_user_autonotes(tmp_path: Path):
+    file_path = tmp_path / "user_autonotes.json"
+    data = {
+        "version": 1,
+        "custom_rule_sets": [
+            {
+                "rule_set_id": "custom_user_rules",
+                "name": "User Custom Rules",
+                "enabled": True,
+                "rules": [
+                    {
+                        "rule_id": "test_rule_1",
+                        "name": "Test Rule 1",
+                        "note_template": "{player} tested",
+                        "enabled": True,
+                        "conditions": {"field": "game.base", "operator": "eq", "value": "holdem"},
+                    }
+                ],
+            }
+        ],
+    }
+
+    save_user_autonotes_data(data, file_path)
+    loaded_data = load_user_autonotes_data(file_path)
+    assert loaded_data == data
+
+    rule_sets = load_custom_rule_sets(file_path)
+    assert len(rule_sets) == 1
+    assert rule_sets[0].rule_set_id == "custom_user_rules"
+    assert len(rule_sets[0].rules) == 1
+    assert rule_sets[0].rules[0].rule_id == "test_rule_1"

--- a/test/test_user_autonotes_parser.py
+++ b/test/test_user_autonotes_parser.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from fpdb_3_legacy.AutoNoteRules import LegacyAction, PreflopContext
+from fpdb_3_legacy.AutoNoteRules import PreflopContext
 from fpdb_3_legacy.user_autonotes_parser import (
     build_evidence_dict,
     compile_custom_rule,
-    compile_custom_rule_set,
     evaluate_condition_tree,
     load_custom_rule_sets,
     load_user_autonotes_data,


### PR DESCRIPTION
## Summary & Implementation

Closes #176

Provide a complete, intuitive User Interface (UI) within the **AUTO NOTES** workbench of FPDB 3 that allows users to create, edit, duplicate, test, and delete custom Auto Note rules without writing Python code.

Custom rules are compiled into the same `AutoNoteRule` / `AutoNoteRuleSet` objects the built-in rules use, so nothing downstream — generation, backfill, storage — needs to know whether a rule came from Python or from JSON.

### Changes Included

1. **Declarative engine & parser (`fpdb_3_legacy/user_autonotes_parser.py`)**:
   - Save & load user rules as `user_autonotes.json` in the fpdb config directory, written atomically.
   - Condition tree evaluator supporting `AND`, `OR`, `NOT` groups and leaf conditions for Game Context, Stack Context, Positions, Action Sequences, Made Hand Ranks, and Board Textures.
   - Leaf operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `between`, `contains`.
   - Dynamic template tag replacement (`{player}`, `{hole}`, `{flop}`, `{board}`, `{eff_stack_bb}`, `{spr}`, `{pot}`, `{action_sequence}`).
   - `CustomAutoNoteRule` subclasses `AutoNoteRule` to interpolate template tags.
2. **PySide6 visual editor (`fpdb_3_legacy/GuiCustomAutoNotesEditor.py`)**:
   - Header Toolbar: `[ + New Rule ]`, `[ 📋 Duplicate ]`, `[ 🗑️ Delete ]`, `[ 💾 Save Rules ]`, `[ 🧪 Test Sandbox ]`.
   - Rule list tree selector (`QTreeWidget`).
   - No-Code Visual Condition Builder for fields, operators, and values.
   - Captured Evidence Schema selection checkboxes.
   - Live Testing Sandbox: Raw HH text evaluator with status badge, high-contrast note display, and 25x33 SVG card rendering.
3. **Workbench integration (`fpdb_3_legacy/GuiAutoNotesWorkbench.py`, `fpdb_3_legacy/AutoNotes.py`)**:
   - Integrated 4th tab **Custom Rules** in the Auto Notes workbench.
   - `available_rule_sets()` now returns the built-in registry plus the user's compiled sets.
   - Auto-refresh rule set selection dropdowns on rule saving.

### Hardening (`d362138b`)

Follow-ups from review, each covered by a regression test:

- **Rule id uniqueness.** Notes are keyed by rule id, so a collision makes a note impossible to attribute. Two paths could produce one — duplicating the same rule twice yielded `<id>_copy` twice, and numbering new rules by list length repeated an id once an earlier rule had been deleted. Both now allocate through `_unique_rule_id`; saving refuses a document that still holds duplicates rather than renaming silently; deletion matches on identity, not on value.
- **Durable saves.** The rule file is written to a sibling temp file, fsynced, then renamed over the target, so an interruption can no longer truncate the user's whole rule collection.
- **Template rendering.** Only bare `{tag}` placeholders are substituted. `format_map` would have evaluated `{player.__class__}`, which matters as soon as rule files are shared between users.
- **Compiled rule sets are cached** against the file's mtime and size — `available_rule_sets()` runs once per imported hand, so the previous code put a stat, a parse and a full compile in the import hot path.
- An optional `games` list restricts a rule set to specific variants (absent, every hand still matches); custom sets that shadow a built-in `rule_set_id` are refused; condition-tree recursion is bounded.

### Tests

**36 tests** across four files:

| File | Tests |
| --- | --- |
| `test/test_user_autonotes_hardening.py` | 19 |
| `test/test_custom_autonotes_regression.py` | 9 |
| `test/test_user_autonotes_parser.py` | 5 |
| `test/test_gui_custom_autonotes_editor.py` | 3 |

The 3 GUI tests are marked `pytest.mark.qt`, which `pytest.ini` deselects by default (`-m "not qt and not perf"`), so the standard run covers 33 of the 36 — use `make test-gui` for the rest.
