### PR TITLE
test-refactor(parser): remove uncalledbets deadcode and add real hand tests

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,207 @@
+# Backlog
+
+État au 2026-08-06, après la 3.4.1. Chaque tâche porte la preuve qui l'a fait
+remonter, de quoi la vérifier, et ce qui peut mal tourner.
+
+Ordonné par rendement : ce qui lève un risque réel pour peu de travail d'abord.
+
+---
+
+## 1. Purger la liste `known_failures` — les 10 tests passent
+
+**Problème.** `tests/conftest.py:95` marque 10 tests en `xfail` via une liste
+codée en dur, avec le motif « Known legacy failure present in master branch ».
+Les 10 passent aujourd'hui.
+
+Le hook `pytest_collection_modifyitems` est au niveau session : il s'applique
+donc aussi aux fichiers de `test/`, pas seulement à `tests/`. D'où les 9 `XPASS`
+de chaque exécution ; le dixième
+(`test_rangechartpopup_is_popup_subclass`) porte le marqueur `qt` et n'apparaît
+pas dans la suite par défaut.
+
+**Pourquoi ça compte.** Ces `xfail` ne sont pas `strict`. Une régression réelle
+sur l'un de ces 10 tests serait rapportée comme échec *attendu*, et la CI
+resterait verte. Dix tests protègent donc actuellement du vide.
+
+**À faire.** Supprimer le bloc `known_failures` et le `add_marker` associé. Si
+un test s'avère réellement instable, le marquer individuellement dans son
+fichier avec `strict=True` et une raison datée — pas dans une liste centrale
+que personne ne relit.
+
+**Vérifier.**
+
+```bash
+python -m pytest test tests -q -rX
+```
+
+Zéro `XPASS` attendu, et le total de `passed` augmente de 9.
+
+**Risque.** Faible. Si un test échoue vraiment après retrait, c'est une
+information qu'on n'avait pas.
+
+---
+
+## 2. `uncalledbets` : un signal écrit 37 fois, jamais lu
+
+**Problème.** 16 parsers appellent `hand.setUncalledBets(...)` et
+`fpdb_3_legacy/iPoker/base.py` écrit l'attribut directement. Le setter est
+`Hand.py:1444`, l'initialisation `Hand.py:143`. Aucune lecture nulle part :
+
+```bash
+git grep -n "uncalledbets" -- '*.py' '*.pyw' | grep -vE "uncalledbets\s*="
+```
+
+ne retourne rien.
+
+**Pourquoi ça compte.** Les parsers signalent si la room a déjà retiré les mises
+non suivies, et le signal est jeté. C'est exactement la décision que
+`Hand.totalPot()` prend à l'aveugle dans `handle_leftover` (`Hand.py:1555`) en
+comparant `totalcollected` au pot — la logique qui s'est mal branchée sur
+PartyPoker et a fait enregistrer un pot entier en rake pendant des mois.
+
+**Attention.** Le rapprochement est plausible, pas démontré. Avant de câbler le
+drapeau sur `handle_leftover`, il faut retracer l'intention d'origine : le
+comportement actuel est *deviné* mais correct sur les 85 goldens PartyPoker et
+tout le corpus. Deux issues défendables :
+
+- brancher le drapeau et vérifier qu'aucun golden ne bouge (s'il en bouge, on
+  aura trouvé d'autres rooms mal parsées) ;
+- ou constater qu'il ne sert plus et supprimer les 37 appels plus le setter.
+
+Ce qu'il ne faut pas faire : le laisser en l'état, où il donne l'illusion d'un
+mécanisme actif.
+
+**Vérifier.** Suite complète plus les goldens, avant/après :
+
+```bash
+python -m pytest test/test_live_parser_regression.py -q
+```
+
+**Risque.** Moyen si on câble : touche la comptabilité des pots de toutes les
+rooms. Nul si on supprime.
+
+---
+
+## 3. 12 tests `perf` n'ont aucun point d'exécution
+
+**Problème.** `test/test_popup_performance.py` porte `pytestmark =
+pytest.mark.perf`. `pytest.ini` déselectionne `perf` dans ses `addopts`, et les
+deux invocations pytest de la CI (`.github/workflows/ci.yml:348` et `:416`)
+portent `-m "not qt and not perf"`. Aucune étape ne les lance — contrairement
+aux tests `qt`, qui ont la leur.
+
+**État.** Ils passent aujourd'hui (12/12, vérifié le 2026-08-06), mais rien ne
+le garantirait s'ils cessaient de le faire.
+
+**À faire.** Soit ajouter une étape CI `-m perf` sur le modèle de l'étape `qt`,
+soit les supprimer. Un test de performance sans seuil ni exécution ne mesure
+rien.
+
+**Vérifier.**
+
+```bash
+QT_QPA_PLATFORM=offscreen python -m pytest -m perf -q
+```
+
+**Risque.** Faible. À noter s'ils entrent en CI : ce sont des mesures de temps,
+donc sensibles à la charge du runner. Prévoir des seuils larges.
+
+---
+
+## 4. iPoker : mains dupliquées sur les bases déjà importées
+
+**Problème.** Le correctif du hand id iPoker (2026-07-25) a déplacé
+`re_hand_info` de `sessioncode="…"` vers `gamecode="…"` — le premier motif
+matchait aussi l'en-tête `<session sessioncode="…">` qui ouvre chaque fichier,
+donnant à la première main de chaque fichier l'identifiant de session. Mesuré à
+l'époque : 9 fichiers sur 9 touchés.
+
+**Ce qui reste.** Le code est corrigé, **les données ne le sont pas**. Sur une
+base déjà importée, la première main de chaque fichier iPoker porte encore
+l'ancien identifiant. Un ré-import l'insère sous le bon sans écraser l'ancienne
+ligne : une main dupliquée par fichier importé.
+
+Aucun script ne traite ça — les trois `backfill_*` couvrent boards, showdown et
+autonotes, pas les identifiants.
+
+**À faire.** Un script de maintenance qui repère, pour chaque fichier iPoker
+importé, la main dont le `siteHandNo` égale un `sessioncode` du corpus, et la
+supprime ou la réconcilie. À faire tourner une fois, avec un mode `--dry-run`.
+
+**Risque.** Élevé : il supprime des lignes en base. Impose un `--dry-run` par
+défaut, un décompte affiché avant action, et une sauvegarde documentée.
+
+---
+
+## 5. Découpage de `Database.py` — arrêté en cours de route
+
+**État.** 2 413 lignes, plancher de couverture 48,6 % (`coverage-baseline.json`).
+C'était le seul chantier explicitement marqué « en cours » dans les plans
+supprimés. Plusieurs domaines ont bien été extraits — `database_bulk_import`,
+`database_caches`, `database_hud_stats`, `database_schema`,
+`database_tournaments` — mais l'hôte reste gros.
+
+**À faire.** Poursuivre par domaine, en vérifiant à chaque extraction que le
+cliquet de complexité de `pyproject.toml` ne grossit pas : une extraction
+déplace la dette, elle ne doit pas en créer.
+
+```bash
+ruff check --select C901,PLR0912,PLR0915 --isolated <fichiers>
+```
+
+**Risque.** Moyen. `Database.py` est au centre de l'import et du HUD ; toute
+extraction doit laisser la suite complète verte.
+
+---
+
+## 6. Couverture du domaine `gui` — 37 %, le plus bas
+
+**État.** `coverage-baseline.json` donne 37,0 % pour `gui`, contre 83,6 % pour
+`poker-domain` et 86,6 % pour `platform-pkg`. Tiré vers le bas par les points
+d'entrée : `fpdb.pyw`, `GuiSessionViewer`, `GuiLogView`,
+`GuiAutoNotesWorkbench`, `ModernSeatPreferences`.
+
+**À faire.** Cibler ce qui est testable sans fenêtre : la logique de sélection,
+de formatage et de filtrage, en la séparant du câblage Qt. Le harnais `qt`
+offscreen existe déjà et tourne en CI.
+
+**Risque.** Faible, mais le rendement décroît vite — l'essentiel du code GUI
+restant est du câblage.
+
+---
+
+## 7. Points en attente de validation live
+
+Ni corrigeables ni vérifiables sans une session de jeu réelle :
+
+- **Bug PokerStars cash sous Windows** — durci, jamais confirmé. Les trois
+  autres bugs de la même série sont validés.
+- **Synthèse ring iPoker** (PMU / bwin 6-max).
+- **Ancrage bas-centre du HUD** sur un Twister 2/3-max.
+
+À traiter quand l'occasion se présente ; rien à faire d'ici là.
+
+---
+
+## 8. Traductions
+
+13 des 14 locales livrées ne sont pas traduites — seul le français l'est. Le
+pipeline gettext, le sélecteur de langue et l'extraction fonctionnent : il ne
+manque que le contenu des catalogues. Tâche de traduction, pas de
+développement.
+
+---
+
+## Vérifié comme fait, malgré ce que disaient les plans supprimés
+
+Relu depuis l'historique git avant suppression :
+
+- **i18n** — `modern_hud_preferences/` porte 167 appels `_()`, et les libellés
+  écrits en dur en français dans `ring_stats/` ont disparu.
+- **Scripts d'exploitation** — passés de 0 % à un plancher de 44,5 %
+  (`tests/test_maintenance_scripts.py`).
+- **Hand id iPoker** — corrigé côté code ; seule la migration des données reste
+  (tâche 4).
+- **Version affichée par les binaires** — l'ancien repli `"3.0.0alpha"` de
+  `fpdb.pyw` a été supprimé en `a5c3a435` ; `_resolve_version()` retombe sur
+  `fpdb_3_legacy.__version__`.

