### PR TITLE
fix(ipoker): add deterministic duplicate session hand cleanup tool

### DIFF
--- a/fpdb_3_legacy/fix_ipoker_duplicate_session_hands.py
+++ b/fpdb_3_legacy/fix_ipoker_duplicate_session_hands.py
@@ -8,24 +8,43 @@ from __future__ import annotations
 
 import argparse
 import os
-import xml.etree.ElementTree as ET
 from pathlib import Path
+
+import defusedxml.ElementTree
+from defusedxml.common import DefusedXmlException
+
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("ipoker_duplicate_cleanup")
+
+# A session file comes from the poker room, so it is parsed with the hardened
+# parser like every other hand history fpdb reads: the stock one honours entity
+# declarations, which turns a hand history into a file-read primitive.
+READ_ERRORS = (OSError, defusedxml.ElementTree.ParseError, DefusedXmlException)
 
 
 def extract_ipoker_gamecodes(file_path: Path) -> set[str]:
-    """Extract game codes from an iPoker XML session file."""
+    """Extract game codes from an iPoker XML session file.
+
+    A file that cannot be read or parsed yields no game codes, which keeps it
+    out of the duplicate list -- this tool deletes files, so anything it does
+    not fully understand has to be left alone. The reason is logged rather than
+    swallowed, otherwise a directory full of unreadable files looks exactly
+    like a directory with nothing to clean.
+    """
     gamecodes: set[str] = set()
     try:
         content = file_path.read_text(encoding="utf-8", errors="ignore")
         if "<game" not in content:
             return gamecodes
-        root = ET.fromstring(content)
+        root = defusedxml.ElementTree.fromstring(content)
         for game in root.findall(".//game"):
             code = game.get("gamecode")
             if code:
                 gamecodes.add(code)
-    except Exception:
-        pass
+    except READ_ERRORS as exc:
+        log.warning("Skipping %s, it could not be read as an iPoker session: %s", file_path, exc)
+        return set()
     return gamecodes
 
 
@@ -62,16 +81,30 @@ def find_duplicate_ipoker_files(directory_path: str | Path) -> list[Path]:
     return duplicates_to_remove
 
 
-def clean_duplicate_ipoker_files(directory_path: str | Path, dry_run: bool = False) -> list[Path]:
-    """Find and remove duplicate iPoker session files."""
+def clean_duplicate_ipoker_files(directory_path: str | Path, *, dry_run: bool = False) -> list[Path]:
+    """Find and remove duplicate iPoker session files.
+
+    Returns the files that were actually removed -- or, on a dry run, the ones
+    that would be. A file whose deletion fails is reported, not counted: this
+    is the difference between telling a player their hand histories were
+    cleaned up and telling them they still have to deal with it.
+
+    ``dry_run`` is keyword-only on purpose. This function deletes files, and a
+    positional flag is the kind of thing that gets passed the wrong way round.
+    """
     duplicates = find_duplicate_ipoker_files(directory_path)
-    if not dry_run:
-        for file_path in duplicates:
-            try:
-                file_path.unlink()
-            except OSError:
-                pass
-    return duplicates
+    if dry_run:
+        return duplicates
+
+    removed: list[Path] = []
+    for file_path in duplicates:
+        try:
+            file_path.unlink()
+        except OSError as exc:
+            log.warning("Could not remove duplicate %s: %s", file_path, exc)
+        else:
+            removed.append(file_path)
+    return removed
 
 
 def main() -> None:
@@ -80,10 +113,10 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="List duplicate files without deleting them")
     args = parser.parse_args()
 
-    duplicates = clean_duplicate_ipoker_files(args.directory, dry_run=args.dry_run)
+    handled = clean_duplicate_ipoker_files(args.directory, dry_run=args.dry_run)
     action = "Found" if args.dry_run else "Removed"
-    print(f"{action} {len(duplicates)} duplicate iPoker file(s):")
-    for dup in duplicates:
+    print(f"{action} {len(handled)} duplicate iPoker file(s):")
+    for dup in handled:
         print(f"  {dup}")
 
 

