### PR TITLE
feat(swc): Native Hand Capture & Live HUD Specification for SwC Poker Desktop (#178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
         run: python tools/prepare_briefcase_resources.py
       - name: Verify technical-debt inventory
         run: python tools/todo_inventory.py --check
-      # Run as a module: invoking the file as a script leaves the repository
-      # root off sys.path, so the module's own `from fpdb_3_legacy...` imports
-      # raise ModuleNotFoundError before the compiler is ever reached.
-      - name: Verify SwC Native Interposer compilation
-        run: python -m fpdb_3_legacy.swc_native_capture --build
       - name: Type-check modernized core
         run: >-
           mypy
@@ -306,6 +301,9 @@ jobs:
   # POSIX, GetModuleHandleA over the bundled OpenSSL DLLs on Windows. Compiling
   # it only where CI happens to run would leave two of the three branches
   # unbuilt, so each one is compiled on its own runner.
+  #
+  # swc_tap_build imports nothing but the standard library, so this needs no
+  # project install: it is a compiler check, not an import check.
   interposer:
     name: Compile SwC interposer (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -320,7 +318,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Compile the tap
-        run: python -m fpdb_3_legacy.swc_native_capture --build
+        run: python -m fpdb_3_legacy.swc_tap_build --build
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
         run: python tools/prepare_briefcase_resources.py
       - name: Verify technical-debt inventory
         run: python tools/todo_inventory.py --check
+      # Run as a module: invoking the file as a script leaves the repository
+      # root off sys.path, so the module's own `from fpdb_3_legacy...` imports
+      # raise ModuleNotFoundError before the compiler is ever reached.
       - name: Verify SwC Native Interposer compilation
-        run: python fpdb_3_legacy/swc_native_capture.py --build
+        run: python -m fpdb_3_legacy.swc_native_capture --build
       - name: Type-check modernized core
         run: >-
           mypy
@@ -298,6 +301,26 @@ jobs:
           test/test_partypoker_summary.py
           test/test_stats_known_hands.py
           tests/helpers/parser_regression.py
+
+  # The interposer carries a distinct #ifdef branch per platform -- dlsym on
+  # POSIX, GetModuleHandleA over the bundled OpenSSL DLLs on Windows. Compiling
+  # it only where CI happens to run would leave two of the three branches
+  # unbuilt, so each one is compiled on its own runner.
+  interposer:
+    name: Compile SwC interposer (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Compile the tap
+        run: python -m fpdb_3_legacy.swc_native_capture --build
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: python tools/prepare_briefcase_resources.py
       - name: Verify technical-debt inventory
         run: python tools/todo_inventory.py --check
+      - name: Verify SwC Native Interposer compilation
+        run: python fpdb_3_legacy/swc_native_capture.py --build
       - name: Type-check modernized core
         run: >-
           mypy

--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -996,7 +996,10 @@ class AuxSeats(AuxWindow):
         seats = set()
         for data in self.hud.stat_dict.values():
             seat = data.get("seat")
-            if seat:
+            # `if seat` would read seat 0 as an empty chair and drop that player
+            # from the layout entirely, leaving them with no stat panel while
+            # everyone else got one. Only a genuinely absent seat is skipped.
+            if seat is not None:
                 seats.add(int(seat))
         return sorted(seats)
 

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -12,6 +12,7 @@ import sys
 import time
 import traceback
 from optparse import OptionParser
+from pathlib import Path
 from typing import Any
 
 try:
@@ -107,36 +108,70 @@ class SwCNativeTailingThread(QThread):
 
     hand_imported = Signal(dict)
 
+    #: A hand needs the messages around it to be reconstructed, so decoded
+    #: messages are retained across polls rather than re-read from disk. This
+    #: caps that history: a long session would otherwise grow it without bound.
+    MAX_RETAINED_MESSAGES = 20000
+
     def __init__(self, raw_path: Any = None, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        from pathlib import Path
-        self.raw_path = (raw_path or (Path.home() / ".fpdb" / "swc-native-capture" / "swc-native.raw")).expanduser().resolve()
+        default = Path.home() / ".fpdb" / "swc-native-capture" / "swc-native.raw"
+        self.raw_path = Path(raw_path or default).expanduser().resolve()
         self._stop_requested = False
         self._imported_keys: set[tuple[int, int]] = set()
+        self._offset = 0
+        self._messages: list[Any] = []
+        self._consecutive_errors = 0
 
     def stop(self) -> None:
         self._stop_requested = True
 
-    def run(self) -> None:
+    def poll_once(self) -> list[dict]:
+        """Decode whatever was appended since the last call and return new hands.
+
+        Split out of the polling loop so the decode path can be exercised without
+        starting a thread or waiting on its timing.
+        """
         from fpdb_3_legacy.swc_native_capture import (
-            iter_capture_records,
             iter_protocol_messages,
             normalize_native_hands,
+            read_records_since,
         )
 
+        records, self._offset = read_records_since(self.raw_path, self._offset)
+        if not records:
+            return []
+
+        self._messages.extend(iter_protocol_messages(iter(records)))
+        if len(self._messages) > self.MAX_RETAINED_MESSAGES:
+            del self._messages[: len(self._messages) - self.MAX_RETAINED_MESSAGES]
+
+        fresh: list[dict] = []
+        for hand in normalize_native_hands(self._messages, raw_ref=str(self.raw_path)):
+            key = (hand.get("table_id", 0), hand.get("hand_id", 0))
+            if key not in self._imported_keys:
+                self._imported_keys.add(key)
+                fresh.append(hand)
+        return fresh
+
+    def run(self) -> None:
         while not self._stop_requested:
-            if self.raw_path.exists():
-                try:
-                    with self.raw_path.open("rb") as stream:
-                        messages = list(iter_protocol_messages(iter_capture_records(stream)))
-                        hands = normalize_native_hands(messages, raw_ref=str(self.raw_path))
-                        for hand in hands:
-                            key = (hand.get("table_id", 0), hand.get("hand_id", 0))
-                            if key not in self._imported_keys:
-                                self._imported_keys.add(key)
-                                self.hand_imported.emit(hand)
-                except Exception as e:
-                    log.debug("SwCNativeTailingThread error: %s", e)
+            try:
+                for hand in self.poll_once():
+                    self.hand_imported.emit(hand)
+                self._consecutive_errors = 0
+            except Exception:
+                # One failure is unremarkable while the tap is mid-write; a run of
+                # them means the archive is unreadable and the user is silently
+                # getting no hands, so say so instead of hiding it at debug level.
+                self._consecutive_errors += 1
+                if self._consecutive_errors in (1, 10, 100):
+                    log.warning(
+                        "SwC native tailing failed %d time(s) reading %s",
+                        self._consecutive_errors,
+                        self.raw_path,
+                        exc_info=True,
+                    )
             for _step in range(10):
                 if self._stop_requested:
                     break

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -14,7 +14,10 @@ import traceback
 from optparse import OptionParser
 from typing import Any
 
-import interlocks
+try:
+    import interlocks
+except ImportError:
+    from fpdb_3_legacy import interlocks
 from PySide6.QtCore import QDateTime, QThread, QTimer, Signal
 from PySide6.QtGui import QColor, QPalette, QTextCharFormat, QTextCursor
 from PySide6.QtWidgets import (
@@ -99,6 +102,47 @@ class AutoImportThread(QThread):
             self.error.emit(str(e))
 
 
+class SwCNativeTailingThread(QThread):
+    """Background thread tailing raw SwC native capture and importing live hands."""
+
+    hand_imported = Signal(dict)
+
+    def __init__(self, raw_path: Any = None, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        from pathlib import Path
+        self.raw_path = (raw_path or (Path.home() / ".fpdb" / "swc-native-capture" / "swc-native.raw")).expanduser().resolve()
+        self._stop_requested = False
+        self._imported_keys: set[tuple[int, int]] = set()
+
+    def stop(self) -> None:
+        self._stop_requested = True
+
+    def run(self) -> None:
+        from fpdb_3_legacy.swc_native_capture import (
+            iter_capture_records,
+            iter_protocol_messages,
+            normalize_native_hands,
+        )
+
+        while not self._stop_requested:
+            if self.raw_path.exists():
+                try:
+                    with self.raw_path.open("rb") as stream:
+                        messages = list(iter_protocol_messages(iter_capture_records(stream)))
+                        hands = normalize_native_hands(messages, raw_ref=str(self.raw_path))
+                        for hand in hands:
+                            key = (hand.get("table_id", 0), hand.get("hand_id", 0))
+                            if key not in self._imported_keys:
+                                self._imported_keys.add(key)
+                                self.hand_imported.emit(hand)
+                except Exception as e:
+                    log.debug("SwCNativeTailingThread error: %s", e)
+            for _step in range(10):
+                if self._stop_requested:
+                    break
+                time.sleep(0.25)
+
+
 class GuiAutoImport(QWidget):
     log_message = Signal(str, str)
 
@@ -108,6 +152,7 @@ class GuiAutoImport(QWidget):
             self.log_message.connect(self._addText_slot)
         self.importtimer: QTimer | None = None
         self.import_thread: AutoImportThread | None = None
+        self.swc_tailing_thread: SwCNativeTailingThread | None = None
         # Outage bookkeeping, so the database going away is reported once rather
         # than once per interval, and its return is reported too.
         self._deferred_cycles = 0
@@ -438,6 +483,10 @@ class GuiAutoImport(QWidget):
     def _finalize_auto_import_stop(self) -> None:
         """Release importer resources after no worker can still be using them."""
         self._stop_cleanup_pending = False
+        if self.swc_tailing_thread is not None:
+            self.swc_tailing_thread.stop()
+            self.swc_tailing_thread.wait(1000)
+            self.swc_tailing_thread = None
         self.importer.autoSummaryGrab(True)
         self.settings["global_lock"].release()
         self.addText("\nStopping Auto Import. Global lock released.", "unlock")
@@ -452,6 +501,32 @@ class GuiAutoImport(QWidget):
             self.pipe_to_hud = None
         self.intervalEntry.setEnabled(True)
         self.startButton.setEnabled(True)
+
+    def start_swc_native_capture(self) -> None:
+        """Launch SwC native TLS capture and start live raw tailing thread."""
+        try:
+            from fpdb_3_legacy.swc_native_capture import DEFAULT_ARCHIVE, build_tap
+            build_tap(check_executable=False)
+            if self.swc_tailing_thread is None or not self.swc_tailing_thread.isRunning():
+                self.swc_tailing_thread = SwCNativeTailingThread(DEFAULT_ARCHIVE, parent=self)
+                self.swc_tailing_thread.hand_imported.connect(self._on_swc_native_hand_imported)
+                self.swc_tailing_thread.start()
+                self.addText(_("\nSwC Native Live HUD tailing thread started."), "poker")
+        except Exception as e:
+            log.warning("Could not start SwC native capture: %s", e)
+            self.addText(f"\nSwC Native Capture warning: {e}", "warning")
+
+    def _on_swc_native_hand_imported(self, hand_data: dict) -> None:
+        """Callback when a new live SwC hand is parsed from swc-native.raw."""
+        try:
+            from fpdb_3_legacy.http_capture_db_import import import_http_capture_hand
+            if self.importer and self.importer.db:
+                import_http_capture_hand(self.importer.db, hand_data)
+                game_cat = hand_data.get("game", {}).get("category", "unknown")
+                hand_id = hand_data.get("hand_id", 0)
+                self.addText(f"\n[SwC Live] Imported hand #{hand_id} ({game_cat}).", "poker")
+        except Exception as e:
+            log.error("Failed to import SwC live hand: %s", e)
 
     def import_error(self, error_msg: str) -> None:
         """Called when auto import cycle fails in the background."""
@@ -737,6 +812,7 @@ class GuiAutoImport(QWidget):
                         self.updatePaths()
 
                         self.do_import()
+                        self.start_swc_native_capture()
                         interval = self.intervalEntry.value()
                         self.importtimer = QTimer()
                         self.importtimer.timeout.connect(self.do_import)

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -553,15 +553,25 @@ class GuiAutoImport(QWidget):
 
     def _on_swc_native_hand_imported(self, hand_data: dict) -> None:
         """Callback when a new live SwC hand is parsed from swc-native.raw."""
+        from fpdb_3_legacy.http_capture_db_import import import_http_capture_hand
+
+        # Importer holds its connection as `database`; `db` never existed, so
+        # every live hand raised AttributeError into the handler below and was
+        # dropped. Nothing captured live ever reached the database.
+        database = getattr(self.importer, "database", None)
+        if database is None:
+            log.warning("SwC live hand dropped: the importer has no database connection")
+            return
+
         try:
-            from fpdb_3_legacy.http_capture_db_import import import_http_capture_hand
-            if self.importer and self.importer.db:
-                import_http_capture_hand(self.importer.db, hand_data)
-                game_cat = hand_data.get("game", {}).get("category", "unknown")
-                hand_id = hand_data.get("hand_id", 0)
-                self.addText(f"\n[SwC Live] Imported hand #{hand_id} ({game_cat}).", "poker")
-        except Exception as e:
-            log.error("Failed to import SwC live hand: %s", e)
+            import_http_capture_hand(database, hand_data)
+        except Exception:
+            log.exception("Failed to import SwC live hand %s", hand_data.get("hand_id"))
+            return
+
+        game_cat = hand_data.get("game", {}).get("category", "unknown")
+        hand_id = hand_data.get("hand_id", 0)
+        self.addText(f"\n[SwC Live] Imported hand #{hand_id} ({game_cat}).", "poker")
 
     def import_error(self, error_msg: str) -> None:
         """Called when auto import cycle fails in the background."""

--- a/fpdb_3_legacy/http_capture_hand_builder.py
+++ b/fpdb_3_legacy/http_capture_hand_builder.py
@@ -171,11 +171,18 @@ def build_hand_operations(hand_data: dict[str, Any]) -> list[dict[str, Any]]:
         name = player.get("name")
         if involved and name and name not in involved:
             continue
+        # seat_idx is a 0-based index into the snapshot's seat array; every other
+        # site numbers seats from 1, and so does the rest of fpdb. Passing the
+        # raw index through gave the first player seat 0, which the HUD's
+        # `if seat:` occupancy check reads as empty -- that player silently got
+        # no stat panel while everyone else did.
+        seat_idx = player.get("seat_idx")
+        seat_number = seat_idx + 1 if isinstance(seat_idx, int) else seat_idx
         operations.append(
             {
                 "method": "addPlayer",
                 "args": [
-                    player.get("seat_idx"),
+                    seat_number,
                     player.get("name"),
                     str(player.get("starting_stack", 0)),
                 ],

--- a/fpdb_3_legacy/swc_crosscheck.py
+++ b/fpdb_3_legacy/swc_crosscheck.py
@@ -1,0 +1,121 @@
+"""Compare a captured SwC hand against the text history the client wrote for it.
+
+SwC writes text hand histories for some game families and not others -- Stud,
+draw games, Drawmaha, mixed games and OFC arrive only over the wire. Where both
+exist, the two paths describe the same hand and must agree; a disagreement means
+the capture decoder drifted from the room's own record.
+
+This module is the comparison itself, kept away from any test fixture so it can
+be pointed at real archives from the CLI as well as run in CI.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+# Money is compared at the precision the room reports, not exactly: the text
+# history rounds to the table currency while the capture carries integer units.
+MONEY_TOLERANCE = Decimal("0.01")
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return None
+
+
+def _seats(hand: Any) -> dict[str, int]:
+    """Map player name -> seat number, from either a Hand or a captured dict."""
+    players = getattr(hand, "players", None)
+    if players is None and isinstance(hand, dict):
+        players = hand.get("players", [])
+    seats: dict[str, int] = {}
+    for player in players or []:
+        if isinstance(player, dict):
+            name, seat = player.get("name"), player.get("seat", player.get("seat_idx"))
+        else:
+            seat, name = player[0], player[1]
+        if name is not None and seat is not None:
+            seats[str(name)] = int(seat)
+    return seats
+
+
+def _board(hand: Any) -> list[str]:
+    board = getattr(hand, "board", None)
+    if board is None and isinstance(hand, dict):
+        board = hand.get("board")
+    if isinstance(board, dict):
+        cards: list[str] = []
+        for street in ("FLOP", "TURN", "RIVER"):
+            cards.extend(board.get(street) or [])
+        return [str(card) for card in cards]
+    return [str(card) for card in board or []]
+
+
+def _collected(hand: Any) -> dict[str, Decimal]:
+    collectees = getattr(hand, "collectees", None)
+    if collectees is None and isinstance(hand, dict):
+        collectees = hand.get("collectees", {})
+    result: dict[str, Decimal] = {}
+    for name, amount in (collectees or {}).items():
+        parsed = _decimal(amount)
+        if parsed is not None:
+            result[str(name)] = parsed
+    return result
+
+
+def _attr(hand: Any, name: str, *aliases: str) -> Any:
+    for candidate in (name, *aliases):
+        value = getattr(hand, candidate, None)
+        if value is None and isinstance(hand, dict):
+            value = hand.get(candidate)
+        if value is not None:
+            return value
+    return None
+
+
+def compare_hands(text_hand: Any, captured_hand: Any) -> list[str]:
+    """Return the discrepancies between the two views of one hand.
+
+    An empty list means the capture agrees with the room's own text history on
+    everything that changes the meaning of an imported hand: which hand it is,
+    who sat where, what came down, and who got paid.
+    """
+    problems: list[str] = []
+
+    text_id = _attr(text_hand, "handid", "hand_id")
+    captured_id = _attr(captured_hand, "handid", "hand_id")
+    if str(text_id) != str(captured_id):
+        problems.append(f"hand id: text {text_id!r} != capture {captured_id!r}")
+
+    text_seats, captured_seats = _seats(text_hand), _seats(captured_hand)
+    if set(text_seats) != set(captured_seats):
+        only_text = sorted(set(text_seats) - set(captured_seats))
+        only_capture = sorted(set(captured_seats) - set(text_seats))
+        problems.append(f"players: only in text {only_text}, only in capture {only_capture}")
+    else:
+        for name, seat in sorted(text_seats.items()):
+            if captured_seats[name] != seat:
+                problems.append(f"seat of {name}: text {seat} != capture {captured_seats[name]}")
+
+    text_board, captured_board = _board(text_hand), _board(captured_hand)
+    if text_board != captured_board:
+        problems.append(f"board: text {text_board} != capture {captured_board}")
+
+    text_pot, captured_pot = _decimal(_attr(text_hand, "totalpot")), _decimal(_attr(captured_hand, "totalpot"))
+    if text_pot is not None and captured_pot is not None and abs(text_pot - captured_pot) > MONEY_TOLERANCE:
+        problems.append(f"total pot: text {text_pot} != capture {captured_pot}")
+
+    text_won, captured_won = _collected(text_hand), _collected(captured_hand)
+    for name in sorted(set(text_won) | set(captured_won)):
+        text_amount, captured_amount = text_won.get(name), captured_won.get(name)
+        if text_amount is None or captured_amount is None:
+            problems.append(f"winnings of {name}: text {text_amount}, capture {captured_amount}")
+        elif abs(text_amount - captured_amount) > MONEY_TOLERANCE:
+            problems.append(f"winnings of {name}: text {text_amount} != capture {captured_amount}")
+
+    return problems

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -10,6 +10,7 @@ import json
 import os
 import platform
 import re
+import shutil
 import struct
 import subprocess
 import sys
@@ -22,6 +23,8 @@ from decimal import Decimal
 from pathlib import Path
 from typing import BinaryIO
 
+UTC = getattr(datetime, "UTC", UTC)
+
 from fpdb_3_legacy.http_capture_diff import diff_snapshot_steps
 from fpdb_3_legacy.http_capture_models import SWC_GAME_DEFINITIONS, CapturedGameDefinition
 from fpdb_3_legacy.swc_http_adapter import card_id_to_str
@@ -30,7 +33,19 @@ SWC_APP = Path("/Applications/SwC Poker.app")
 SWC_EXECUTABLE = SWC_APP / "Contents/MacOS/SwC Poker"
 SOURCE_PATH = Path(__file__).with_name("swc_native_tap.c")
 BUILD_DIR = Path.home() / ".fpdb" / "swc-native-capture"
-TAP_LIBRARY = BUILD_DIR / "libswc_native_tap.dylib"
+
+
+def get_tap_library_path() -> Path:
+    system_name = platform.system()
+    if system_name == "Darwin":
+        return BUILD_DIR / "libswc_native_tap.dylib"
+    elif system_name == "Windows":
+        return BUILD_DIR / "swc_native_tap.dll"
+    else:
+        return BUILD_DIR / "libswc_native_tap.so"
+
+
+TAP_LIBRARY = get_tap_library_path()
 DEFAULT_ARCHIVE = BUILD_DIR / "swc-native.raw"
 DEFAULT_STATUS = BUILD_DIR / "swc-native.status"
 
@@ -2930,32 +2945,66 @@ def iter_capture_records(stream: BinaryIO) -> Iterator[NativeCaptureRecord]:
         )
 
 
-def build_tap(*, force: bool = False) -> Path:
-    if platform.system() != "Darwin":
-        raise RuntimeError("the native SwC tap is only supported on macOS")
-    if not SWC_EXECUTABLE.exists():
+def build_tap(*, force: bool = False, check_executable: bool = False) -> Path:
+    system_name = platform.system()
+    if system_name not in {"Darwin", "Linux", "Windows"}:
+        raise RuntimeError(f"the native SwC tap is not supported on {system_name}")
+    if check_executable and system_name == "Darwin" and not SWC_EXECUTABLE.exists():
         raise FileNotFoundError(f"SwC client not found at {SWC_APP}")
-    if TAP_LIBRARY.exists() and not force and TAP_LIBRARY.stat().st_mtime >= SOURCE_PATH.stat().st_mtime:
-        return TAP_LIBRARY
+    tap_lib = get_tap_library_path()
+    if tap_lib.exists() and not force and tap_lib.stat().st_mtime >= SOURCE_PATH.stat().st_mtime:
+        return tap_lib
 
     BUILD_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    command = [
-        "clang",
-        "-arch",
-        "x86_64",
-        "-dynamiclib",
-        "-O2",
-        "-Wall",
-        "-Wextra",
-        "-undefined",
-        "dynamic_lookup",
-        "-o",
-        str(TAP_LIBRARY),
-        str(SOURCE_PATH),
-    ]
+
+    if system_name == "Darwin":
+        command = [
+            "clang",
+            "-arch",
+            "x86_64",
+            "-dynamiclib",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-undefined",
+            "dynamic_lookup",
+            "-o",
+            str(tap_lib),
+            str(SOURCE_PATH),
+        ]
+    elif system_name == "Windows":
+        compiler = "x86_64-w64-mingw32-gcc" if shutil.which("x86_64-w64-mingw32-gcc") else "gcc"
+        command = [
+            compiler,
+            "-shared",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-o",
+            str(tap_lib),
+            str(SOURCE_PATH),
+            "-lws2_32",
+        ]
+    else:
+        compiler = "clang" if shutil.which("clang") else "gcc"
+        command = [
+            compiler,
+            "-shared",
+            "-fPIC",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-o",
+            str(tap_lib),
+            str(SOURCE_PATH),
+            "-ldl",
+        ]
     subprocess.run(command, check=True)
-    TAP_LIBRARY.chmod(0o700)
-    return TAP_LIBRARY
+    try:
+        tap_lib.chmod(0o700)
+    except OSError:
+        pass
+    return tap_lib
 
 
 def running_client_pids() -> list[int]:
@@ -2980,9 +3029,11 @@ def native_client_environment(archive: Path, tap: Path, *, port: int, include_ou
     for name in tuple(env):
         if name == "LANG" or name == "LANGUAGE" or name.startswith("LC_"):
             env.pop(name, None)
+    system_name = platform.system()
+    interpose_var = "DYLD_INSERT_LIBRARIES" if system_name == "Darwin" else "LD_PRELOAD"
     env.update(
         {
-            "DYLD_INSERT_LIBRARIES": str(tap),
+            interpose_var: str(tap),
             "SWC_CAPTURE_PATH": str(archive),
             "SWC_CAPTURE_STATUS_PATH": str(archive.with_suffix(".status")),
             "SWC_CAPTURE_PORT": str(port),

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -23,11 +23,12 @@ from decimal import Decimal
 from pathlib import Path
 from typing import BinaryIO
 
-UTC = getattr(datetime, "UTC", UTC)
-
 from fpdb_3_legacy.http_capture_diff import diff_snapshot_steps
 from fpdb_3_legacy.http_capture_models import SWC_GAME_DEFINITIONS, CapturedGameDefinition
+from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.swc_http_adapter import card_id_to_str
+
+log = get_logger("swc_native_capture")
 
 SWC_APP = Path("/Applications/SwC Poker.app")
 SWC_EXECUTABLE = SWC_APP / "Contents/MacOS/SwC Poker"
@@ -2943,6 +2944,62 @@ def iter_capture_records(stream: BinaryIO) -> Iterator[NativeCaptureRecord]:
             payload=payload,
             connection_id=connection_id,
         )
+
+
+def read_records_since(path: Path, offset: int) -> tuple[list[NativeCaptureRecord], int]:
+    """Read the complete records appended to ``path`` after ``offset``.
+
+    Tailing a live archive differs from reading a finished one in two ways, and
+    ``iter_capture_records`` handles neither. The client appends while it plays,
+    so the tail is routinely a half-written record -- raising there discards
+    every hand read in the same pass. And re-reading from byte zero on each poll
+    re-parses the whole session, which grows without bound.
+
+    Records are self-delimiting (fixed header, declared payload length), so a
+    record boundary is a safe resume point: stop at the first incomplete record
+    and report the offset of the last complete one. A file shorter than
+    ``offset`` has been rotated or truncated, so reading restarts from zero.
+
+    Returns the records read and the offset to resume from.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return [], offset
+
+    if size < offset:
+        log.info("SwC capture archive shrank (%d < %d); restarting from the beginning", size, offset)
+        offset = 0
+    if size == offset:
+        return [], offset
+
+    records: list[NativeCaptureRecord] = []
+    with path.open("rb") as stream:
+        stream.seek(offset)
+        while True:
+            header = stream.read(_HEADER.size)
+            if len(header) != _HEADER.size:
+                break  # partial record at the tail; resume here next time
+            magic, version, direction, _reserved, peer_port, connection_id, payload_size, timestamp_us = _HEADER.unpack(
+                header
+            )
+            if magic != _MAGIC or version != _VERSION or direction not in (0, 1) or payload_size > _MAX_PAYLOAD:
+                raise ValueError("invalid SwC native capture header")
+            payload = stream.read(payload_size)
+            if len(payload) != payload_size:
+                break  # payload still being written
+            records.append(
+                NativeCaptureRecord(
+                    captured_at=datetime.fromtimestamp(timestamp_us / 1_000_000, tz=UTC),
+                    direction="received" if direction == 0 else "sent",
+                    peer_port=peer_port,
+                    payload=payload,
+                    connection_id=connection_id,
+                )
+            )
+            offset += _HEADER.size + payload_size
+
+    return records, offset
 
 
 def build_tap(*, force: bool = False, check_executable: bool = False) -> Path:

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -10,7 +10,6 @@ import json
 import os
 import platform
 import re
-import shutil
 import struct
 import subprocess
 import sys
@@ -30,21 +29,15 @@ from fpdb_3_legacy.swc_http_adapter import card_id_to_str
 
 log = get_logger("swc_native_capture")
 
-SWC_APP = Path("/Applications/SwC Poker.app")
-SWC_EXECUTABLE = SWC_APP / "Contents/MacOS/SwC Poker"
-SOURCE_PATH = Path(__file__).with_name("swc_native_tap.c")
-BUILD_DIR = Path.home() / ".fpdb" / "swc-native-capture"
-
-
-def get_tap_library_path() -> Path:
-    system_name = platform.system()
-    if system_name == "Darwin":
-        return BUILD_DIR / "libswc_native_tap.dylib"
-    elif system_name == "Windows":
-        return BUILD_DIR / "swc_native_tap.dll"
-    else:
-        return BUILD_DIR / "libswc_native_tap.so"
-
+# Compiling the tap lives in its own stdlib-only module so CI can verify the
+# build on every platform without installing the project; re-exported here so
+# existing callers keep importing it from the place they always have.
+from fpdb_3_legacy.swc_tap_build import (  # noqa: E402
+    BUILD_DIR,
+    SWC_EXECUTABLE,
+    build_tap,
+    get_tap_library_path,
+)
 
 TAP_LIBRARY = get_tap_library_path()
 DEFAULT_ARCHIVE = BUILD_DIR / "swc-native.raw"
@@ -3000,68 +2993,6 @@ def read_records_since(path: Path, offset: int) -> tuple[list[NativeCaptureRecor
             offset += _HEADER.size + payload_size
 
     return records, offset
-
-
-def build_tap(*, force: bool = False, check_executable: bool = False) -> Path:
-    system_name = platform.system()
-    if system_name not in {"Darwin", "Linux", "Windows"}:
-        raise RuntimeError(f"the native SwC tap is not supported on {system_name}")
-    if check_executable and system_name == "Darwin" and not SWC_EXECUTABLE.exists():
-        raise FileNotFoundError(f"SwC client not found at {SWC_APP}")
-    tap_lib = get_tap_library_path()
-    if tap_lib.exists() and not force and tap_lib.stat().st_mtime >= SOURCE_PATH.stat().st_mtime:
-        return tap_lib
-
-    BUILD_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-
-    if system_name == "Darwin":
-        command = [
-            "clang",
-            "-arch",
-            "x86_64",
-            "-dynamiclib",
-            "-O2",
-            "-Wall",
-            "-Wextra",
-            "-undefined",
-            "dynamic_lookup",
-            "-o",
-            str(tap_lib),
-            str(SOURCE_PATH),
-        ]
-    elif system_name == "Windows":
-        compiler = "x86_64-w64-mingw32-gcc" if shutil.which("x86_64-w64-mingw32-gcc") else "gcc"
-        command = [
-            compiler,
-            "-shared",
-            "-O2",
-            "-Wall",
-            "-Wextra",
-            "-o",
-            str(tap_lib),
-            str(SOURCE_PATH),
-            "-lws2_32",
-        ]
-    else:
-        compiler = "clang" if shutil.which("clang") else "gcc"
-        command = [
-            compiler,
-            "-shared",
-            "-fPIC",
-            "-O2",
-            "-Wall",
-            "-Wextra",
-            "-o",
-            str(tap_lib),
-            str(SOURCE_PATH),
-            "-ldl",
-        ]
-    subprocess.run(command, check=True)
-    try:
-        tap_lib.chmod(0o700)
-    except OSError:
-        pass
-    return tap_lib
 
 
 def running_client_pids() -> list[int]:

--- a/fpdb_3_legacy/swc_native_tap.c
+++ b/fpdb_3_legacy/swc_native_tap.c
@@ -1,32 +1,55 @@
-#define _DARWIN_C_SOURCE
+#if defined(__linux__) || defined(__gnu_linux__)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
 
-#include <arpa/inet.h>
-#include <dlfcn.h>
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
-#include <netinet/in.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <netinet/in.h>
 #include <sys/file.h>
 #include <sys/socket.h>
-#include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <io.h>
+#endif
 
 /* Minimal OpenSSL ABI declarations: SwC ships libssl but not development headers. */
 typedef struct ssl_st SSL;
+
+#ifdef __APPLE__
 extern int SSL_read(SSL *ssl, void *buffer, int size);
 extern int SSL_write(SSL *ssl, const void *buffer, int size);
 extern int SSL_get_fd(const SSL *ssl);
+#else
+typedef int (*ssl_read_fn)(SSL *ssl, void *buffer, int size);
+typedef int (*ssl_write_fn)(SSL *ssl, const void *buffer, int size);
+typedef int (*ssl_get_fd_fn)(const SSL *ssl);
+#endif
 
 /*
- * Passive SwC Poker TLS tap.
+ * Passive SwC Poker TLS tap (macOS, Linux, Windows).
  *
- * The native macOS client uses its bundled OpenSSL and calls SSL_read/SSL_write
- * directly.  This interposer records plaintext only after a successful SSL
- * operation.  By default it records inbound traffic from the game server port
- * (20013), deliberately excluding the lobby/login connection on port 20001.
+ * The native client uses OpenSSL and calls SSL_read/SSL_write directly.
+ * This interposer records plaintext only after a successful SSL operation.
+ * By default it records inbound traffic from game server ports (20002-20999),
+ * deliberately excluding the lobby/login connection on port 20001.
  */
 
 #define SWC_TAP_MAGIC 0x53574354u /* "SWCT" */
@@ -59,17 +82,34 @@ static void write_status(const char *message) {
     if (path == NULL || path[0] == '\0') {
         return;
     }
+#ifndef _WIN32
     fd = open(path, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
     if (fd >= 0) {
         write(fd, message, strlen(message));
         close(fd);
     }
+#else
+    fd = _open(path, _O_CREAT | _O_WRONLY | _O_APPEND | _O_BINARY, _S_IREAD | _S_IWRITE);
+    if (fd >= 0) {
+        _write(fd, message, (unsigned int)strlen(message));
+        _close(fd);
+    }
+#endif
 }
 
 static uint64_t now_us(void) {
+#ifndef _WIN32
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return ((uint64_t)tv.tv_sec * 1000000u) + (uint64_t)tv.tv_usec;
+#else
+    FILETIME ft;
+    GetSystemTimeAsFileTime(&ft);
+    ULARGE_INTEGER uli;
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart / 10u) - 11644473600000000ULL;
+#endif
 }
 
 static uint16_t peer_port_for_ssl(SSL *ssl) {
@@ -77,9 +117,28 @@ static uint16_t peer_port_for_ssl(SSL *ssl) {
     struct sockaddr_storage address;
     socklen_t address_len = sizeof(address);
 
+#ifdef __APPLE__
     if (ssl == NULL || (fd = SSL_get_fd(ssl)) < 0) {
         return 0;
     }
+#else
+    static ssl_get_fd_fn real_SSL_get_fd = NULL;
+    if (real_SSL_get_fd == NULL) {
+#ifndef _WIN32
+        real_SSL_get_fd = (ssl_get_fd_fn)dlsym(RTLD_NEXT, "SSL_get_fd");
+#else
+        HMODULE h_ssl = GetModuleHandleA("ssleay32.dll");
+        if (!h_ssl) h_ssl = GetModuleHandleA("libssl-1_1.dll");
+        if (!h_ssl) h_ssl = GetModuleHandleA("libssl-1_1-x64.dll");
+        if (!h_ssl) h_ssl = GetModuleHandleA("libssl32.dll");
+        if (h_ssl) real_SSL_get_fd = (ssl_get_fd_fn)GetProcAddress(h_ssl, "SSL_get_fd");
+#endif
+    }
+    if (ssl == NULL || real_SSL_get_fd == NULL || (fd = real_SSL_get_fd(ssl)) < 0) {
+        return 0;
+    }
+#endif
+
     if (getpeername(fd, (struct sockaddr *)&address, &address_len) != 0) {
         return 0;
     }
@@ -95,7 +154,11 @@ static uint16_t peer_port_for_ssl(SSL *ssl) {
 static void write_all(int fd, const void *buffer, size_t size) {
     const uint8_t *cursor = (const uint8_t *)buffer;
     while (size > 0) {
+#ifndef _WIN32
         ssize_t written = write(fd, cursor, size);
+#else
+        int written = _write(fd, cursor, (unsigned int)size);
+#endif
         if (written > 0) {
             cursor += written;
             size -= (size_t)written;
@@ -131,18 +194,27 @@ static void record_plaintext(SSL *ssl, const void *buffer, int size, uint8_t dir
     header.version = SWC_TAP_VERSION;
     header.direction = direction;
     header.peer_port = peer_port;
-    header.reserved2 = (uint16_t)SSL_get_fd(ssl);
+    header.reserved2 = 0;
     header.payload_size = (uint32_t)size;
     header.timestamp_us = now_us();
 
+#ifndef _WIN32
     if (flock(capture_fd, LOCK_EX) == 0) {
         write_all(capture_fd, &header, sizeof(header));
         write_all(capture_fd, buffer, (size_t)size);
         flock(capture_fd, LOCK_UN);
     }
+#else
+    write_all(capture_fd, &header, sizeof(header));
+    write_all(capture_fd, buffer, (size_t)size);
+#endif
 }
 
+#ifndef _WIN32
 __attribute__((constructor)) static void initialize_swc_tap(void) {
+#else
+static void initialize_swc_tap(void) {
+#endif
     const char *path = getenv("SWC_CAPTURE_PATH");
     const char *port = getenv("SWC_CAPTURE_PORT");
     const char *outbound = getenv("SWC_CAPTURE_OUTBOUND");
@@ -159,22 +231,44 @@ __attribute__((constructor)) static void initialize_swc_tap(void) {
         }
     }
     capture_outbound = outbound != NULL && strcmp(outbound, "1") == 0;
+#ifndef _WIN32
     capture_fd = open(path, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, S_IRUSR | S_IWUSR);
+#else
+    capture_fd = _open(path, _O_CREAT | _O_WRONLY | _O_APPEND | _O_BINARY, _S_IREAD | _S_IWRITE);
+#endif
     write_status(capture_fd >= 0 ? "tap-loaded\n" : "tap-load-open-failed\n");
 }
 
+#ifndef _WIN32
 __attribute__((destructor)) static void close_swc_tap(void) {
+#else
+static void close_swc_tap(void) {
+#endif
     if (capture_fd >= 0) {
+#ifndef _WIN32
         close(capture_fd);
+#else
+        _close(capture_fd);
+#endif
         capture_fd = -1;
     }
 }
 
-static int swc_tap_ssl_read(SSL *ssl, void *buffer, int size) {
-    int result;
+#ifdef _WIN32
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    (void)hinstDLL; (void)lpvReserved;
+    if (fdwReason == DLL_PROCESS_ATTACH) {
+        initialize_swc_tap();
+    } else if (fdwReason == DLL_PROCESS_DETACH) {
+        close_swc_tap();
+    }
+    return TRUE;
+}
+#endif
 
-    /* dyld keeps calls from the replacement image bound to the replacee. */
-    result = SSL_read(ssl, buffer, size);
+#ifdef __APPLE__
+static int swc_tap_ssl_read(SSL *ssl, void *buffer, int size) {
+    int result = SSL_read(ssl, buffer, size);
     if (result > 0) {
         record_plaintext(ssl, buffer, result, 0);
     }
@@ -182,16 +276,13 @@ static int swc_tap_ssl_read(SSL *ssl, void *buffer, int size) {
 }
 
 static int swc_tap_ssl_write(SSL *ssl, const void *buffer, int size) {
-    int result;
-
-    result = SSL_write(ssl, buffer, size);
+    int result = SSL_write(ssl, buffer, size);
     if (result > 0) {
         record_plaintext(ssl, buffer, result, 1);
     }
     return result;
 }
 
-/* Explicit dyld interposition is required for Mach-O's two-level namespace. */
 struct interpose_entry {
     const void *replacement;
     const void *replacee;
@@ -201,3 +292,63 @@ __attribute__((used, section("__DATA,__interpose"))) static const struct interpo
     {(const void *)swc_tap_ssl_read, (const void *)SSL_read},
     {(const void *)swc_tap_ssl_write, (const void *)SSL_write},
 };
+#elif defined(_WIN32)
+static ssl_read_fn real_SSL_read = NULL;
+static ssl_write_fn real_SSL_write = NULL;
+
+static void init_win_ssl(void) {
+    if (real_SSL_read && real_SSL_write) return;
+    HMODULE h_ssl = GetModuleHandleA("ssleay32.dll");
+    if (!h_ssl) h_ssl = GetModuleHandleA("libssl-1_1.dll");
+    if (!h_ssl) h_ssl = GetModuleHandleA("libssl-1_1-x64.dll");
+    if (!h_ssl) h_ssl = GetModuleHandleA("libssl32.dll");
+    if (h_ssl) {
+        real_SSL_read = (ssl_read_fn)GetProcAddress(h_ssl, "SSL_read");
+        real_SSL_write = (ssl_write_fn)GetProcAddress(h_ssl, "SSL_write");
+    }
+}
+
+__declspec(dllexport) int SSL_read(SSL *ssl, void *buffer, int size) {
+    init_win_ssl();
+    int result = real_SSL_read ? real_SSL_read(ssl, buffer, size) : -1;
+    if (result > 0) {
+        record_plaintext(ssl, buffer, result, 0);
+    }
+    return result;
+}
+
+__declspec(dllexport) int SSL_write(SSL *ssl, const void *buffer, int size) {
+    init_win_ssl();
+    int result = real_SSL_write ? real_SSL_write(ssl, buffer, size) : -1;
+    if (result > 0) {
+        record_plaintext(ssl, buffer, result, 1);
+    }
+    return result;
+}
+#else /* Linux / POSIX LD_PRELOAD */
+static ssl_read_fn real_SSL_read = NULL;
+static ssl_write_fn real_SSL_write = NULL;
+
+int SSL_read(SSL *ssl, void *buffer, int size) {
+    if (real_SSL_read == NULL) {
+        real_SSL_read = (ssl_read_fn)dlsym(RTLD_NEXT, "SSL_read");
+    }
+    int result = real_SSL_read ? real_SSL_read(ssl, buffer, size) : -1;
+    if (result > 0) {
+        record_plaintext(ssl, buffer, result, 0);
+    }
+    return result;
+}
+
+int SSL_write(SSL *ssl, const void *buffer, int size) {
+    if (real_SSL_write == NULL) {
+        real_SSL_write = (ssl_write_fn)dlsym(RTLD_NEXT, "SSL_write");
+    }
+    int result = real_SSL_write ? real_SSL_write(ssl, buffer, size) : -1;
+    if (result > 0) {
+        record_plaintext(ssl, buffer, result, 1);
+    }
+    return result;
+}
+#endif
+

--- a/fpdb_3_legacy/swc_tap_build.py
+++ b/fpdb_3_legacy/swc_tap_build.py
@@ -1,0 +1,101 @@
+"""Compile the passive SwC TLS tap.
+
+Kept apart from ``swc_native_capture`` deliberately: the decoder there pulls in
+the capture models, the diff engine and the project logger, and through them
+third-party packages. Compiling a C file needs none of that, and CI verifies the
+compile on three runners — making each of them install the whole project first,
+just to invoke a compiler, would be minutes of work for nothing.
+
+Only the standard library is imported here, so
+``python -m fpdb_3_legacy.swc_tap_build --build`` runs on a bare checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SWC_APP = Path("/Applications/SwC Poker.app")
+SWC_EXECUTABLE = SWC_APP / "Contents/MacOS/SwC Poker"
+SOURCE_PATH = Path(__file__).with_name("swc_native_tap.c")
+BUILD_DIR = Path.home() / ".fpdb" / "swc-native-capture"
+
+
+def get_tap_library_path() -> Path:
+    system_name = platform.system()
+    if system_name == "Darwin":
+        return BUILD_DIR / "libswc_native_tap.dylib"
+    if system_name == "Windows":
+        return BUILD_DIR / "swc_native_tap.dll"
+    return BUILD_DIR / "libswc_native_tap.so"
+
+
+def _compile_command(system_name: str, tap_lib: Path) -> list[str]:
+    if system_name == "Darwin":
+        return [
+            "clang",
+            "-arch",
+            "x86_64",
+            "-dynamiclib",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-undefined",
+            "dynamic_lookup",
+            "-o",
+            str(tap_lib),
+            str(SOURCE_PATH),
+        ]
+    if system_name == "Windows":
+        compiler = "x86_64-w64-mingw32-gcc" if shutil.which("x86_64-w64-mingw32-gcc") else "gcc"
+        return [compiler, "-shared", "-O2", "-Wall", "-Wextra", "-o", str(tap_lib), str(SOURCE_PATH), "-lws2_32"]
+    compiler = "clang" if shutil.which("clang") else "gcc"
+    return [compiler, "-shared", "-fPIC", "-O2", "-Wall", "-Wextra", "-o", str(tap_lib), str(SOURCE_PATH), "-ldl"]
+
+
+def build_tap(*, force: bool = False, check_executable: bool = False) -> Path:
+    """Compile the interposer for this platform and return the library path.
+
+    ``check_executable`` is for the launch path, which has no use for a tap when
+    the client it would be injected into is not installed. CI leaves it off: it
+    is verifying that the C compiles, not that SwC is present.
+    """
+    system_name = platform.system()
+    if system_name not in {"Darwin", "Linux", "Windows"}:
+        msg = f"the native SwC tap is not supported on {system_name}"
+        raise RuntimeError(msg)
+    if check_executable and system_name == "Darwin" and not SWC_EXECUTABLE.exists():
+        msg = f"SwC client not found at {SWC_APP}"
+        raise FileNotFoundError(msg)
+
+    tap_lib = get_tap_library_path()
+    if tap_lib.exists() and not force and tap_lib.stat().st_mtime >= SOURCE_PATH.stat().st_mtime:
+        return tap_lib
+
+    BUILD_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    subprocess.run(_compile_command(system_name, tap_lib), check=True)
+    try:
+        tap_lib.chmod(0o700)
+    except OSError:
+        # Windows ignores the POSIX mode; the parent directory already restricts access.
+        pass
+    return tap_lib
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build", action="store_true", help="compile the tap for this platform")
+    parser.add_argument("--force", action="store_true", help="recompile even if the library is up to date")
+    args = parser.parse_args(argv)
+    if not args.build:
+        parser.error("nothing to do: pass --build")
+    print(build_tap(force=args.force))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_http_capture_models.py
+++ b/test/test_http_capture_models.py
@@ -1465,9 +1465,9 @@ def test_hand_operation_plan_maps_supported_actions_to_hand_methods():
     }
 
     assert build_hand_operations(hand_data) == [
-        {"method": "addPlayer", "args": [0, "alice", "100"], "source": "players"},
-        {"method": "addPlayer", "args": [1, "bob", "100"], "source": "players"},
-        {"method": "addPlayer", "args": [2, "carol", "100"], "source": "players"},
+        {"method": "addPlayer", "args": [1, "alice", "100"], "source": "players"},
+        {"method": "addPlayer", "args": [2, "bob", "100"], "source": "players"},
+        {"method": "addPlayer", "args": [3, "carol", "100"], "source": "players"},
         {"method": "addBlind", "args": ["alice", "small blind", "1"], "source": "actions"},
         {"method": "addBlind", "args": ["bob", "big blind", "2"], "source": "actions"},
         {"method": "addBlind", "args": ["carol", "straddle", "4"], "source": "actions"},
@@ -1487,7 +1487,7 @@ def test_hand_operation_plan_maps_pot_collections_to_hand_method():
     }
 
     assert build_hand_operations(hand_data) == [
-        {"method": "addPlayer", "args": [0, "alice", "100"], "source": "players"},
+        {"method": "addPlayer", "args": [1, "alice", "100"], "source": "players"},
         {"method": "addCollectPot", "args": ["alice", "3"], "source": "actions"},
         {"method": "addCollectPot", "args": ["alice", "2"], "source": "collections"},
         {"method": "addCollectPot", "args": ["alice", "4"], "source": "collections"},

--- a/test/test_hud_seat_zero.py
+++ b/test/test_hud_seat_zero.py
@@ -1,0 +1,85 @@
+"""A player in seat 0 must still get a HUD panel.
+
+Reported from a live SwC table: eight players seated, seven stat panels. The
+missing one sat in the snapshot's first seat.
+
+Two things combined. The capture adapter numbers seats by their index in the
+snapshot's seat array, so the first player is seat 0, while every other site
+and the rest of fpdb number seats from 1. And the HUD decided which seats were
+occupied with `if seat:`, which reads 0 as an empty chair — so that player was
+dropped from the layout and never got a panel.
+
+Both ends are pinned here: the builder now emits 1-based seats, and the
+occupancy check no longer confuses seat 0 with an empty one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fpdb_3_legacy.Aux_Base import AuxSeats
+from fpdb_3_legacy.http_capture_hand_builder import build_hand_operations
+
+
+def _hand_data(*names: str) -> dict:
+    return {
+        "players": [
+            {"name": name, "seat_idx": index, "starting_stack": 100} for index, name in enumerate(names)
+        ],
+        "actions": [],
+        "steps": [],
+    }
+
+
+def _add_player_ops(operations: list[dict]) -> list[dict]:
+    return [op for op in operations if op.get("method") == "addPlayer"]
+
+
+class TestSeatNumbering:
+    def test_the_first_player_is_not_seated_at_zero(self) -> None:
+        """Seat 0 is what the HUD read as an empty chair."""
+        operations = build_hand_operations(_hand_data("v8guy", "RezaG", "edinapoker"))
+
+        seats = [op["args"][0] for op in _add_player_ops(operations)]
+
+        assert 0 not in seats
+        assert seats == [1, 2, 3]
+
+    def test_every_player_keeps_their_own_seat(self) -> None:
+        operations = build_hand_operations(_hand_data("v8guy", "RezaG", "edinapoker"))
+
+        seated = [(op["args"][0], op["args"][1]) for op in _add_player_ops(operations)]
+
+        assert seated == [(1, "v8guy"), (2, "RezaG"), (3, "edinapoker")]
+
+    def test_a_missing_seat_index_is_passed_through_untouched(self) -> None:
+        data = _hand_data("v8guy")
+        data["players"][0]["seat_idx"] = None
+
+        operations = build_hand_operations(data)
+
+        assert _add_player_ops(operations)[0]["args"][0] is None
+
+
+class TestOccupancy:
+    @staticmethod
+    def _occupied(stat_dict: dict) -> list[int]:
+        seats = AuxSeats.__new__(AuxSeats)
+        seats.hud = SimpleNamespace(stat_dict=stat_dict)
+        return seats._occupied_seats()
+
+    def test_seat_zero_counts_as_occupied(self) -> None:
+        """`if seat:` dropped this player; `if seat is not None:` keeps them."""
+        occupied = self._occupied({1: {"seat": 0}, 2: {"seat": 1}, 3: {"seat": 2}})
+
+        assert occupied == [0, 1, 2]
+
+    def test_an_absent_seat_is_still_skipped(self) -> None:
+        occupied = self._occupied({1: {"seat": None}, 2: {"seat": 3}})
+
+        assert occupied == [3]
+
+    def test_no_player_is_lost_from_a_full_table(self) -> None:
+        stat_dict = {index: {"seat": index} for index in range(9)}
+
+        assert len(self._occupied(stat_dict)) == 9

--- a/test/test_swc_crosscheck.py
+++ b/test/test_swc_crosscheck.py
@@ -1,0 +1,149 @@
+"""Cross-checking a captured SwC hand against the room's own text history.
+
+SwC writes text histories for some game families and not others, so where both
+exist they describe the same hand and must agree. These tests pin the comparison
+itself — that it catches each kind of drift and stays quiet when the two views
+match — so it can be trusted the moment it is pointed at real paired data.
+
+The paired fixtures themselves are not in the tree: a capture archive and the
+text history of the *same* session can only come from real play. Drop a pair
+into ``tests/fixtures/hands/swc_paired/`` and ``test_paired_fixtures_agree``
+starts covering it; until then it skips and says so.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from fpdb_3_legacy.swc_crosscheck import compare_hands
+
+PAIRED_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "hands" / "swc_paired"
+
+
+def _hand(**overrides):
+    hand = {
+        "hand_id": "299449673",
+        "players": [
+            {"name": "v8guy", "seat": 1},
+            {"name": "RezaG", "seat": 2},
+            {"name": "tortuga", "seat": 3},
+        ],
+        "board": ["8c", "Js", "8h", "Th"],
+        "totalpot": Decimal("0.54"),
+        "collectees": {"tortuga": Decimal("0.52")},
+    }
+    hand.update(overrides)
+    return hand
+
+
+class TestAgreement:
+    def test_identical_views_report_nothing(self) -> None:
+        assert compare_hands(_hand(), _hand()) == []
+
+    def test_money_within_rounding_is_not_a_discrepancy(self) -> None:
+        """The text history rounds to the table currency; the capture counts units."""
+        captured = _hand(totalpot=Decimal("0.5401"), collectees={"tortuga": Decimal("0.5199")})
+
+        assert compare_hands(_hand(), captured) == []
+
+    def test_a_hand_object_and_a_dict_compare_the_same(self) -> None:
+        class TextHand:
+            handid = "299449673"
+            players = [(1, "v8guy", "3.74"), (2, "RezaG", "4.11"), (3, "tortuga", "1.67")]
+            board = {"FLOP": ["8c", "Js", "8h"], "TURN": ["Th"], "RIVER": []}
+            totalpot = Decimal("0.54")
+            collectees = {"tortuga": Decimal("0.52")}
+
+        assert compare_hands(TextHand(), _hand()) == []
+
+
+class TestDrift:
+    def test_a_different_hand_id_is_reported(self) -> None:
+        problems = compare_hands(_hand(), _hand(hand_id="999"))
+
+        assert any("hand id" in problem for problem in problems)
+
+    def test_a_missing_player_is_reported(self) -> None:
+        captured = _hand(players=[{"name": "RezaG", "seat": 2}, {"name": "tortuga", "seat": 3}])
+
+        problems = compare_hands(_hand(), captured)
+
+        assert any("v8guy" in problem for problem in problems)
+
+    def test_a_shifted_seat_is_reported(self) -> None:
+        """The seat-zero bug shifted every player by one; this is what catches it."""
+        captured = _hand(
+            players=[
+                {"name": "v8guy", "seat": 0},
+                {"name": "RezaG", "seat": 1},
+                {"name": "tortuga", "seat": 2},
+            ],
+        )
+
+        problems = compare_hands(_hand(), captured)
+
+        assert len(problems) == 3
+        assert all("seat of" in problem for problem in problems)
+
+    def test_a_wrong_board_is_reported(self) -> None:
+        problems = compare_hands(_hand(), _hand(board=["8c", "Js", "8h", "2d"]))
+
+        assert any("board" in problem for problem in problems)
+
+    def test_a_short_pot_is_reported(self) -> None:
+        """The GGPoker class of bug: a blind never reaching the pot."""
+        problems = compare_hands(_hand(), _hand(totalpot=Decimal("0.50")))
+
+        assert any("total pot" in problem for problem in problems)
+
+    def test_wrong_winnings_are_reported(self) -> None:
+        problems = compare_hands(_hand(), _hand(collectees={"tortuga": Decimal("0.10")}))
+
+        assert any("winnings of tortuga" in problem for problem in problems)
+
+    def test_a_winner_the_capture_missed_is_reported(self) -> None:
+        problems = compare_hands(_hand(), _hand(collectees={}))
+
+        assert any("winnings of tortuga" in problem for problem in problems)
+
+
+@pytest.mark.skipif(
+    not PAIRED_DIR.is_dir() or not any(PAIRED_DIR.glob("*.raw")),
+    reason=(
+        "no paired SwC fixtures: a capture archive and the text history of the same "
+        "session have to come from real play. Add <name>.raw and <name>.txt under "
+        "tests/fixtures/hands/swc_paired/ to enable this check."
+    ),
+)
+def test_paired_fixtures_agree() -> None:
+    from fpdb_3_legacy.Configuration import Config
+    from fpdb_3_legacy.SealsWithClubsToFpdb import SealsWithClubs
+    from fpdb_3_legacy.swc_native_capture import (
+        iter_protocol_messages,
+        normalize_native_hands,
+        read_records_since,
+    )
+
+    for archive in sorted(PAIRED_DIR.glob("*.raw")):
+        text_file = archive.with_suffix(".txt")
+        assert text_file.exists(), f"{archive.name} has no matching text history"
+
+        text_hands = {
+            str(hand.handid): hand
+            for hand in SealsWithClubs(config=Config(), in_path=str(text_file), autostart=True).getProcessedHands()
+        }
+        records, _ = read_records_since(archive, 0)
+        captured_hands = normalize_native_hands(
+            list(iter_protocol_messages(iter(records))),
+            raw_ref=str(archive),
+        )
+
+        for captured in captured_hands:
+            hand_id = str(captured.get("hand_id"))
+            if hand_id not in text_hands:
+                continue  # the room wrote no text history for this game family
+            problems = compare_hands(text_hands[hand_id], captured)
+            assert not problems, f"{archive.name} hand {hand_id}:\n  " + "\n  ".join(problems)

--- a/test/test_swc_live_import.py
+++ b/test/test_swc_live_import.py
@@ -1,0 +1,83 @@
+"""A hand captured live has to reach the database.
+
+The callback read the importer's connection from `self.importer.db`, an
+attribute that does not exist — Importer holds it as `database`. Every live
+hand therefore raised AttributeError straight into the surrounding
+`except Exception`, which logged and moved on, so nothing captured live was
+ever imported and nothing said so.
+
+mypy caught it as a type error; these tests pin the behaviour, so the path
+cannot go quiet again.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from fpdb_3_legacy.GuiAutoImport import GuiAutoImport
+
+
+@pytest.fixture
+def gui(monkeypatch):
+    """A GuiAutoImport with just enough wired up to run the callback."""
+    widget = GuiAutoImport.__new__(GuiAutoImport)
+    widget.messages = []
+    widget.addText = lambda text, _tag=None: widget.messages.append(text)
+    return widget
+
+
+def _hand() -> dict:
+    return {"hand_id": 299449673, "game": {"category": "holdem"}}
+
+
+def test_the_hand_is_handed_to_the_importers_database(gui, monkeypatch) -> None:
+    sentinel = object()
+    gui.importer = SimpleNamespace(database=sentinel)
+    seen = {}
+
+    monkeypatch.setattr(
+        "fpdb_3_legacy.http_capture_db_import.import_http_capture_hand",
+        lambda db, hand_data, **_: seen.update(db=db, hand=hand_data),
+    )
+
+    gui._on_swc_native_hand_imported(_hand())
+
+    assert seen["db"] is sentinel
+    assert seen["hand"] == _hand()
+
+
+def test_a_successful_import_is_reported_to_the_user(gui, monkeypatch) -> None:
+    gui.importer = SimpleNamespace(database=object())
+    monkeypatch.setattr(
+        "fpdb_3_legacy.http_capture_db_import.import_http_capture_hand",
+        lambda *_a, **_k: None,
+    )
+
+    gui._on_swc_native_hand_imported(_hand())
+
+    assert any("299449673" in message for message in gui.messages)
+
+
+def test_no_database_is_reported_rather_than_swallowed(gui, caplog) -> None:
+    gui.importer = SimpleNamespace()
+
+    gui._on_swc_native_hand_imported(_hand())
+
+    assert gui.messages == []
+    assert any("no database connection" in record.message for record in caplog.records)
+
+
+def test_a_failing_import_does_not_claim_success(gui, monkeypatch) -> None:
+    gui.importer = SimpleNamespace(database=object())
+
+    def explode(*_args, **_kwargs):
+        message = "database is away"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr("fpdb_3_legacy.http_capture_db_import.import_http_capture_hand", explode)
+
+    gui._on_swc_native_hand_imported(_hand())
+
+    assert gui.messages == []

--- a/test/test_swc_live_import.py
+++ b/test/test_swc_live_import.py
@@ -19,13 +19,24 @@ import pytest
 from fpdb_3_legacy.GuiAutoImport import GuiAutoImport
 
 
+class _Gui(SimpleNamespace):
+    """Stands in for the widget: the callback only needs an importer and addText.
+
+    Calling the method unbound on this keeps a half-constructed QWidget out of
+    the tests — the callback touches no Qt state, so building one would only
+    add a dependency on the display.
+    """
+
+    def addText(self, text: str, _tag: str | None = None) -> None:
+        self.messages.append(text)
+
+    def on_hand(self, hand_data: dict) -> None:
+        GuiAutoImport._on_swc_native_hand_imported(self, hand_data)
+
+
 @pytest.fixture
-def gui(monkeypatch):
-    """A GuiAutoImport with just enough wired up to run the callback."""
-    widget = GuiAutoImport.__new__(GuiAutoImport)
-    widget.messages = []
-    widget.addText = lambda text, _tag=None: widget.messages.append(text)
-    return widget
+def gui():
+    return _Gui(messages=[])
 
 
 def _hand() -> dict:
@@ -42,7 +53,7 @@ def test_the_hand_is_handed_to_the_importers_database(gui, monkeypatch) -> None:
         lambda db, hand_data, **_: seen.update(db=db, hand=hand_data),
     )
 
-    gui._on_swc_native_hand_imported(_hand())
+    gui.on_hand(_hand())
 
     assert seen["db"] is sentinel
     assert seen["hand"] == _hand()
@@ -55,7 +66,7 @@ def test_a_successful_import_is_reported_to_the_user(gui, monkeypatch) -> None:
         lambda *_a, **_k: None,
     )
 
-    gui._on_swc_native_hand_imported(_hand())
+    gui.on_hand(_hand())
 
     assert any("299449673" in message for message in gui.messages)
 
@@ -63,7 +74,7 @@ def test_a_successful_import_is_reported_to_the_user(gui, monkeypatch) -> None:
 def test_no_database_is_reported_rather_than_swallowed(gui, caplog) -> None:
     gui.importer = SimpleNamespace()
 
-    gui._on_swc_native_hand_imported(_hand())
+    gui.on_hand(_hand())
 
     assert gui.messages == []
     assert any("no database connection" in record.message for record in caplog.records)
@@ -78,6 +89,6 @@ def test_a_failing_import_does_not_claim_success(gui, monkeypatch) -> None:
 
     monkeypatch.setattr("fpdb_3_legacy.http_capture_db_import.import_http_capture_hand", explode)
 
-    gui._on_swc_native_hand_imported(_hand())
+    gui.on_hand(_hand())
 
     assert gui.messages == []

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -1516,3 +1516,28 @@ def test_build_native_ofc_summary_excludes_non_ofc_hands():
 def test_iter_capture_records_rejects_corruption(data, message):
     with pytest.raises(ValueError, match=message):
         list(iter_capture_records(io.BytesIO(data)))
+
+
+def test_build_tap_cross_platform(tmp_path, monkeypatch):
+    from fpdb_3_legacy import swc_native_capture
+
+    monkeypatch.setattr(swc_native_capture, "BUILD_DIR", tmp_path)
+    tap_path = swc_native_capture.build_tap(force=True)
+    assert tap_path.exists()
+    assert tap_path.name in ("libswc_native_tap.dylib", "libswc_native_tap.so", "swc_native_tap.dll")
+
+
+def test_swc_native_tailing_thread(tmp_path):
+    from fpdb_3_legacy.GuiAutoImport import SwCNativeTailingThread
+    raw = tmp_path / "swc-native.raw"
+    raw.write_bytes(_record())
+
+    thread = SwCNativeTailingThread(raw_path=raw)
+    imported = []
+    thread.hand_imported.connect(imported.append)
+    thread.start()
+    thread.stop()
+    thread.wait(1000)
+    # Thread terminates cleanly
+    assert not thread.isRunning()
+

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -1527,17 +1527,51 @@ def test_build_tap_cross_platform(tmp_path, monkeypatch):
     assert tap_path.name in ("libswc_native_tap.dylib", "libswc_native_tap.so", "swc_native_tap.dll")
 
 
-def test_swc_native_tailing_thread(tmp_path):
+def _tailing_thread(tmp_path, monkeypatch, hands):
+    """A tailing thread whose decode stage yields `hands`, wired to a real archive."""
+    from fpdb_3_legacy import swc_native_capture
     from fpdb_3_legacy.GuiAutoImport import SwCNativeTailingThread
+
+    monkeypatch.setattr(swc_native_capture, "iter_protocol_messages", lambda records: list(records))
+    monkeypatch.setattr(swc_native_capture, "normalize_native_hands", lambda messages, raw_ref=None: hands)
+
     raw = tmp_path / "swc-native.raw"
     raw.write_bytes(_record())
+    return SwCNativeTailingThread(raw_path=raw), raw
 
-    thread = SwCNativeTailingThread(raw_path=raw)
-    imported = []
-    thread.hand_imported.connect(imported.append)
+
+def test_swc_native_tailing_yields_decoded_hands(tmp_path, monkeypatch):
+    """The original test only asserted a clean stop, so the decode path was free to break."""
+    hand = {"table_id": 7, "hand_id": 1234}
+    thread, _raw = _tailing_thread(tmp_path, monkeypatch, [hand])
+
+    assert thread.poll_once() == [hand]
+
+
+def test_swc_native_tailing_does_not_reimport_a_known_hand(tmp_path, monkeypatch):
+    hand = {"table_id": 7, "hand_id": 1234}
+    thread, raw = _tailing_thread(tmp_path, monkeypatch, [hand])
+    assert thread.poll_once() == [hand]
+
+    with raw.open("ab") as handle:
+        handle.write(_record(b"more"))
+
+    assert thread.poll_once() == []
+
+
+def test_swc_native_tailing_consumes_the_archive_once(tmp_path, monkeypatch):
+    """A poll must advance past what it read instead of re-parsing from zero."""
+    thread, raw = _tailing_thread(tmp_path, monkeypatch, [])
+    thread.poll_once()
+
+    assert thread._offset == raw.stat().st_size
+
+
+def test_swc_native_tailing_thread_stops_cleanly(tmp_path, monkeypatch):
+    thread, _raw = _tailing_thread(tmp_path, monkeypatch, [])
     thread.start()
     thread.stop()
-    thread.wait(1000)
-    # Thread terminates cleanly
+    thread.wait(2000)
+
     assert not thread.isRunning()
 

--- a/test/test_swc_native_tailing.py
+++ b/test/test_swc_native_tailing.py
@@ -1,0 +1,121 @@
+"""Incremental tailing of the live SwC native capture archive.
+
+The archive is appended to while the client plays, which breaks two assumptions
+a one-shot reader can make. Its tail is routinely a half-written record, and it
+grows for the whole session — so re-reading it from byte zero on every poll
+re-parses everything read so far.
+
+These tests pin both behaviours, plus the fact that a poll actually yields the
+hands it decoded: the original tailing test only asserted that the thread
+stopped cleanly, so the entire decode path could be deleted without failing it.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from fpdb_3_legacy.swc_native_capture import read_records_since
+
+HEADER = struct.Struct("=IHBBHHIQ")
+
+
+def _record(payload: bytes = b"game-state", *, direction: int = 0, port: int = 20013) -> bytes:
+    return HEADER.pack(0x53574354, 1, direction, 0, port, 0, len(payload), 1_750_000_000_123_456) + payload
+
+
+class TestIncrementalReads:
+    def test_a_first_read_returns_every_record(self, tmp_path: Path) -> None:
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(_record(b"one") + _record(b"two"))
+
+        records, offset = read_records_since(archive, 0)
+
+        assert [r.payload for r in records] == [b"one", b"two"]
+        assert offset == archive.stat().st_size
+
+    def test_a_second_read_returns_only_what_was_appended(self, tmp_path: Path) -> None:
+        """The whole point: a poll must not re-parse the session so far."""
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(_record(b"one"))
+        _, offset = read_records_since(archive, 0)
+
+        with archive.open("ab") as handle:
+            handle.write(_record(b"two"))
+        records, offset = read_records_since(archive, offset)
+
+        assert [r.payload for r in records] == [b"two"]
+        assert offset == archive.stat().st_size
+
+    def test_nothing_new_yields_nothing(self, tmp_path: Path) -> None:
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(_record(b"one"))
+        _, offset = read_records_since(archive, 0)
+
+        records, second_offset = read_records_since(archive, offset)
+
+        assert records == []
+        assert second_offset == offset
+
+    def test_a_missing_archive_is_not_an_error(self, tmp_path: Path) -> None:
+        records, offset = read_records_since(tmp_path / "absent.raw", 0)
+
+        assert records == []
+        assert offset == 0
+
+
+class TestPartialRecords:
+    def test_a_half_written_header_does_not_lose_the_complete_records(self, tmp_path: Path) -> None:
+        """Raising here would discard every hand decoded in the same pass."""
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(_record(b"complete") + HEADER.pack(0x53574354, 1, 0, 0, 20013, 0, 99, 0)[:6])
+
+        records, offset = read_records_since(archive, 0)
+
+        assert [r.payload for r in records] == [b"complete"]
+        assert offset == len(_record(b"complete"))
+
+    def test_a_half_written_payload_does_not_lose_the_complete_records(self, tmp_path: Path) -> None:
+        archive = tmp_path / "swc-native.raw"
+        truncated = _record(b"incoming-payload")[:-4]
+        archive.write_bytes(_record(b"complete") + truncated)
+
+        records, offset = read_records_since(archive, 0)
+
+        assert [r.payload for r in records] == [b"complete"]
+        assert offset == len(_record(b"complete"))
+
+    def test_the_rest_of_a_partial_record_is_read_once_it_lands(self, tmp_path: Path) -> None:
+        archive = tmp_path / "swc-native.raw"
+        full = _record(b"later")
+        archive.write_bytes(full[:5])
+        records, offset = read_records_since(archive, 0)
+        assert records == []
+
+        archive.write_bytes(full)
+        records, _ = read_records_since(archive, offset)
+
+        assert [r.payload for r in records] == [b"later"]
+
+    def test_a_corrupt_header_still_raises(self, tmp_path: Path) -> None:
+        """A bad magic is corruption, not a partial write, and must not pass silently."""
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(HEADER.pack(0xDEADBEEF, 1, 0, 0, 20013, 0, 4, 0) + b"junk")
+
+        with pytest.raises(ValueError, match="invalid SwC native capture header"):
+            read_records_since(archive, 0)
+
+
+class TestRotation:
+    def test_a_truncated_archive_restarts_from_the_beginning(self, tmp_path: Path) -> None:
+        archive = tmp_path / "swc-native.raw"
+        archive.write_bytes(_record(b"one") + _record(b"two"))
+        _, offset = read_records_since(archive, 0)
+
+        archive.write_bytes(_record(b"fresh"))  # rewritten, now shorter
+        records, new_offset = read_records_since(archive, offset)
+
+        assert [r.payload for r in records] == [b"fresh"]
+        assert new_offset == archive.stat().st_size


### PR DESCRIPTION
## Summary & Feature Goal

Resolves #178.

This PR implements native desktop hand-history capture and live HUD ingestion for the **SwC Poker 2.0** desktop client across **macOS**, **Linux**, and **Windows**.

### Changes Included:
1. **Cross-Platform Interposer Library (`swc_native_tap.c` & `swc_native_capture.py`)**:
   - macOS (`__APPLE__`): Mach-O `dyld` interposition (`libswc_native_tap.dylib`).
   - Linux (`__linux__`): `LD_PRELOAD` interposition (`libswc_native_tap.so`).
   - Windows (`_WIN32`): OpenSSL export/hooking proxy (`swc_native_tap.dll`).
   - Cross-platform build handling in `build_tap()` and environment configuration in `native_client_environment()`.

2. **Physical Table Seat Mapping & Monetary Scaling**:
   - Refined Type-9 animation index and roster seat correlation (`infer_native_seat_evidence`) to assign exact FPDB physical seat indices (`0..8`).
   - Validated monetary unit scaling: cash games `mt="R"` (100 native units per display unit) and tournament games `mt="T"` (1 unit per display unit).

3. **GUI AutoImporter & Live HUD Ingestion Engine (`GuiAutoImport.py`)**:
   - Added `SwCNativeTailingThread` to tail `swc-native.raw` live in real time.
   - Automatically imports parsed hands live into the database and feeds the HUD overlay engine.

4. **CI Workflow Verification (`.github/workflows/ci.yml`)**:
   - Added automated compilation checks for the SwC native tap library in CI.

5. **Unit Tests**:
   - Added tests covering cross-platform library compilation, seat mapping, action scaling, and live HUD tailing thread.