### PR TITLE
fix(importer): ignore sidecar files and cache failed site identifications (#181)

### DIFF
--- a/fpdb_3_legacy/IdentifySite.py
+++ b/fpdb_3_legacy/IdentifySite.py
@@ -155,6 +155,7 @@ class IdentifySite:
         self.codepage = ("utf8", "cp1252", "ISO-8859-1")
         self.sitelist: dict[int | None, Site] = {}
         self.filelist: dict[str | bytes, FPDBFile] = {}
+        self.failed_files: set[str | bytes] = set()
         self.re_Identify_PT: re.Pattern[str] | None = None
         self.re_SumIdentify_PT: re.Pattern[str] | None = None
         self.generateSiteList(hhcs)
@@ -330,6 +331,8 @@ class IdentifySite:
             self.processFile(path)
 
     def get_fobj(self, file):
+        if file in self.failed_files:
+            return False
         try:
             fobj = self.filelist[file]
         except KeyError:
@@ -341,6 +344,7 @@ class IdentifySite:
 
     def clear_filelist(self) -> None:
         self.filelist = {}
+        self.failed_files = set()
 
     def generateSiteList(self, hhcs) -> None:
         """Generates a ordered dictionary of site, filter and filter name for each site in hhcs."""
@@ -390,7 +394,7 @@ class IdentifySite:
 
     def processFile(self, path) -> None:
         log.debug(f"process fill identify {path}")
-        if path not in self.filelist:
+        if path not in self.filelist and path not in self.failed_files:
             log.debug(f"filelist {self.filelist}")
             whole_file, kodec = self.read_file(path)
             # log.debug('whole_file',whole_file)
@@ -401,13 +405,16 @@ class IdentifySite:
                 # print(fobj.path)
                 if fobj is False:  # Site id failed
                     log.debug(f"siteId Failed for: {path}")
+                    self.failed_files.add(path)
                 else:
                     self.filelist[path] = fobj
+            else:
+                self.failed_files.add(path)
 
     def read_file(self, in_path):
-        # Ignore macOS-specific hidden files such as .DS_Store
-        if in_path.endswith(".DS_Store"):
-            log.warning(f"Skipping system file {in_path}")
+        # Ignore macOS-specific hidden files such as .DS_Store and test sidecars/artifacts
+        if in_path.endswith((".DS_Store", ".hp", ".gt", ".hands")):
+            log.warning(f"Skipping system or test sidecar file {in_path}")
             return None, None
 
         # Excel file management if xlrd is available

--- a/fpdb_3_legacy/IdentifySite.py
+++ b/fpdb_3_legacy/IdentifySite.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from fpdb_3_legacy import Configuration
 from fpdb_3_legacy.HandHistoryConverter import HandHistoryConverter, unpack_sqlite_hand_history
+from fpdb_3_legacy.import_failure_cache import FailureCache, is_sidecar_file
 from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.parser_registry import (
     LEGACY_MODULE_REGISTRY as LEGACY_MODULE_REGISTRY,
@@ -155,10 +156,18 @@ class IdentifySite:
         self.codepage = ("utf8", "cp1252", "ISO-8859-1")
         self.sitelist: dict[int | None, Site] = {}
         self.filelist: dict[str | bytes, FPDBFile] = {}
-        self.failed_files: set[str | bytes] = set()
+        self.failed_files = FailureCache()
         self.re_Identify_PT: re.Pattern[str] | None = None
         self.re_SumIdentify_PT: re.Pattern[str] | None = None
         self.generateSiteList(hhcs)
+
+    def identification_failed(self, path) -> bool:
+        """True if `path` already failed and has not been written to since."""
+        return self.failed_files.failed(path)
+
+    def remember_failure(self, path) -> None:
+        """Record that `path` failed as it currently stands."""
+        self.failed_files.remember(path)
 
     def detectiPokerSkin(self, handText):
         """Detect specific iPoker skin from hand text content."""
@@ -331,7 +340,7 @@ class IdentifySite:
             self.processFile(path)
 
     def get_fobj(self, file):
-        if file in self.failed_files:
+        if self.identification_failed(file):
             return False
         try:
             fobj = self.filelist[file]
@@ -344,7 +353,7 @@ class IdentifySite:
 
     def clear_filelist(self) -> None:
         self.filelist = {}
-        self.failed_files = set()
+        self.failed_files = FailureCache()
 
     def generateSiteList(self, hhcs) -> None:
         """Generates a ordered dictionary of site, filter and filter name for each site in hhcs."""
@@ -394,27 +403,37 @@ class IdentifySite:
 
     def processFile(self, path) -> None:
         log.debug(f"process fill identify {path}")
-        if path not in self.filelist and path not in self.failed_files:
-            log.debug(f"filelist {self.filelist}")
-            whole_file, kodec = self.read_file(path)
-            # log.debug('whole_file',whole_file)
-            log.debug(f"kodec {kodec}")
-            if whole_file:
-                fobj = self.idSite(path, whole_file, kodec)
-                log.debug(f"siteid obj {fobj}")
-                # print(fobj.path)
-                if fobj is False:  # Site id failed
-                    log.debug(f"siteId Failed for: {path}")
-                    self.failed_files.add(path)
-                else:
-                    self.filelist[path] = fobj
-            else:
-                self.failed_files.add(path)
+        if path in self.filelist or self.identification_failed(path):
+            return
+
+        log.debug(f"filelist {self.filelist}")
+        whole_file, kodec = self.read_file(path)
+        # log.debug('whole_file',whole_file)
+        log.debug(f"kodec {kodec}")
+        if not whole_file:
+            # Empty or unreadable: the poker client creates the history file when
+            # a table opens and only writes the first hand later, so this is a
+            # file that has not been written yet, not one that never will be.
+            # Recording the signature means the next poll re-reads it as soon as
+            # anything lands in it, without re-reading an unchanged one.
+            self.remember_failure(path)
+            return
+
+        fobj = self.idSite(path, whole_file, kodec)
+        log.debug(f"siteid obj {fobj}")
+        # print(fobj.path)
+        if fobj is False:  # Site id failed
+            log.debug(f"siteId Failed for: {path}")
+            self.remember_failure(path)
+        else:
+            self.filelist[path] = fobj
 
     def read_file(self, in_path):
-        # Ignore macOS-specific hidden files such as .DS_Store and test sidecars/artifacts
-        if in_path.endswith((".DS_Store", ".hp", ".gt", ".hands")):
-            log.warning(f"Skipping system or test sidecar file {in_path}")
+        # System leftovers and the regression corpus' reference data are not
+        # hand histories. Logged at debug: they are expected in a watched
+        # directory, and shouting about them is the noise this set out to fix.
+        if is_sidecar_file(in_path):
+            log.debug(f"Skipping system or sidecar file {in_path}")
             return None, None
 
         # Excel file management if xlrd is available

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -36,6 +36,7 @@ from fpdb_3_legacy.Exceptions import (
     FpdbParseError,
     FpdbSummaryNotFound,
 )
+from fpdb_3_legacy.import_failure_cache import SIDECAR_EXTENSIONS, FailureCache
 from fpdb_3_legacy.iPoker.dispatcher import get_parser_class_for_path as get_ipoker_parser_class_for_path
 from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.parser_registry import get_parser_class, get_summary_class
@@ -155,7 +156,7 @@ class Importer:
         self.idsite = IdentifySite.IdentifySite(config)
 
         self.filelist: dict[str, IdentifySite.FPDBFile] = {}
-        self.failed_files: set[str] = set()
+        self.failed_files = FailureCache()
         self.dirlist: dict[Any, list[Any]] = {}
         self.siteIds: dict[str, int] = {}
         self.removeFromFileList: dict[str, bool] = {}  # to remove deleted files
@@ -386,7 +387,9 @@ class Importer:
         self.updatedtime = {}
         self.pos_in_file = {}
         self.filelist = {}
-        self.failed_files = set()
+        # Reassigned rather than cleared in place: callers that build an
+        # Importer without running __init__ rely on this creating the cache.
+        self.failed_files = FailureCache()
 
     def logImport(self, type, file, stored, dups, partial, skipped, errs, ttime, id) -> None:
         """Log the results of an import operation to the database.
@@ -465,13 +468,13 @@ class Importer:
         # filename not guaranteed to be unicode
         if (
             self.filelist.get(filename) is not None
-            or filename in self.failed_files
+            or self.failed_files.failed(filename)
             or not os.path.exists(filename)
         ):
             return False
 
         if not self._is_valid_import_file(filename):
-            self.failed_files.add(filename)
+            self.failed_files.remember(filename)
             return False
 
         self.idsite.processFile(filename)
@@ -479,7 +482,7 @@ class Importer:
             fpdbfile = self.idsite.filelist[filename]
         else:
             log.warning(f"siteId Failed for: '{filename}'")
-            self.failed_files.add(filename)
+            self.failed_files.remember(filename)
             return False
 
         self.addFileToList(fpdbfile)
@@ -594,10 +597,8 @@ class Importer:
             ".o",
             ".obj",
             ".py",
-            # Test & sidecar reference data
-            ".hp",
-            ".gt",
-            ".hands",
+            # Test & sidecar reference data (shared with IdentifySite)
+            *SIDECAR_EXTENSIONS,
         }
 
         if ext in ignored_extensions:
@@ -675,7 +676,7 @@ class Importer:
                     if os.path.islink(filename):
                         log.info(f"Ignoring symlink {filename}")
                         continue
-                    if not self._is_valid_import_file(filename) or filename in self.failed_files:
+                    if not self._is_valid_import_file(filename) or self.failed_files.failed(filename):
                         continue
                     if (time() - os.stat(filename).st_mtime) <= 43200:  # look all files modded in the last 12 hours
                         # need long time because FTP in Win does not
@@ -717,14 +718,16 @@ class Importer:
                     self.updatedsize.pop(filename, None)
                     self.updatedtime.pop(filename, None)
                     self.pos_in_file.pop(filename, None)
-            for filename in list(self.failed_files):
+            for failed_path in list(self.failed_files):
                 try:
-                    file_path = os.path.abspath(filename)
+                    # The cache accepts bytes paths, which commonpath cannot mix
+                    # with the str prefix, so normalise before comparing.
+                    file_path = os.path.abspath(os.fsdecode(failed_path))
                     common = os.path.commonpath([watched_prefix, file_path])
                 except ValueError:
                     continue
                 if common == watched_prefix:
-                    self.failed_files.discard(filename)
+                    self.failed_files.discard(failed_path)
 
     def runImport(self):
         """Run the import process for all files in the file list.

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -155,6 +155,7 @@ class Importer:
         self.idsite = IdentifySite.IdentifySite(config)
 
         self.filelist: dict[str, IdentifySite.FPDBFile] = {}
+        self.failed_files: set[str] = set()
         self.dirlist: dict[Any, list[Any]] = {}
         self.siteIds: dict[str, int] = {}
         self.removeFromFileList: dict[str, bool] = {}  # to remove deleted files
@@ -385,6 +386,7 @@ class Importer:
         self.updatedtime = {}
         self.pos_in_file = {}
         self.filelist = {}
+        self.failed_files = set()
 
     def logImport(self, type, file, stored, dups, partial, skipped, errs, ttime, id) -> None:
         """Log the results of an import operation to the database.
@@ -461,7 +463,15 @@ class Importer:
         """
         # DEBUG->print("addimportfile: filename is a", filename.__class__, filename)
         # filename not guaranteed to be unicode
-        if self.filelist.get(filename) is not None or not os.path.exists(filename):
+        if (
+            self.filelist.get(filename) is not None
+            or filename in self.failed_files
+            or not os.path.exists(filename)
+        ):
+            return False
+
+        if not self._is_valid_import_file(filename):
+            self.failed_files.add(filename)
             return False
 
         self.idsite.processFile(filename)
@@ -469,6 +479,7 @@ class Importer:
             fpdbfile = self.idsite.filelist[filename]
         else:
             log.warning(f"siteId Failed for: '{filename}'")
+            self.failed_files.add(filename)
             return False
 
         self.addFileToList(fpdbfile)
@@ -568,8 +579,14 @@ class Importer:
             ".rtf",
             # Database
             ".db",
+            ".db-wal",
+            ".db-shm",
             ".sqlite",
+            ".sqlite-wal",
+            ".sqlite-shm",
             ".sqlite3",
+            ".sqlite3-wal",
+            ".sqlite3-shm",
             ".mdb",
             # Code/Compiled
             ".pyc",
@@ -577,6 +594,10 @@ class Importer:
             ".o",
             ".obj",
             ".py",
+            # Test & sidecar reference data
+            ".hp",
+            ".gt",
+            ".hands",
         }
 
         if ext in ignored_extensions:
@@ -654,6 +675,8 @@ class Importer:
                     if os.path.islink(filename):
                         log.info(f"Ignoring symlink {filename}")
                         continue
+                    if not self._is_valid_import_file(filename) or filename in self.failed_files:
+                        continue
                     if (time() - os.stat(filename).st_mtime) <= 43200:  # look all files modded in the last 12 hours
                         # need long time because FTP in Win does not
                         # update the timestamp on the HH during session
@@ -694,6 +717,14 @@ class Importer:
                     self.updatedsize.pop(filename, None)
                     self.updatedtime.pop(filename, None)
                     self.pos_in_file.pop(filename, None)
+            for filename in list(self.failed_files):
+                try:
+                    file_path = os.path.abspath(filename)
+                    common = os.path.commonpath([watched_prefix, file_path])
+                except ValueError:
+                    continue
+                if common == watched_prefix:
+                    self.failed_files.discard(filename)
 
     def runImport(self):
         """Run the import process for all files in the file list.

--- a/fpdb_3_legacy/import_failure_cache.py
+++ b/fpdb_3_legacy/import_failure_cache.py
@@ -1,0 +1,85 @@
+"""Remember which files failed identification, without condemning them for good.
+
+Auto-import polls its directories every few seconds, so a file that cannot be
+identified is examined again and again — that is what flooded the log with
+`siteId Failed` for the regression corpus.
+
+Caching the failure by path alone fixes the noise and breaks the import: the
+poker client creates a hand-history file when a table opens and writes the first
+hand later, so a poll that arrives in between sees an empty file. Blacklisting
+it by path means the hands written a minute later are never imported, and the
+same cache that silenced the warning also silences the loss.
+
+So the failure is remembered against the file's size and modification time. An
+unchanged file is skipped; one that has grown is read again.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Reference data written beside the regression corpus: Python literals used by
+# the test suite, never hand histories. Kept here so the importer and the
+# identifier cannot drift apart on what counts as a sidecar.
+SIDECAR_EXTENSIONS = (".hp", ".gt", ".hands")
+
+# Files the operating system or an editor leaves behind next to real ones.
+SYSTEM_FILES = (".DS_Store",)
+
+
+def is_sidecar_file(path: str | bytes) -> bool:
+    """True for files that sit beside hand histories and are never importable."""
+    name = os.fsdecode(path)
+    return name.endswith(SYSTEM_FILES) or name.endswith(SIDECAR_EXTENSIONS)
+
+
+def _signature(path: str | bytes) -> tuple[int, int] | None:
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return (stat.st_size, stat.st_mtime_ns)
+
+
+class FailureCache:
+    """Files whose identification failed, keyed by the content that failed.
+
+    Supports ``in``, iteration and ``discard`` so it can stand where a plain set
+    used to.
+    """
+
+    def __init__(self) -> None:
+        self._signatures: dict[str | bytes, tuple[int, int] | None] = {}
+
+    def remember(self, path: str | bytes) -> None:
+        """Record that `path` failed as it currently stands."""
+        self._signatures[path] = _signature(path)
+
+    def failed(self, path: str | bytes) -> bool:
+        """True only if `path` failed and has not changed since."""
+        if path not in self._signatures:
+            return False
+        if self._signatures[path] != _signature(path):
+            # Written to since it failed, so it deserves another read.
+            del self._signatures[path]
+            return False
+        return True
+
+    def discard(self, path: str | bytes) -> None:
+        self._signatures.pop(path, None)
+
+    def clear(self) -> None:
+        self._signatures.clear()
+
+    def __contains__(self, path: object) -> bool:
+        return self.failed(path)  # type: ignore[arg-type]
+
+    def __iter__(self) -> Iterator[str | bytes]:
+        return iter(list(self._signatures))
+
+    def __len__(self) -> int:
+        return len(self._signatures)

--- a/fpdb_3_legacy/import_failure_cache.py
+++ b/fpdb_3_legacy/import_failure_cache.py
@@ -12,6 +12,11 @@ same cache that silenced the warning also silences the loss.
 
 So the failure is remembered against the file's size and modification time. An
 unchanged file is skipped; one that has grown is read again.
+
+The signature does not catch a rewrite that keeps the byte count identical and
+lands inside one filesystem mtime tick — coarse on Windows in particular. That
+is deliberate: detecting it would mean reading the file, which is exactly the
+work being avoided, and a hand history only ever grows as the client appends.
 """
 
 from __future__ import annotations

--- a/tests/test_import_failure_cache.py
+++ b/tests/test_import_failure_cache.py
@@ -66,10 +66,18 @@ class TestRememberingFailures:
         assert not cache.failed(target)
 
     def test_a_second_failure_re_arms_the_cache(self, tmp_path: Path) -> None:
+        """A file that changed, failed again, and has not changed since stays skipped.
+
+        The content grows rather than being swapped for something the same
+        length: the signature is (size, mtime), so a same-size rewrite inside
+        one filesystem mtime tick is deliberately not detected. Hand histories
+        only ever grow, so that trade-off costs nothing real -- but a test must
+        not claim a guarantee the design does not make.
+        """
         cache = FailureCache()
         target = _touch(tmp_path / "junk.txt", "one")
         cache.remember(target)
-        _touch(target, "two")
+        _touch(target, "one and more")
         assert not cache.failed(target)
 
         cache.remember(target)

--- a/tests/test_import_failure_cache.py
+++ b/tests/test_import_failure_cache.py
@@ -1,0 +1,195 @@
+"""Silencing repeated identification failures must not lose hands.
+
+Auto-import polls every few seconds, so an unidentifiable file is examined over
+and over — the flooding that #181 reported. Remembering the failure by path
+alone stops the noise and creates a worse problem: the poker client creates a
+hand-history file when a table opens and writes the first hand later, so a poll
+landing in between sees an empty file and blacklists it. The hands written a
+minute later are then never imported, and the cache that silenced the warning
+silences the loss too.
+
+The failure is therefore remembered against the file's size and mtime: an
+unchanged file stays skipped, one that has been written to is read again.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from fpdb_3_legacy.import_failure_cache import (
+    SIDECAR_EXTENSIONS,
+    FailureCache,
+    is_sidecar_file,
+)
+
+
+def _touch(path: Path, content: str = "") -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestRememberingFailures:
+    def test_an_unchanged_file_stays_failed(self, tmp_path: Path) -> None:
+        """The point of the cache: no second warning for the same content."""
+        cache = FailureCache()
+        target = _touch(tmp_path / "junk.txt", "not a hand history")
+        cache.remember(target)
+
+        assert cache.failed(target)
+        assert target in cache
+
+    def test_an_unknown_file_has_not_failed(self, tmp_path: Path) -> None:
+        assert not FailureCache().failed(tmp_path / "never-seen.txt")
+
+    def test_a_file_written_to_is_examined_again(self, tmp_path: Path) -> None:
+        """The regression: an empty file must not be condemned for good."""
+        cache = FailureCache()
+        target = _touch(tmp_path / "HH20260806.txt")
+        cache.remember(target)
+        assert cache.failed(target)
+
+        _touch(target, "PokerStars Hand #1: Hold'em No Limit")
+
+        assert not cache.failed(target)
+
+    def test_a_file_that_only_grew_is_examined_again(self, tmp_path: Path) -> None:
+        """A client appending the next hand changes size even within one mtime tick."""
+        cache = FailureCache()
+        target = _touch(tmp_path / "HH20260806.txt", "partial")
+        cache.remember(target)
+
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(" ...and the rest of the hand")
+
+        assert not cache.failed(target)
+
+    def test_a_second_failure_re_arms_the_cache(self, tmp_path: Path) -> None:
+        cache = FailureCache()
+        target = _touch(tmp_path / "junk.txt", "one")
+        cache.remember(target)
+        _touch(target, "two")
+        assert not cache.failed(target)
+
+        cache.remember(target)
+
+        assert cache.failed(target)
+
+    def test_a_deleted_file_does_not_raise(self, tmp_path: Path) -> None:
+        cache = FailureCache()
+        target = _touch(tmp_path / "junk.txt", "gone soon")
+        cache.remember(target)
+        os.unlink(target)
+
+        assert cache.failed(target) in (True, False)  # must not raise
+
+
+class TestSetInterface:
+    """It stands where a plain set used to, so existing callers keep working."""
+
+    def test_discard_forgets_the_file(self, tmp_path: Path) -> None:
+        cache = FailureCache()
+        target = _touch(tmp_path / "junk.txt", "x")
+        cache.remember(target)
+
+        cache.discard(target)
+
+        assert not cache.failed(target)
+
+    def test_clear_forgets_everything(self, tmp_path: Path) -> None:
+        cache = FailureCache()
+        for name in ("a.txt", "b.txt"):
+            cache.remember(_touch(tmp_path / name, "x"))
+
+        cache.clear()
+
+        assert len(cache) == 0
+
+    def test_iteration_yields_the_remembered_paths(self, tmp_path: Path) -> None:
+        cache = FailureCache()
+        first = _touch(tmp_path / "a.txt", "x")
+        second = _touch(tmp_path / "b.txt", "x")
+        cache.remember(first)
+        cache.remember(second)
+
+        assert sorted(str(path) for path in cache) == sorted([str(first), str(second)])
+
+    def test_iterating_while_discarding_is_safe(self, tmp_path: Path) -> None:
+        """removeImportDirectory discards as it walks the cache."""
+        cache = FailureCache()
+        for name in ("a.txt", "b.txt", "c.txt"):
+            cache.remember(_touch(tmp_path / name, "x"))
+
+        for path in cache:
+            cache.discard(path)
+
+        assert len(cache) == 0
+
+
+class TestSidecarRecognition:
+    def test_reference_data_is_a_sidecar(self, tmp_path: Path) -> None:
+        for extension in SIDECAR_EXTENSIONS:
+            assert is_sidecar_file(str(tmp_path / f"hand.txt{extension}"))
+
+    def test_system_leftovers_are_sidecars(self, tmp_path: Path) -> None:
+        assert is_sidecar_file(str(tmp_path / ".DS_Store"))
+
+    def test_a_hand_history_is_not_a_sidecar(self, tmp_path: Path) -> None:
+        assert not is_sidecar_file(str(tmp_path / "HH20260806 T1.txt"))
+
+    def test_bytes_paths_are_accepted(self, tmp_path: Path) -> None:
+        assert is_sidecar_file(os.fsencode(str(tmp_path / "hand.txt.hp")))
+
+
+def test_the_cache_does_not_depend_on_clock_resolution(tmp_path: Path) -> None:
+    """Two writes inside one mtime tick still differ, because size is part of it."""
+    cache = FailureCache()
+    target = _touch(tmp_path / "HH.txt", "a")
+    cache.remember(target)
+    _touch(target, "ab")
+    first = cache.failed(target)
+
+    cache.remember(target)
+    time.sleep(0.01)
+    _touch(target, "abc")
+
+    assert first is False
+    assert cache.failed(target) is False
+
+
+class TestIdentifySiteWiring:
+    """The reported scenario, end to end through the identifier."""
+
+    @staticmethod
+    def _identifier():
+        from fpdb_3_legacy import IdentifySite
+        from fpdb_3_legacy.Configuration import Config
+
+        return IdentifySite.IdentifySite(Config())
+
+    @staticmethod
+    def _a_real_hand_history() -> str:
+        source = Path(__file__).resolve().parents[1] / "regression-test-files" / "cash" / "Stars" / "Flop"
+        return next(source.glob("*.txt")).read_text(encoding="utf-8", errors="replace")
+
+    def test_a_file_polled_while_empty_is_still_imported_once_written(self, tmp_path: Path) -> None:
+        """Caching by path alone lost these hands for the rest of the session."""
+        identifier = self._identifier()
+        history = _touch(tmp_path / "HH20260806 T1.txt")
+
+        identifier.processFile(str(history))
+        assert str(history) not in identifier.filelist
+
+        _touch(history, self._a_real_hand_history())
+        identifier.processFile(str(history))
+
+        assert str(history) in identifier.filelist
+
+    def test_an_empty_file_is_not_re_read_until_it_changes(self, tmp_path: Path) -> None:
+        """Without this the log floods again, which is what #181 was about."""
+        identifier = self._identifier()
+        history = _touch(tmp_path / "HH20260806 T2.txt")
+        identifier.processFile(str(history))
+
+        assert identifier.identification_failed(str(history))

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -247,3 +247,42 @@ def test_the_hud_and_session_switches_are_held_on_the_importer(importer, setter,
     getattr(importer, setter)(value)
 
     assert getattr(importer, attribute) == value
+
+
+def test_test_sidecars_are_ignored_and_not_queued(importer, tmp_path) -> None:
+    sidecars = [
+        tmp_path / "sample.txt.hp",
+        tmp_path / "sample.txt.gt",
+        tmp_path / "sample.txt.hands",
+    ]
+    for file in sidecars:
+        file.write_text("{'dummy': 1}", encoding="utf-8")
+        assert not importer._is_valid_import_file(str(file))
+        assert not importer.addImportFile(str(file), "auto")
+
+    assert importer.filelist == {}
+
+
+def test_failed_site_identification_is_cached_without_repeated_processing(importer, tmp_path, caplog) -> None:
+    unknown_file = tmp_path / "unknown_data.txt"
+    unknown_file.write_text("random content not a hand history\n", encoding="utf-8")
+
+    # First attempt: fails site identification, logs warning once
+    assert not importer.addImportFile(str(unknown_file), "auto")
+    assert str(unknown_file) in importer.failed_files
+    assert str(unknown_file) in importer.idsite.failed_files
+    warnings = [rec for rec in caplog.records if "siteId Failed" in rec.message]
+    assert len(warnings) == 1
+
+    # Second attempt: cached in failed_files, immediately skipped without adding new warning
+    caplog.clear()
+    assert not importer.addImportFile(str(unknown_file), "auto")
+    warnings_second = [rec for rec in caplog.records if "siteId Failed" in rec.message]
+    assert len(warnings_second) == 0
+
+    # Directory import loop: also skips cached failed file without warning
+    caplog.clear()
+    importer.addImportDirectory(str(tmp_path), monitor=False)
+    warnings_dir = [rec for rec in caplog.records if "siteId Failed" in rec.message]
+    assert len(warnings_dir) == 0
+


### PR DESCRIPTION
## Summary

Fixes #181.

### Root Cause
During import, `addImportDirectory` and `addImportFile` scanned all files recursively without filtering out test sidecar files (`.hp`, `.gt`, `.hands`) or SQLite sidecar files (`.sqlite3-wal`, `.sqlite3-shm`, etc.). Furthermore, when a file failed site identification (`idSite` returning `False`), it was not cached. Consequently, on every auto-import polling cycle (every 5 seconds), the importer re-read and re-evaluated site identification for these files, flooding the log with repeated `[WARNING] siteId Failed` messages.

### Fix Details
1. **Extension Blacklist Update**: Added test reference sidecar extensions (`.hp`, `.gt`, `.hands`) and SQLite sidecars (`.sqlite-wal`, `.sqlite-shm`, `.sqlite3-wal`, `.sqlite3-shm`, `.db-wal`, `.db-shm`) to `ignored_extensions` in `Importer._is_valid_import_file()`.
2. **Early System / Sidecar Filtering**: Updated `IdentifySite.read_file()` to skip system (`.DS_Store`) and sidecar files (`.hp`, `.gt`, `.hands`). Updated `Importer.addImportDirectory()` to check `_is_valid_import_file()` before queuing.
3. **Failed Identification Caching**: Added `failed_files` set tracking in `IdentifySite` and `Importer`. Files that fail site identification or file validation are recorded in `failed_files`. On subsequent import cycles, cached failed files are skipped immediately without re-reading or re-logging warnings.
4. **Cache Lifecycle Management**: Connected `failed_files` cleanup to `clearFileList()` and `removeImportDirectory()`.
5. **Unit Tests**: Added unit tests in `tests/test_importer.py` verifying sidecar filtering and caching of failed site identifications.