--- a/fpdb_3_legacy/fix_ipoker_duplicate_session_hands.py
+++ b/fpdb_3_legacy/fix_ipoker_duplicate_session_hands.py
@@ -1,0 +1,91 @@
+"""iPoker Duplicate Session Files Cleanup Tool.
+
+Scans an iPoker hand history directory tree, identifies duplicate XML session files
+containing game codes already present in earlier session files, and removes them deterministically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def extract_ipoker_gamecodes(file_path: Path) -> set[str]:
+    """Extract game codes from an iPoker XML session file."""
+    gamecodes: set[str] = set()
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
+        if "<game" not in content:
+            return gamecodes
+        root = ET.fromstring(content)
+        for game in root.findall(".//game"):
+            code = game.get("gamecode")
+            if code:
+                gamecodes.add(code)
+    except Exception:
+        pass
+    return gamecodes
+
+
+def find_duplicate_ipoker_files(directory_path: str | Path) -> list[Path]:
+    """Recursively scan directory_path for duplicate iPoker session files.
+
+    Guarantees deterministic execution across platforms by explicitly sorting
+    all discovered session files by path before processing.
+    """
+    directory_path = Path(directory_path)
+    seen_gamecodes: set[str] = set()
+    duplicates_to_remove: list[Path] = []
+
+    all_files: list[Path] = []
+    for root, dirnames, filenames in os.walk(directory_path):
+        dirnames.sort()
+        filenames.sort()
+        for filename in filenames:
+            if filename.lower().endswith(".xml"):
+                all_files.append(Path(root) / filename)
+
+    all_files.sort()
+
+    for file_path in all_files:
+        gamecodes = extract_ipoker_gamecodes(file_path)
+        if not gamecodes:
+            continue
+
+        if gamecodes.issubset(seen_gamecodes):
+            duplicates_to_remove.append(file_path)
+        else:
+            seen_gamecodes.update(gamecodes)
+
+    return duplicates_to_remove
+
+
+def clean_duplicate_ipoker_files(directory_path: str | Path, dry_run: bool = False) -> list[Path]:
+    """Find and remove duplicate iPoker session files."""
+    duplicates = find_duplicate_ipoker_files(directory_path)
+    if not dry_run:
+        for file_path in duplicates:
+            try:
+                file_path.unlink()
+            except OSError:
+                pass
+    return duplicates
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Clean duplicate iPoker session XML files.")
+    parser.add_argument("directory", help="Path to iPoker hand history directory")
+    parser.add_argument("--dry-run", action="store_true", help="List duplicate files without deleting them")
+    args = parser.parse_args()
+
+    duplicates = clean_duplicate_ipoker_files(args.directory, dry_run=args.dry_run)
+    action = "Found" if args.dry_run else "Removed"
+    print(f"{action} {len(duplicates)} duplicate iPoker file(s):")
+    for dup in duplicates:
+        print(f"  {dup}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_fix_ipoker_duplicate_session_hands.py
+++ b/test/test_fix_ipoker_duplicate_session_hands.py
@@ -89,3 +89,48 @@ def test_filesystem_traversal_order_independence(tmp_path: Path) -> None:
         res2 = find_duplicate_ipoker_files(tmp_path)
 
     assert res1 == res2, f"Results differed across traversal orders: {res1} vs {res2}"
+
+
+def test_a_file_that_cannot_be_parsed_is_left_alone(tmp_path: Path) -> None:
+    # This tool deletes files, so anything it cannot fully read has to survive
+    # -- including a truncated session whose codes it never got to see.
+    broken = tmp_path / "truncated.xml"
+    broken.write_text("<session><game gamecode=\"10001\">", encoding="utf-8")
+    known = tmp_path / "known.xml"
+    known.write_text(SAMPLE_XML_1, encoding="utf-8")
+
+    assert extract_ipoker_gamecodes(broken) == set()
+    assert clean_duplicate_ipoker_files(tmp_path, dry_run=False) == []
+    assert broken.exists()
+    assert known.exists()
+
+
+def test_an_entity_declaration_is_refused_rather_than_expanded(tmp_path: Path) -> None:
+    # Session files come from the poker room. An entity declaration is the
+    # billion-laughs vector, and the stock parser expands it without a word --
+    # it would report this file's gamecode as 10001. The hardened one refuses
+    # the declaration outright, so nothing is extracted and the file is left
+    # alone. Swap the parser back and this test fails, which is the point.
+    hostile = tmp_path / "hostile.xml"
+    hostile.write_text(
+        '<?xml version="1.0"?>\n'
+        '<!DOCTYPE session [<!ENTITY code "10001">]>\n'
+        '<session><game gamecode="&code;"/></session>',
+        encoding="utf-8",
+    )
+
+    assert extract_ipoker_gamecodes(hostile) == set()
+
+
+def test_a_file_that_could_not_be_deleted_is_not_reported_as_removed(tmp_path: Path) -> None:
+    # Reporting a failed deletion as a cleanup tells the player the problem is
+    # gone when their directory is untouched.
+    first = tmp_path / "session_01.xml"
+    second = tmp_path / "session_02.xml"
+    first.write_text(SAMPLE_XML_1, encoding="utf-8")
+    second.write_text(SAMPLE_XML_2, encoding="utf-8")
+
+    with patch.object(Path, "unlink", side_effect=PermissionError("read-only")):
+        assert clean_duplicate_ipoker_files(tmp_path, dry_run=False) == []
+
+    assert second.exists()

--- a/test/test_fix_ipoker_duplicate_session_hands.py
+++ b/test/test_fix_ipoker_duplicate_session_hands.py
@@ -1,0 +1,91 @@
+"""Unit tests for iPoker duplicate session files cleanup script."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from fpdb_3_legacy.fix_ipoker_duplicate_session_hands import (
+    clean_duplicate_ipoker_files,
+    extract_ipoker_gamecodes,
+    find_duplicate_ipoker_files,
+)
+
+SAMPLE_XML_1 = """<session sessioncode="1001">
+<game gamecode="10001"><general><startdate>2026-08-04</startdate></general></game>
+<game gamecode="10002"><general><startdate>2026-08-04</startdate></general></game>
+</session>"""
+
+SAMPLE_XML_2 = """<session sessioncode="1002">
+<game gamecode="10002"><general><startdate>2026-08-04</startdate></general></game>
+</session>"""
+
+SAMPLE_XML_3 = """<session sessioncode="1003">
+<game gamecode="10003"><general><startdate>2026-08-04</startdate></general></game>
+</session>"""
+
+
+def test_extract_ipoker_gamecodes(tmp_path: Path) -> None:
+    file_path = tmp_path / "session.xml"
+    file_path.write_text(SAMPLE_XML_1, encoding="utf-8")
+    codes = extract_ipoker_gamecodes(file_path)
+    assert codes == {"10001", "10002"}
+
+
+def test_find_and_clean_duplicate_ipoker_files(tmp_path: Path) -> None:
+    dir_a = tmp_path / "dir_a"
+    dir_b = tmp_path / "dir_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    file1 = dir_a / "session_01.xml"
+    file2 = dir_a / "session_02.xml"
+    file3 = dir_b / "session_03.xml"
+
+    file1.write_text(SAMPLE_XML_1, encoding="utf-8")
+    file2.write_text(SAMPLE_XML_2, encoding="utf-8")  # Duplicate of gamecode 10002
+    file3.write_text(SAMPLE_XML_3, encoding="utf-8")  # Unique gamecode 10003
+
+    duplicates = find_duplicate_ipoker_files(tmp_path)
+    assert duplicates == [file2]
+
+    # Dry run shouldn't delete file
+    clean_duplicate_ipoker_files(tmp_path, dry_run=True)
+    assert file2.exists()
+
+    # Actual clean should delete file2
+    cleaned = clean_duplicate_ipoker_files(tmp_path, dry_run=False)
+    assert cleaned == [file2]
+    assert not file2.exists()
+    assert file1.exists()
+    assert file3.exists()
+
+
+def test_filesystem_traversal_order_independence(tmp_path: Path) -> None:
+    """Verify that results are 100% deterministic regardless of OS/FS walk order."""
+    dir_z = tmp_path / "z_dir"
+    dir_a = tmp_path / "a_dir"
+    dir_z.mkdir()
+    dir_a.mkdir()
+
+    f1 = dir_z / "b_session.xml"
+    f2 = dir_a / "a_session.xml"
+
+    f1.write_text(SAMPLE_XML_1, encoding="utf-8")
+    f2.write_text(SAMPLE_XML_2, encoding="utf-8")
+
+    # Order 1: Standard os.walk
+    res1 = find_duplicate_ipoker_files(tmp_path)
+
+    # Order 2: Reverse order mock of os.walk
+    original_walk = os.walk
+
+    def reversed_walk(top, **kwargs):
+        for root, dirs, files in original_walk(top, **kwargs):
+            yield root, list(reversed(dirs)), list(reversed(files))
+
+    with patch("os.walk", side_effect=reversed_walk):
+        res2 = find_duplicate_ipoker_files(tmp_path)
+
+    assert res1 == res2, f"Results differed across traversal orders: {res1} vs {res2}"

--- a/tests/test_xml_hardening.py
+++ b/tests/test_xml_hardening.py
@@ -88,6 +88,7 @@ PARSING_MODULES = (
     "ModernHudPreferences.py",
     "L10n.py",
     "ThemeManager.py",
+    "fix_ipoker_duplicate_session_hands.py",
 )
 
 # Creating a document is not parsing, so getDOMImplementation stays on the


### PR DESCRIPTION
Provides fpdb_3_legacy/fix_ipoker_duplicate_session_hands.py with deterministic directory traversal sorting to clean up duplicate iPoker XML session files regardless of OS filesystem iteration order, along with unit test coverage.