### PR TITLE
fix(packaging): ensure Python 3.10 UTC compatibility for PyOxidizer builds

### DIFF
--- a/fpdb_3_legacy/RegressionFileComparator.py
+++ b/fpdb_3_legacy/RegressionFileComparator.py
@@ -21,7 +21,7 @@ _SIDECAR_FACTORIES = {
 }
 _SIDECAR_CONSTANTS = {
     "pytz.utc": pytz.utc,
-    "datetime.timezone.utc": datetime.UTC,
+    "datetime.timezone.utc": getattr(datetime, "UTC", datetime.timezone.utc),
 }
 
 IGNORED_HAND_KEYS = {

--- a/fpdb_3_legacy/RegressionFileComparator.py
+++ b/fpdb_3_legacy/RegressionFileComparator.py
@@ -21,7 +21,7 @@ _SIDECAR_FACTORIES = {
 }
 _SIDECAR_CONSTANTS = {
     "pytz.utc": pytz.utc,
-    "datetime.timezone.utc": getattr(datetime, "UTC", datetime.timezone.utc),
+    "datetime.timezone.utc": datetime.timezone.utc,
 }
 
 IGNORED_HAND_KEYS = {

--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -8,4 +8,9 @@ This package contains the legacy Python implementation of FPDB-3.
 It is maintained for parity testing with the new Rust implementation.
 """
 
+import datetime
+
+if not hasattr(datetime, "UTC"):
+    datetime.UTC = datetime.timezone.utc
+
 __version__ = "3.2.0"

--- a/fpdb_3_legacy/aof_ranges.py
+++ b/fpdb_3_legacy/aof_ranges.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = getattr(datetime, "UTC", timezone.utc)
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Protocol
 

--- a/fpdb_3_legacy/aof_ranges.py
+++ b/fpdb_3_legacy/aof_ranges.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Protocol
 

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -15,6 +15,10 @@
 # In the "official" distribution you can find the license in agpl-3.0.txt.
 
 import sys
+import datetime
+
+if not hasattr(datetime, "UTC"):
+    datetime.UTC = datetime.timezone.utc
 
 from fpdb_3_legacy.subprocess_launch import dispatch_run_module
 

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -14,9 +14,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 # In the "official" distribution you can find the license in agpl-3.0.txt.
 
-import sys
 import datetime
+import sys
 
+# The packaged builds embed CPython 3.10.14 (PyOxidizer 0.24 cannot link 3.11+),
+# where datetime.UTC does not exist. Install the alias before importing anything
+# that reads it. fpdb_3_legacy/__init__.py does the same for every other entry
+# point; this covers the frozen executable, whose __main__ is this file.
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -17,7 +17,9 @@ import threading
 from collections import Counter
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = getattr(datetime, "UTC", timezone.utc)
 from decimal import Decimal
 from pathlib import Path
 from typing import BinaryIO

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -19,7 +19,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 from decimal import Decimal
 from pathlib import Path
 from typing import BinaryIO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,12 @@ ignore = [
     "E501",
     "E731",
     "E713",
+    # UP017 rewrites `timezone.utc` to `datetime.UTC`, which requires 3.11.
+    # requires-python says >=3.11, but the shipped binaries do not run on it:
+    # PyOxidizer 0.24 cannot link CPython 3.11+ and embeds 3.10.14 (see
+    # pyoxidizer.bzl), where `datetime.UTC` does not exist. Applying this rule
+    # would reintroduce the exact import that breaks every packaged build.
+    "UP017",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/test/test_BovadaToFpdb.py
+++ b/test/test_BovadaToFpdb.py
@@ -5,7 +5,9 @@ various game types including Hold'em, Omaha, and Stud variants.
 """
 
 import unittest
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = getattr(datetime, "UTC", timezone.utc)
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace

--- a/test/test_BovadaToFpdb.py
+++ b/test/test_BovadaToFpdb.py
@@ -7,7 +7,7 @@ various game types including Hold'em, Omaha, and Stud variants.
 import unittest
 from datetime import datetime, timezone
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace

--- a/test/test_assemble_hands.py
+++ b/test/test_assemble_hands.py
@@ -2,7 +2,9 @@
 
 import sys
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = getattr(datetime, "UTC", timezone.utc)
 from decimal import Decimal
 from pathlib import Path
 

--- a/test/test_assemble_hands.py
+++ b/test/test_assemble_hands.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Callable
 from datetime import datetime, timezone
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 from decimal import Decimal
 from pathlib import Path
 

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 
 from fpdb_3_legacy.swc_native_capture import (
     NativeAnimationEvent,

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -2,12 +2,11 @@ import io
 import struct
 import threading
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
 
-# datetime.UTC only exists on Python 3.11+; the project targets >=3.10.
-UTC = UTC
+UTC = getattr(datetime, "UTC", timezone.utc)
 
 from fpdb_3_legacy.swc_native_capture import (
     NativeAnimationEvent,


### PR DESCRIPTION
Fixes #183

### Summary of Changes
- Added  compatibility polyfill in `fpdb_3_legacy/__init__.py` and `fpdb.pyw` for Python 3.10 environments (PyOxidizer 0.24).
- Replaced direct `from datetime import UTC` imports and `datetime.UTC` accesses with `timezone.utc` fallbacks.
- Verified test suite passes without regressions.