### PR TITLE
fix(partypoker): support modern hand history format and multi-hand splitting (fixes #187)

### DIFF
--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -293,14 +293,11 @@ class PartyPoker(HandHistoryConverter):
     # winner it carries their own uncalled bet back. Every other room reports the
     # pot alone (PokerStars prints the return on its own line and keeps it out of
     # both "collected" and "Total pot"), and Hand.addUncalled removes it from the
-    # pot to match. These two let readCollectPot tell the pot from the surplus.
+    # pot to match. This lets readCollectPot tell the pot from the surplus.
     re_AnnouncedPot = re.compile(
         r"^\s*(?:Main|Side)\s+Pot(?:\s+\d+)?\s*:\s*[$€£]?\s*(?P<POT>[.,\d]+)",
         re.MULTILINE | re.IGNORECASE,
     )
-    # A cash-out pays insurance money that never sat in the pot, so there the
-    # surplus is real and must not be mistaken for an uncalled bet.
-    re_CashedOut = re.compile(r"Cash-?out|Cashed\s+out", re.IGNORECASE)
     re_identify = re.compile(r"\*{5}\sHand\sHistory\s[fF]or\sGame\s\w+")
     # Hands are normally preceded by a "Game #N starts. / #Game No : N" banner.
     # Some exports (e.g. tournament STT histories) omit the banner and simply
@@ -449,6 +446,11 @@ class PartyPoker(HandHistoryConverter):
                 "re_HeroCards": rf"Dealt to {subst['PLYR']} \[\s*(?P<NEWCARDS>.+)\s*\]",
                 "re_ShownCards": rf"{subst['PLYR']}(?: (?P<SHOWED>(?:doesn\'t )?shows?)|(?:\s+Cashed\s+out)?\s+balance\s+[^\[\n]+)\s*\[\s*(?P<CARDS>[A-Za-z0-9,\s]+?)\s*\](?:\s*\[\s*|\s*)(?P<COMBINATION>[^\]\n\.]*?)(?:\s*\]|\.|\s*$)",
                 "re_CollectPot": rf"{subst['PLYR']}(?:\s+wins\s+(?:Lo\s\()?|(?:\s+Cashed\s+out)?\s+balance\s+[^,\n]+,\s*(?:bet\s+[^,\n]+,\s*)?collected\s+){subst['CUR_SYM']}?(?P<POT>[.,\d]+)",
+                # The body announces a cash-out before the summary does, the way
+                # GGPoker prints "Receives Cashout". This is what tells the two
+                # kinds of money apart: the summary line looks identical either
+                # way, so without it an insurance payout reads as pot winnings.
+                "re_CashOutAmount": rf"^{subst['PLYR']}\s+Cashout\s+Amount\s+is\s+{subst['CUR_SYM']}?(?P<AMOUNT>[.,\d]+)",
             }
 
             try:
@@ -1628,11 +1630,19 @@ class PartyPoker(HandHistoryConverter):
 
         hand.setUncalledBets(True)
 
+        cashed_out = self._read_cash_outs(hand)
         remaining = self._announced_pot_total(hand)
 
         for m in self.re_CollectPot.finditer(hand.handText):
             player = m.group("PNAME")
             pot = Decimal(self.clearMoneyString(m.group("POT")))
+
+            if player in cashed_out:
+                # Insurance money that never sat in the pot. DerivedStats keeps
+                # it in its own column precisely so it is not counted as pot
+                # winnings; it is recorded by _read_cash_outs above.
+                log.debug("PartyPoker: %s cashed out %s, not pot winnings", player, pot)
+                continue
 
             if remaining is not None:
                 # Hand.totalPot() decides what to do with a lone unmatched bet by
@@ -1663,15 +1673,32 @@ class PartyPoker(HandHistoryConverter):
 
         log.info("Exiting readCollectPot method")
 
-    def _announced_pot_total(self, hand) -> Decimal | None:
-        """Total of the summary's announced pots, or None when it cannot be used.
+    def _read_cash_outs(self, hand) -> set[str]:
+        """Record each player's cash-out and return who took one.
 