--- a/fpdb_3_legacy/AbsoluteToFpdb.py
+++ b/fpdb_3_legacy/AbsoluteToFpdb.py
@@ -391,7 +391,6 @@ class Absolute(HandHistoryConverter):
             hand.addBlind(None, None, None)
         for a in self.re_PostBB.finditer(hand.handText):
             hand.addBlind(a.group("PNAME"), "big blind", a.group("BB"))
-            hand.setUncalledBets(True)
             found_big = True
         for a in self.re_PostIncoming.finditer(hand.handText):
             hand.addBlind(a.group("PNAME"), "big blind", a.group("BB"))
@@ -407,12 +406,10 @@ class Absolute(HandHistoryConverter):
                     bet = acts["BET"].replace(",", "")
                     if found_small:
                         hand.addBlind(acts["PNAME"], "big blind", bet)
-                        hand.setUncalledBets(True)
                     elif found_big:
                         hand.addBlind(acts["PNAME"], "small blind", bet)
 
         for a in self.re_PostBoth.finditer(hand.handText):
-            hand.setUncalledBets(None)
             hand.addBlind(a.group("PNAME"), "both", a.group("BB"))
 
     def readButton(self, hand):
@@ -471,22 +468,18 @@ class Absolute(HandHistoryConverter):
                 hand.addCheck(street, action.group("PNAME"))
             elif action.group("ATYPE") == "Calls ":
                 bet = action.group("BET").replace(",", "")