-        Returns None for a cash-out hand: the insurance payout never sat in the
-        pot, so the surplus over the announced total is real money owed to the
-        player rather than a bet nobody called.
+        Same model as GGPoker: the payout goes to hand.cashOutAmounts, which
+        DerivedStats carries to HandsPlayers.cashOutAmount/isCashOut and the
+        HandsCashout table, and it stays out of the pot.
+
+        The fee is left alone. PartyPoker prints "Cash-out Premium % is 1.0", a
+        rate whose base is not stated -- and the summary reconciles without it
+        (bet 20.20, collected 23.01, net +2.81), so there is nothing to derive.
+        Recording a guessed figure in a money column would be worse than none.
         """
-        if self.re_CashedOut.search(hand.handText):
-            return None
+        cashed_out: set[str] = set()
+        for m in self.re_CashOutAmount.finditer(hand.handText):
+            player = m.group("PNAME")
+            amount = Decimal(self.clearMoneyString(m.group("AMOUNT")))
+            hand.cashOutAmounts[player] = amount
+            cashed_out.add(player)
+            log.debug("PartyPoker: %s cashed out for %s", player, amount)
+
+        if cashed_out:
+            hand.cashedOut = True
+        return cashed_out
+
+    def _announced_pot_total(self, hand) -> Decimal | None:
+        """Total of the summary's announced pots, or None when it cannot be used."""
 
         pots = [Decimal(self.clearMoneyString(m.group("POT"))) for m in self.re_AnnouncedPot.finditer(hand.handText)]
         return sum(pots) if pots else None

--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -289,7 +289,7 @@ class PartyPoker(HandHistoryConverter):
         r"Total\s+number\s+of\s+players\s*:\s*(?P<COUNTED_SEATS>\d+)",
         re.MULTILINE,
     )
-    re_identify = re.compile(r"\*{5}\sHand\sHistory\s[fF]or\sGame\s\d+\w+?\s")
+    re_identify = re.compile(r"\*{5}\sHand\sHistory\s[fF]or\sGame\s\w+")
     # Hands are normally preceded by a "Game #N starts. / #Game No : N" banner.
     # Some exports (e.g. tournament STT histories) omit the banner and simply
     # separate bare "***** Hand History for Game N *****" headers with blank
@@ -297,7 +297,7 @@ class PartyPoker(HandHistoryConverter):
     # one chunk that fails identification (many markers => isPartial count != 1).
     re_SplitHands = re.compile(
         r"Game\s*\#\d+\s*starts.\n\n+\#Game\s*No\s*\:\s*\d+\s*"
-        r"|\n\n+(?=\*\*\*\*\*\sHand\sHistory\sfor\sGame)"
+        r"|\n\n+(?=\*\*\*\*\*\sHand\sHistory\s[fF]or\sGame)"
     )
     re_TailSplitHands = re.compile("(\x00+)")
     lineSplitter = "\n"
@@ -435,8 +435,8 @@ class PartyPoker(HandHistoryConverter):
                 "re_Antes": rf"{subst['PLYR']} posts ante(?: of)? [\[\(\)\]]?{subst['CUR_SYM']}?(?P<ANTE>[.,0-9]+)\s*({subst['CUR']})?[\[\(\)\]]?\.?\s*$",
                 "re_Action": r"""(?P<PNAME>.+?)\s(?P<ATYPE>bets|checks|raises|completes|bring-ins|calls|folds|is\sall-In|double\sbets)(?:\s*[\[\(\)\]]?\s?(€|\$)?(?P<BET>[.,\d]+)\s*(EUR|DOL)?\s*[\]\)]?)?(?:\sto\s[.,\d]+)?\.?\s*$""",
                 "re_HeroCards": rf"Dealt to {subst['PLYR']} \[\s*(?P<NEWCARDS>.+)\s*\]",
-                "re_ShownCards": rf"{subst['PLYR']} (?P<SHOWED>(?:doesn\'t )?shows?) \[ *(?P<CARDS>.+) *\](?P<COMBINATION>.+)\.",
-                "re_CollectPot": rf"{subst['PLYR']}\s+wins\s+(Lo\s\()?{subst['CUR_SYM']}?(?P<POT>[.,\d]+)\s*({subst['CUR']})?\)?",
+                "re_ShownCards": rf"{subst['PLYR']}(?: (?P<SHOWED>(?:doesn\'t )?shows?)|(?:\s+Cashed\s+out)?\s+balance\s+[^\[\n]+)\s*\[\s*(?P<CARDS>[A-Za-z0-9,\s]+?)\s*\](?:\s*\[\s*|\s*)(?P<COMBINATION>[^\]\n\.]*?)(?:\s*\]|\.|\s*$)",
+                "re_CollectPot": rf"{subst['PLYR']}(?:\s+wins\s+(?:Lo\s\()?|(?:\s+Cashed\s+out)?\s+balance\s+[^,\n]+,\s*(?:bet\s+[^,\n]+,\s*)?collected\s+){subst['CUR_SYM']}?(?P<POT>[.,\d]+)",
             }
 
             try:

--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -46,6 +46,7 @@ class PartyPoker(HandHistoryConverter):
     re_PostDead: Any
     re_HeroCards: Any
     re_CollectPot: Any
+    re_CashOutAmount: Any
     re_ShownCards: Any
     db: Any
     sitename = "PartyPoker"
@@ -1701,7 +1702,7 @@ class PartyPoker(HandHistoryConverter):
         """Total of the summary's announced pots, or None when it cannot be used."""
 
         pots = [Decimal(self.clearMoneyString(m.group("POT"))) for m in self.re_AnnouncedPot.finditer(hand.handText)]
-        return sum(pots) if pots else None
+        return sum(pots, Decimal(0)) if pots else None
 
     def readShownCards(self, hand) -> None:
         log.info("Entering readShownCards method")

--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -289,6 +289,18 @@ class PartyPoker(HandHistoryConverter):
         r"Total\s+number\s+of\s+players\s*:\s*(?P<COUNTED_SEATS>\d+)",
         re.MULTILINE,
     )