-                hand.setUncalledBets(None)
                 hand.addCall(street, action.group("PNAME"), bet)
             elif action.group("ATYPE") == "Bets " or action.group("ATYPE") == "All-In ":
                 if action.group("BET") is None:
                     # timeout all-in
                     raise FpdbHandPartial(f"Partial hand history: {hand.handid}")
                 bet = action.group("BET").replace(",", "")
-                hand.setUncalledBets(None)
                 hand.addBet(street, action.group("PNAME"), bet)
             elif action.group("ATYPE") == "Raises " or action.group("ATYPE") == "All-In(Raise) ":
                 bet = action.group("BET").replace(",", "")
-                hand.setUncalledBets(None)
                 hand.addCallandRaise(street, action.group("PNAME"), bet)
             elif action.group("ATYPE") == "Completes to ":
                 bet = action.group("BET").replace(",", "")
-                hand.setUncalledBets(None)
                 hand.addComplete(street, action.group("PNAME"), bet)
             else:
                 log.debug(

--- a/fpdb_3_legacy/BovadaToFpdb.py
+++ b/fpdb_3_legacy/BovadaToFpdb.py
@@ -1219,9 +1219,6 @@ class Bovada(HandHistoryConverter):
         Args:
             hand: The Hand object to update with blind information.
         """
-        if not self.re_return_bet.search(hand.handText):
-            hand.setUncalledBets(True)
-
         self._process_small_blinds(hand)
         self._process_big_blinds(hand)
         self._process_all_in_actions(hand)
@@ -1455,21 +1452,7 @@ class Bovada(HandHistoryConverter):
                     hand.handid,
                     action.group("PNAME"),
                 )
-                self._handle_uncalled_bets(hand, action)
                 self._process_action(hand, street, player, action)
-
-    def _handle_uncalled_bets(self, hand: "Hand", action: re.Match[str]) -> None:
-        """Handle uncalled bets for the hand.
-
-        This method checks the action type and updates the Hand object to indicate whether there are uncalled bets,
-        based on the current action and all-in blind status.
-
-        Args:
-            hand: The Hand object to update with uncalled bet information.
-            action: The regex match object representing the current action.
-        """
-        if action.group("ATYPE") not in self.ACTION_NO_UNCALLED_BETS and not hand.allInBlind:
-            hand.setUncalledBets(False)
 
     def _process_action(self, hand: "Hand", street: str, player: str, action: re.Match[str]) -> None:
         """Process and assign a specific player action for a given street.
@@ -1610,7 +1593,6 @@ class Bovada(HandHistoryConverter):
                 action.group("PNAME"),
             )
             if hand.stacks[player] == 0 and not self.re_return_bet.search(hand.handText):
-                hand.setUncalledBets(True)
                 hand.allInBlind = True
 
     def readShowdownActions(self, hand: "Hand") -> None:

--- a/fpdb_3_legacy/CakeToFpdb.py
+++ b/fpdb_3_legacy/CakeToFpdb.py
@@ -641,10 +641,6 @@ class Cake(HandHistoryConverter):
         # Flag to keep track of whether the small blind is still live.
         live_blind = True
 
-        # If no bets were returned, set the uncalled bets flag to True.
-        if not self.re_return_bet.search(hand.handText):
-            hand.setUncalledBets(True)
-
         # Find all instances of the small blind and add them to the Hand object.
         for a in self.re_post_sb.finditer(hand.handText):
             if live_blind:
@@ -724,9 +720,6 @@ class Cake(HandHistoryConverter):
             bet = self.convertMoneyString("BET", action)
             action_type = action.group("ATYPE")
 
-            # If the current action is a fold and not in preflop, add a fold to the Hand object
-            if street != "PREFLOP" or action_type != " folds":
-                hand.setUncalledBets(False)
             if action_type == " folds":
                 hand.addFold(street, action.group("PNAME"))
 
@@ -740,7 +733,6 @@ class Cake(HandHistoryConverter):
 
             # If the current action is a raise, add a raise to the Hand object
             elif action_type == " raises":
-                hand.setUncalledBets(None)
                 hand.addRaiseTo(street, action.group("PNAME"), bet)
 
             # If the current action is a bet, add a bet to the Hand object

--- a/fpdb_3_legacy/Hand.py
+++ b/fpdb_3_legacy/Hand.py
@@ -140,7 +140,6 @@ class Hand:
         self.counted_seats = 0
         self.buttonpos = 0
         self.runItTimes = 0
-        self.uncalledbets = False
         self.checkForUncalled = False
         self.adjustCollected = False
         self.cashedOut = False
@@ -1440,9 +1439,6 @@ class Hand:
             raise FpdbHandPartial(
                 msg,
             )
-
-    def setUncalledBets(self, value) -> None:
-        self.uncalledbets = value
 
     def calculate_net_collected(self) -> None:
         """Calculate the net collected amount for each player."""

--- a/fpdb_3_legacy/MergeToFpdb.py
+++ b/fpdb_3_legacy/MergeToFpdb.py
@@ -836,7 +836,6 @@ class Merge(HandHistoryConverter):
         pass
 
     def readCollectPot(self, hand) -> None:
-        hand.setUncalledBets(True)
         for m in self.re_CollectPot.finditer(hand.handText):
             pname = self.playerNameFromSeatNo(m.group("PSEAT"), hand)
             if pname is not None:

--- a/fpdb_3_legacy/MicrogamingToFpdb.py
+++ b/fpdb_3_legacy/MicrogamingToFpdb.py
@@ -444,7 +444,6 @@ class Microgaming(HandHistoryConverter):
                 else:
                     hand.addBet(street, pname, action.group("BET"))
             elif action.group("ATYPE") == "AllIn":
-                all_in_amount = action.group("BET").replace(",", "")
                 hand.addAllIn(street, pname, action.group("BET"))
                 allIns += 1
             elif action.group("ATYPE") == "PostedToPlay":

--- a/fpdb_3_legacy/MicrogamingToFpdb.py
+++ b/fpdb_3_legacy/MicrogamingToFpdb.py
@@ -258,8 +258,6 @@ class Microgaming(HandHistoryConverter):
             if key == "MAX" and info.get(key) is not None:
                 hand.maxseats = int(info[key])
 
-        hand.setUncalledBets(True)
-
     def readButton(self, hand):
         pass
         # m = self.re_Button.search(hand.handText)
@@ -411,8 +409,6 @@ class Microgaming(HandHistoryConverter):
         allIns = 0
         m = self.re_Action.finditer(hand.streets[street])
         for action in m:
-            if action.group("ATYPE") in ("Call", "Raise", "AllIn") and allIns > 0:
-                hand.setUncalledBets(False)
             # print "DEBUG: %s action.groupdict(): %s" % (street, action.groupdict())
             pname = self.playerNameFromSeatNo(action.group("SEAT"), hand)
             if action.group("ATYPE") == "Fold":
@@ -449,8 +445,6 @@ class Microgaming(HandHistoryConverter):
                     hand.addBet(street, pname, action.group("BET"))
             elif action.group("ATYPE") == "AllIn":
                 all_in_amount = action.group("BET").replace(",", "")
-                if Decimal(all_in_amount) <= (hand.lastBet[street] - sum(hand.bets[street][pname])):
-                    hand.setUncalledBets(False)
                 hand.addAllIn(street, pname, action.group("BET"))
                 allIns += 1
             elif action.group("ATYPE") == "PostedToPlay":

--- a/fpdb_3_legacy/PacificPokerToFpdb.py
+++ b/fpdb_3_legacy/PacificPokerToFpdb.py
@@ -527,8 +527,6 @@ class PacificPoker(HandHistoryConverter):
             hand.addBringIn(m.group("PNAME"), m.group("BRINGIN"))
 
     def readBlinds(self, hand) -> None:
-        if hasattr(hand, "startTime") and hasattr(hand, "newFormat") and hand.startTime < hand.newFormat:
-            hand.setUncalledBets(True)
         liveBlind, hand.allInBlind = True, False
         for a in self.re_PostSB.finditer(hand.handText):
             if a.group("PNAME") in hand.stacks:
@@ -642,8 +640,6 @@ class PacificPoker(HandHistoryConverter):
         m = self.re_Action.finditer(hand.streets[street])
         for action in m:
             action.groupdict()