+    # The summary's "collected" is what the player took off the table, so for the
+    # winner it carries their own uncalled bet back. Every other room reports the
+    # pot alone (PokerStars prints the return on its own line and keeps it out of
+    # both "collected" and "Total pot"), and Hand.addUncalled removes it from the
+    # pot to match. These two let readCollectPot tell the pot from the surplus.
+    re_AnnouncedPot = re.compile(
+        r"^\s*(?:Main|Side)\s+Pot(?:\s+\d+)?\s*:\s*[$€£]?\s*(?P<POT>[.,\d]+)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    # A cash-out pays insurance money that never sat in the pot, so there the
+    # surplus is real and must not be mistaken for an uncalled bet.
+    re_CashedOut = re.compile(r"Cash-?out|Cashed\s+out", re.IGNORECASE)
     re_identify = re.compile(r"\*{5}\sHand\sHistory\s[fF]or\sGame\s\w+")
     # Hands are normally preceded by a "Game #N starts. / #Game No : N" banner.
     # Some exports (e.g. tournament STT histories) omit the banner and simply
@@ -1616,16 +1628,53 @@ class PartyPoker(HandHistoryConverter):
 
         hand.setUncalledBets(True)
 
+        remaining = self._announced_pot_total(hand)
+
         for m in self.re_CollectPot.finditer(hand.handText):
             player = m.group("PNAME")
-            pot = self.clearMoneyString(m.group("POT"))
-            hand.addCollectPot(player=player, pot=pot)
+            pot = Decimal(self.clearMoneyString(m.group("POT")))
+
+            if remaining is not None:
+                # Hand.totalPot() decides what to do with a lone unmatched bet by
+                # comparing what was collected against the pot: collected too high
+                # and it builds an extra solo pot instead of returning the bet.
+                # Feeding it the player's own money back therefore inflated the
+                # pot by exactly the uncalled amount. Keep the pot share here and
+                # let that machinery return the rest, as it already does for every
+                # room whose history omits an "Uncalled bet returned" line.
+                share = min(pot, remaining)
+                remaining -= share
+                if share != pot:
+                    log.debug(
+                        "PartyPoker: %s collected %s of an announced %s pot; "
+                        "leaving %s to be returned as an uncalled bet",
+                        player,
+                        share,
+                        pot,
+                        pot - share,
+                    )
+                pot = share
+
+            hand.addCollectPot(player=player, pot=str(pot))
 
             log.debug(
                 f"Player collected pot method: PartyPoker:readCollectPot, player: {player}, amount: {pot}",
             )
 
         log.info("Exiting readCollectPot method")
+
+    def _announced_pot_total(self, hand) -> Decimal | None:
+        """Total of the summary's announced pots, or None when it cannot be used.
+
+        Returns None for a cash-out hand: the insurance payout never sat in the
+        pot, so the surplus over the announced total is real money owed to the
+        player rather than a bet nobody called.
+        """
+        if self.re_CashedOut.search(hand.handText):
+            return None
+
+        pots = [Decimal(self.clearMoneyString(m.group("POT"))) for m in self.re_AnnouncedPot.finditer(hand.handText)]
+        return sum(pots) if pots else None
 
     def readShownCards(self, hand) -> None:
         log.info("Entering readShownCards method")

--- a/test/test_partypoker_parser_debt.py
+++ b/test/test_partypoker_parser_debt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -184,3 +185,27 @@ Player3 balance $85.96, didn't bet (folded)
     assert ["Player1", "1.09"] in hand2.collected
     assert "Player1" in hand2.shown
 
+
+
+def test_the_summary_collected_keeps_its_uncalled_bet_out_of_the_pot() -> None:
+    """PartyPoker's "collected" is what left the table, not the pot won.
+
+    Every other room reports the pot alone -- PokerStars prints "Uncalled bet
+    returned" on its own line and keeps it out of both "collected" and "Total
+    pot" -- and Hand.addUncalled removes it from the pot to match. Passing the
+    summary figure through unchanged made Hand.totalPot() see more collected
+    than the announced pot and build an extra solo pot from the difference,
+    inflating the pot by exactly the bet nobody called.
+
+    In this hand Player3 bets 0.13 on the flop, Player6 folds, and the summary
+    reads "bet $0.21, collected $0.31, net +$0.1" against "Main Pot: $0.18".
+    """
+    from fpdb_3_legacy.Configuration import Config
+
+    path = CASH / "NLHE-USD-0.01-0.02-20100712.emailedHistory.txt"
+    hand = PartyPoker(config=Config(), in_path=str(path), autostart=True).getProcessedHands()[0]
+
+    assert hand.totalpot == Decimal("0.18")  # the announced pot, not the 0.31 collected
+    assert hand.rake == Decimal("0.00")  # the file says "Rake: $0"
+    assert hand.collectees["Player3"] == Decimal("0.18")
+    assert hand.pot.returned["Player3"] == Decimal("0.13")  # the uncalled flop bet

--- a/test/test_partypoker_parser_debt.py
+++ b/test/test_partypoker_parser_debt.py
@@ -173,10 +173,21 @@ Player3 balance $85.96, didn't bet (folded)
     hand1 = parser.processHand(hands_list[0])
     assert hand1.handid == "1770659766668"
     assert hand1.hero == "Hero"
-    assert ["Player2", "23.01"] in hand1.collected
-    assert ["Hero", "41.47"] in hand1.collected
     assert "Player2" in hand1.shown
     assert "Hero" in hand1.shown
+
+    # The summary reports what left the table, which is two different kinds of
+    # money here. Player2's 23.01 is an insurance payout that never sat in the
+    # pot, and Hero's 41.47 is the 38.50 pot plus the 2.97 of his own bet that
+    # Player2, all-in for less, could not call. Recording either as pot winnings
+    # is what GGPoker's readCollectPot calls out: "cashouts are separate
+    # transactions that don't affect the main pot distribution".
+    assert hand1.cashedOut is True
+    assert hand1.cashOutAmounts["Player2"] == Decimal("23.01")
+    assert "Player2" not in dict(hand1.collected)  # insurance, not the pot
+    assert ["Hero", "38.50"] in hand1.collected
+    assert hand1.pot.returned["Hero"] == Decimal("2.97")
+    assert hand1.totalpot - hand1.rake == Decimal("38.50")  # the announced Main Pot
 
     # Process hand 2
     hand2 = parser.processHand(hands_list[1])

--- a/test/test_partypoker_parser_debt.py
+++ b/test/test_partypoker_parser_debt.py
@@ -83,3 +83,104 @@ def test_play_money_ring_is_not_read_as_a_real_currency() -> None:
 
     assert game_type["type"] == "ring"
     assert game_type["currency"] == "play"
+
+
+def test_partypoker_modern_hh_summary_and_splitting() -> None:
+    from fpdb_3_legacy.Configuration import Config
+
+    sample_hands = """***** Hand History For Game 1770659766668adeb0h5qfm *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Feb 09 12:55:26 EST 2026
+Table Table 7488952 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($56.64)
+Seat 2: Player1 ($19.93)
+Seat 3: Player2 ($20.20)
+Seat 4: Hero ($25.86)
+Player1 posts small blind (0.10)
+Player2 posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ 9c, 7h, 8h, 4d ]
+Hero raises 0.85 to 0.85
+Player4 folds
+Player1 folds
+Player2 raises 2.40 to 2.65
+Hero calls (1.80)
+** Dealing Flop ** : [ Jc, 7d, 6c ]
+Player2 bets (5.13)
+Hero raises 20.52 to 20.52
+Player2 calls (12.42)
+Player2 is all-In.
+Creating Main Pot with $ 38.50 with Player2, Hero
+Player2 Cash-out Premium % is 1.0
+Player2 opted for cash-out
+Player2 probabilty is 60.37
+Player2 Cashout Amount is 23.01
+** Dealing Turn ** : [ Ts ]
+** Dealing River ** : [ Js ]
+** Summary **
+Main Pot: $38.50 Rake: $2.0
+Board: [ Jc, 7d, 6c, Ts, Js ]
+Player4 balance $56.64, didn't bet (folded)
+Player1 balance $19.83, lost $0.10 (folded)
+Player2 Cashed out balance $23.01, bet $20.20, collected $23.01, net +$2.81[ Tc, Ac, Ad, 4c ] [ two pairs, aces and jacks -- Ac,Ad,Jc,Js,Ts ]
+Hero balance $44.16, bet $23.17, collected $41.47, net +$18.30[ 9c, 7h, 8h, 4d ] [ a straight, seven to jack -- Jc,Ts,9c,8h,7d ]
+
+***** Hand History For Game 1784559729098bywbird3xlj *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:01:17 EDT 2026
+Table Table 7490030 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($113.97)
+Seat 2: Player1 ($12.60)
+Seat 3: Hero ($51.56)
+Seat 4: Player3 ($85.96)
+Player1 posts small blind (0.10)
+Hero posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ 7s, Tc, 5c, Jh ]
+Player3 folds
+Player4 folds
+Player1 calls (0.15)
+Hero checks
+** Dealing Flop ** : [ 8d, 5s, 8h ]
+Player1 checks
+Hero checks
+** Dealing Turn ** : [ 2c ]
+Player1 bets (0.32)
+Hero calls (0.32)
+** Dealing River ** : [ 6s ]
+Player1 checks
+Hero checks
+** Summary **
+Main Pot: $1.09 Rake: $0.05
+Board: [ 8d, 5s, 8h, 2c, 6s ]
+Player4 balance $113.97, didn't bet (folded)
+Player1 balance $13.12, bet $0.57, collected $1.09, net +$0.52[ 9s, 4d, 8s, Jc ] [ three of a kind, eights -- Jc,8s,8d,8h,6s ]
+Hero balance $50.99, lost $0.57[ 7s, Tc, 5c, Jh ] [ two pairs, eights and fives -- Jh,8d,8h,5c,5s ]
+Player3 balance $85.96, didn't bet (folded)
+"""
+
+    config = Config()
+    parser = PartyPoker(config, autostart=False)
+    parser.obs = sample_hands
+    parser.in_path = "test.txt"
+    parser.readFile = lambda: None
+
+    hands_list = parser.allHandsAsList()
+    assert len(hands_list) == 2
+
+    # Process hand 1 (Cashout & Showdown)
+    hand1 = parser.processHand(hands_list[0])
+    assert hand1.handid == "1770659766668"
+    assert hand1.hero == "Hero"
+    assert ["Player2", "23.01"] in hand1.collected
+    assert ["Hero", "41.47"] in hand1.collected
+    assert "Player2" in hand1.shown
+    assert "Hero" in hand1.shown
+
+    # Process hand 2
+    hand2 = parser.processHand(hands_list[1])
+    assert hand2.handid == "1784559729098"
+    assert hand2.hero == "Hero"
+    assert ["Player1", "1.09"] in hand2.collected
+    assert "Player1" in hand2.shown
+

--- a/tests/fixtures/hands/live_parser_snapshots.json
+++ b/tests/fixtures/hands/live_parser_snapshots.json
@@ -1441,7 +1441,7 @@
   },
   "regression/PartyPoker/Flop/NLHE-USD-0.01-0.02-20100712.emailedHistory.txt": {
     "hand_count": 1,
-    "sha256": "d08d48800d920b2745e003b97f14b5013c94fd80cf81e0aaf642c95d861bffb4"
+    "sha256": "d4f105ec493039d7c94dac8923895d8ad0e894e92ea5cb3698088a456a8a1398"
   },
   "regression/PartyPoker/Flop/NLHE-USD-0.01-0.02-20100731.bigBlindIsForcedAllIn.txt": {
     "hand_count": 1,
@@ -1759,7 +1759,7 @@
     "hand_count": 1,
     "sha256": "11ceae2a8be3ebfa09e2ec63e1a9fa2b32ce0d667f66fe502a2d0701a4c77f9a"
   },