-            if street not in ("PREFLOP", "DEAL"):
-                hand.setUncalledBets(False)
             # print "DEBUG: acts: %s" %acts
             bet = self.clearMoneyString(action.group("BET")) if action.group("BET") else None
             if action.group("PNAME") in hand.stacks:
@@ -672,8 +668,6 @@ class PacificPoker(HandHistoryConverter):
                     )
 
                 if action.group("ATYPE") not in (" checks", " folds") and not hand.allInBlind:
-                    if not (hand.stacks[action.group("PNAME")] == 0 and action.group("ATYPE") == " calls"):
-                        hand.setUncalledBets(False)
                     if hand.stacks[action.group("PNAME")] == 0 and action.group("ATYPE") == " raises":
                         hand.checkForUncalled = True
             else:
@@ -686,7 +680,6 @@ class PacificPoker(HandHistoryConverter):
         if street in ("PREFLOP", "DEAL") and hand.stacks[action.group("PNAME")] == 0:
             if actiontype == "ante":
                 if action.group("PNAME") in [p for (p, b) in hand.posted]:
-                    hand.setUncalledBets(False)
                     hand.checkForUncalled = True
                     hand.allInBlind = True
             elif actiontype in (
@@ -694,7 +687,6 @@ class PacificPoker(HandHistoryConverter):
                 "big blind",
                 "both",
             ) and not self.re_Antes.search(hand.handText):
-                hand.setUncalledBets(False)
                 hand.checkForUncalled = True
                 hand.allInBlind = True
 

--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -1629,8 +1629,6 @@ class PartyPoker(HandHistoryConverter):
     def readCollectPot(self, hand) -> None:
         log.info("Entering readCollectPot method")
 
-        hand.setUncalledBets(True)
-
         cashed_out = self._read_cash_outs(hand)
         remaining = self._announced_pot_total(hand)
 

--- a/fpdb_3_legacy/PokerTrackerToFpdb.py
+++ b/fpdb_3_legacy/PokerTrackerToFpdb.py
@@ -611,9 +611,6 @@ class PokerTracker(HandHistoryConverter):
             info.update(m.groupdict())
         info.update(m2.groupdict())
 
-        if self.sitename != "Everest" and info.get("UNCALLED") is None:
-            hand.setUncalledBets(True)
-
         # print 'readHandInfo', info
         for key in sorted(info.keys(), key=lambda x: 0 if x == "DATETIME" else 1):
             if key == "DATETIME":
@@ -1072,8 +1069,6 @@ class PokerTracker(HandHistoryConverter):
             elif action.group("ATYPE") in (" Allin", " went all-in"):
                 amount = Decimal(self.clearMoneyString(action.group("BET")))
                 hand.addAllIn(street, action.group("PNAME"), action.group("BET"))
-                if curr_pot > amount and curr_pot > Decimal(0) and self.sitename == "Microgaming":
-                    hand.setUncalledBets(False)
                 curr_pot = amount
             else:
                 log.debug(
@@ -1081,10 +1076,7 @@ class PokerTracker(HandHistoryConverter):
                 )
 
     def allInBlind(self, hand, street, action, actiontype) -> None:
-        if street in ("PREFLOP", "DEAL"):
-            player = action.group("PNAME")
-            if hand.stacks[player] == 0:
-                hand.setUncalledBets(True)
+        pass
 
     def adjustMergeTourneyStack(self, hand, player, amount) -> None:
         if self.sitename == "Merge":

--- a/fpdb_3_legacy/SealsWithClubsToFpdb.py
+++ b/fpdb_3_legacy/SealsWithClubsToFpdb.py
@@ -696,7 +696,6 @@ class SealsWithClubs(HandHistoryConverter):
             # Old format has no summary line; let Hand compute the pot from the
             # bets and derive the rake from pot - collected. Refunds appear as
             # "X refunded N" and are handled as uncalled bets.
-            hand.setUncalledBets(True)
             for m in self.re_OldCollect.finditer(hand.handText):
                 hand.addCollectPot(player=m.group("PNAME"), pot=m.group("POT"))
             return
@@ -725,11 +724,6 @@ class SealsWithClubs(HandHistoryConverter):
                 hand.addCollectPot(player=m.group("PNAME"), pot=m.group("POT").replace(",", ""))
             elif m.group("POT2") is not None:
                 hand.addCollectPot(player=m.group("PNAME"), pot=m.group("POT2").replace(",", ""))
-
-        # The uncalled bets themselves are returned to their owner in
-        # readAction; the summary pot above already excludes them.
-        if self.re_Uncalled.search(hand.handText) is not None:
-            hand.setUncalledBets(True)
 
         # Set rake
         if hand.rake is None:

--- a/fpdb_3_legacy/UnibetToFpdb.py
+++ b/fpdb_3_legacy/UnibetToFpdb.py
@@ -984,7 +984,6 @@ class Unibet(HandHistoryConverter):
         """Reads knockout bounties and add them to the koCounts dict."""
 
     def readCollectPot(self, hand) -> None:
-        hand.setUncalledBets(True)
         for m in self.re_CollectPot.finditer(hand.handText):
             # A "wins" line is only written for a pot actually taken, so unlike the
             # summary there is no zero-amount row to filter out here. A player who

--- a/fpdb_3_legacy/WinamaxToFpdb.py
+++ b/fpdb_3_legacy/WinamaxToFpdb.py
@@ -1215,7 +1215,6 @@ class Winamax(HandHistoryConverter):
         Returns:
             None
         """
-        hand.setUncalledBets(True)
         for m in self.re_collect_pot.finditer(hand.handText):
             hand.addCollectPot(player=m.group("PNAME"), pot=m.group("POT"))
 

--- a/fpdb_3_legacy/WinningToFpdb.py
+++ b/fpdb_3_legacy/WinningToFpdb.py
@@ -1662,15 +1662,6 @@ class Winning(HandHistoryConverter):
                     log.debug(
                         f"Adjustment calculated: {adjustment}, Blinds/Antes total: {blindsantes}",
                     )
-            else:
-                log.debug(
-                    "Not all actions in PREFLOP are folds, checking for uncalled bets",
-                )
-                m0 = self.re_Uncalled.search(hand.handText)
-                if not m0:
-                    hand.setUncalledBets(True)
-                    log.debug("Set uncalled bets to True")
-
             for m in self.re_CollectPot2.finditer(post):
                 pot = self.clearMoneyString(m.group("POT"))
                 player = m.group("PNAME")

--- a/fpdb_3_legacy/iPoker/base.py
+++ b/fpdb_3_legacy/iPoker/base.py
@@ -774,22 +774,6 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
             self.info["seats"] = mg2["SEATS"]
             log.debug("Set number of seats to '%s'.", self.info["seats"])
 
-    def _process_uncalled_bets(self, hand_text: str) -> None:
-        """Process uncalled bets settings."""
-        if self.re_uncalled_bets.search(hand_text):
-            self.uncalledbets = False
-            log.debug("Uncalled bets disabled.")
-        else:
-            self.uncalledbets = True
-            log.debug("Uncalled bets enabled.")
-            mv = self.re_client_version.search(hand_text)
-            if mv:
-                major_version = mv.group("VERSION").split(".")[0]
-                log.debug("Client version major number: %s", major_version)
-                if int(major_version) >= self.MIN_CLIENT_VERSION_FOR_UNCALLED_BETS:
-                    self.uncalledbets = False
-                    log.debug("Client version >= 20 => Uncalled bets disabled.")
-
     def _process_tournament_info(self, mg: dict, mg3: dict, hand_text: str) -> bool:
         """Process tournament-specific information."""
         # Check if this is a tournament (type should already be set by _parse_xml_format)
@@ -1162,9 +1146,6 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
 
         # Process seats information
         self._process_seats_info(mg2)
-
-        # Process uncalled bets information
-        self._process_uncalled_bets(hand_text)
 
         # Detect tournament vs ring game (check for tournament markers in whole file)
         if hasattr(self, "whole_file") and self.whole_file:

--- a/fpdb_3_legacy/iPoker/streets_actions.py
+++ b/fpdb_3_legacy/iPoker/streets_actions.py
@@ -599,9 +599,6 @@ class IPokerStreetsActionsMixin:
         """
         log.info("Entering readCollectPot method")
 
-        # Enable uncalled bets
-        hand.setUncalledBets(True)
-
         # Initialize total pot to zero
         total_pot = Decimal("0.00")
 

--- a/test/test_absolute_parser.py
+++ b/test/test_absolute_parser.py
@@ -82,7 +82,6 @@ def test_absolute_incoming_player_post_is_one_big_blind() -> None:
         handid="123",
         players=[(3, "New Player", "1.00")],
         addBlind=lambda *args: calls.append(args),
-        setUncalledBets=lambda _value: None,
     )
     parser = Absolute.__new__(Absolute)
     parser.compiledPlayers = set()
@@ -161,7 +160,6 @@ def test_absolute_stud_completion_is_recorded() -> None:
     hand = SimpleNamespace(
         players=[(1, "Alice", "10.00")],
         streets={"THIRD": "Alice - Completes to $0.20"},
-        setUncalledBets=lambda _value: None,
         addComplete=lambda *args: completions.append(args),
     )
     parser = Absolute.__new__(Absolute)

--- a/test/test_winamax_parser_comprehensive.py
+++ b/test/test_winamax_parser_comprehensive.py
@@ -87,10 +87,6 @@ class MockHand:
         self.players.append([seat, name, Decimal(str(chips))])
         self.stacks[name] = Decimal(str(chips))
 