-  "regression/Stars/Flop/HH20100819 Vibilia II - $0,02-$0,04 - USD Лимит Холдем.txt": {
+  "regression/Stars/Flop/HH20100819 Vibilia II - $0,02-$0,04 - USD \u041b\u0438\u043c\u0438\u0442 \u0425\u043e\u043b\u0434\u0435\u043c.txt": {
     "hand_count": 1,
     "sha256": "315ecfabb64056cc8f4567a8571ac6d8021bf8a5ae87233d0faab38b0cb438fd"
   },


### PR DESCRIPTION
Fixes #187

### Summary of Changes
1. **Multi-hand file splitting**: Updated `re_SplitHands` lookahead to `(?=\*\*\*\*\*\sHand\sHistory\s[fF]or\sGame)` and simplified `re_identify` to match `***** Hand History For Game ... *****` headers regardless of casing or extra character combinations.
2. **Shown cards regex (`re_ShownCards`)**: Extended pattern to match modern PartyPoker summary lines with showdown cards (`[ cards ] [ combination ]`) and cashout balance lines.
3. **Pot collection regex (`re_CollectPot`)**: Extended pattern to match modern PartyPoker summary lines (`collected $...` / `collected ...` / `Cashed out balance ...`).
4. **Tests**: Added unit test `test_partypoker_modern_hh_summary_and_splitting` in `test/test_partypoker_parser_debt.py` covering modern hand history parsing and multi-hand file splitting.