-    def setUncalledBets(self, value: bool) -> None:
-        """Set uncalled bets flag."""
-        self.uncalledbets = value
-
     def addBlind(self, player: str, blindtype: str, amount: float | None) -> None:
         """Add a blind bet to the hand."""
         if amount is not None:

--- a/tests/helpers/mock_hand.py
+++ b/tests/helpers/mock_hand.py
@@ -177,9 +177,6 @@ class ParserMockHand:
     def addBlind(self, player: str, blind_type: str, amount: str) -> None:
         self.blinds.append({"player": player, "type": blind_type, "amount": self._dec(amount)})
 
-    def setUncalledBets(self, value: bool) -> None:
-        self.uncalledBets = bool(value)
-
     def setCommunityCards(self, street: str, cards: list[str]) -> None:
         self.community_cards[street] = list(cards)
 

--- a/tests/test_uncalled_bets_real_hands.py
+++ b/tests/test_uncalled_bets_real_hands.py
@@ -1,8 +1,18 @@
-"""Comprehensive unit and non-regression tests for uncalled bets using real hand history fixtures.
+"""Uncalled bets, checked against real hand histories from every supported room.
 
-Verifies that uncalled bets are correctly recognized, returned to the proper player
-in `hand.pot.returned`, and accounted for in total pot, rake, and net collected calculations
-across all supported poker room fixture files without money leaks or phantom rake.
+When the last bet of a street goes uncalled the room hands it back, and the
+returned chips must leave the pot with it. Get that wrong in either direction
+and the money does not add up: too little returned and the winner is credited
+with chips nobody ever paid, too much and the rake looks larger than it was.
+
+So each room is read from its own fixture and the accounting identity is
+checked on every hand it yields:
+
+    total pot == what the collectors were credited + rake
+
+with the returned bets already taken out of the total. That identity is what
+"no money leaks or phantom rake" actually means, and it is what a regression in
+uncalled-bet handling breaks first.
 """
 
 from __future__ import annotations
@@ -27,6 +37,21 @@ from fpdb_3_legacy.WinningToFpdb import Winning
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = ROOT / "tests" / "fixtures" / "hands"
 
+# One fixture per room, so a room whose uncalled-bet handling regresses is named
+# by the failing test rather than hidden in a combined run.
+ROOMS = [
+    pytest.param(PokerStars, "pokerstars/holdem/cash_nl_6max.txt", id="pokerstars"),
+    pytest.param(PartyPoker, "partypoker/stud/7stud.txt", id="partypoker"),
+    pytest.param(Winamax, "winamax/nlhe_cash.txt", id="winamax"),
+    pytest.param(Unibet, "unibet/banzai.txt", id="unibet"),
+    pytest.param(iPoker, "ipoker/twister/twister_sng.txt", id="ipoker"),
+    pytest.param(Bovada, "bovada/zone_poker.txt", id="bovada"),
+    pytest.param(Winning, "winning/modern_cash.txt", id="winning"),
+    pytest.param(Cake, "cake/cash_nlhe.txt", id="cake"),
+    pytest.param(PacificPoker, "pacific/jackpot_table.txt", id="pacific"),
+    pytest.param(GGPoker, "ggpoker/nlh_cash_6max.txt", id="ggpoker"),
+]
+
 
 @pytest.fixture(scope="module")
 def parser_config() -> Config:
@@ -42,115 +67,23 @@ def parse_fixture(parser_class, parser_config, relative_path: str):
     return hands
 
 
-def test_pokerstars_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test PokerStars real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(PokerStars, parser_config, "pokerstars/holdem/cash_nl_6max.txt")
+@pytest.mark.parametrize(("parser_class", "fixture"), ROOMS)
+def test_a_returned_bet_is_given_back_to_one_player(parser_class, fixture, parser_config) -> None:
+    for hand in parse_fixture(parser_class, parser_config, fixture):
+        for player, amount in hand.pot.returned.items():
+            assert amount > 0, f"hand {hand.handid}: uncalled bet returned to {player} is {amount}"
 
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0, f"Uncalled bet for {player} must be positive"
+
+@pytest.mark.parametrize(("parser_class", "fixture"), ROOMS)
+def test_the_pot_is_exactly_what_was_collected_plus_rake(parser_class, fixture, parser_config) -> None:
+    # The returned chips are already out of totalpot, so anything left over
+    # after the collectors and the rake is money the parser invented or lost.
+    for hand in parse_fixture(parser_class, parser_config, fixture):
         hand.calculate_net_collected()
-        collected_sum = sum(hand.collectees.values())
-        returned_sum = sum(hand.pot.returned.values())
+        collected = sum(hand.collectees.values())
         rake = Decimal(str(hand.rake))
-        assert hand.totalpot >= collected_sum, f"Total pot {hand.totalpot} must cover collected {collected_sum}"
 
-
-def test_partypoker_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test PartyPoker real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(PartyPoker, parser_config, "partypoker/stud/7stud.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_winamax_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Winamax real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(Winamax, parser_config, "winamax/nlhe_cash.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_unibet_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Unibet real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(Unibet, parser_config, "unibet/banzai.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_ipoker_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test iPoker real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(iPoker, parser_config, "ipoker/twister/twister_sng.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_bovada_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Bovada real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(Bovada, parser_config, "bovada/zone_poker.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_winning_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Winning real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(Winning, parser_config, "winning/modern_cash.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_cake_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Cake real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(Cake, parser_config, "cake/cash_nlhe.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_pacific_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test Pacific / 888 real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(PacificPoker, parser_config, "pacific/jackpot_table.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
-
-
-def test_ggpoker_real_fixture_uncalled_bets(parser_config) -> None:
-    """Test GGPoker real fixture hands for uncalled bet accounting."""
-    hands = parse_fixture(GGPoker, parser_config, "ggpoker/nlh_cash_6max.txt")
-
-    for hand in hands:
-        if hand.pot.returned:
-            for player, amount in hand.pot.returned.items():
-                assert amount > 0
-        hand.calculate_net_collected()
+        assert hand.totalpot == collected + rake, (
+            f"hand {hand.handid}: pot {hand.totalpot} != collected {collected} + rake {rake}"
+            f" (returned {sum(hand.pot.returned.values())})"
+        )

--- a/tests/test_uncalled_bets_real_hands.py
+++ b/tests/test_uncalled_bets_real_hands.py
@@ -1,0 +1,156 @@
+"""Comprehensive unit and non-regression tests for uncalled bets using real hand history fixtures.
+
+Verifies that uncalled bets are correctly recognized, returned to the proper player
+in `hand.pot.returned`, and accounted for in total pot, rake, and net collected calculations
+across all supported poker room fixture files without money leaks or phantom rake.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from fpdb_3_legacy.BovadaToFpdb import Bovada
+from fpdb_3_legacy.CakeToFpdb import Cake
+from fpdb_3_legacy.Configuration import Config
+from fpdb_3_legacy.GGPokerToFpdb import GGPoker
+from fpdb_3_legacy.iPoker.base import iPoker
+from fpdb_3_legacy.PacificPokerToFpdb import PacificPoker
+from fpdb_3_legacy.PartyPokerToFpdb import PartyPoker
+from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
+from fpdb_3_legacy.UnibetToFpdb import Unibet
+from fpdb_3_legacy.WinamaxToFpdb import Winamax
+from fpdb_3_legacy.WinningToFpdb import Winning
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "hands"
+
+
+@pytest.fixture(scope="module")
+def parser_config() -> Config:
+    return Config()
+
+
+def parse_fixture(parser_class, parser_config, relative_path: str):
+    file_path = FIXTURES / relative_path
+    assert file_path.exists(), f"Fixture file not found: {file_path}"
+    parser = parser_class(config=parser_config, in_path=str(file_path), autostart=True)
+    hands = parser.getProcessedHands()
+    assert len(hands) > 0, f"No hands parsed from {file_path}"
+    return hands
+
+
+def test_pokerstars_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test PokerStars real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(PokerStars, parser_config, "pokerstars/holdem/cash_nl_6max.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0, f"Uncalled bet for {player} must be positive"
+        hand.calculate_net_collected()
+        collected_sum = sum(hand.collectees.values())
+        returned_sum = sum(hand.pot.returned.values())
+        rake = Decimal(str(hand.rake))
+        assert hand.totalpot >= collected_sum, f"Total pot {hand.totalpot} must cover collected {collected_sum}"
+
+
+def test_partypoker_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test PartyPoker real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(PartyPoker, parser_config, "partypoker/stud/7stud.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_winamax_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Winamax real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(Winamax, parser_config, "winamax/nlhe_cash.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_unibet_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Unibet real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(Unibet, parser_config, "unibet/banzai.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_ipoker_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test iPoker real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(iPoker, parser_config, "ipoker/twister/twister_sng.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_bovada_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Bovada real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(Bovada, parser_config, "bovada/zone_poker.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_winning_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Winning real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(Winning, parser_config, "winning/modern_cash.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_cake_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Cake real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(Cake, parser_config, "cake/cash_nlhe.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_pacific_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test Pacific / 888 real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(PacificPoker, parser_config, "pacific/jackpot_table.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()
+
+
+def test_ggpoker_real_fixture_uncalled_bets(parser_config) -> None:
+    """Test GGPoker real fixture hands for uncalled bet accounting."""
+    hands = parse_fixture(GGPoker, parser_config, "ggpoker/nlh_cash_6max.txt")
+
+    for hand in hands:
+        if hand.pot.returned:
+            for player, amount in hand.pot.returned.items():
+                assert amount > 0
+        hand.calculate_net_collected()


### PR DESCRIPTION
Purges unused uncalledbets attribute, setter method, and 37 redundant calls across 16 parser files. Adds real-hand unit test suite for uncalled bet parsing and profit/pot/rake accounting across 10 poker rooms.