### PR TITLE
fix(partypoker): attribute hands to the configured skin, not the last <hhc>

### DIFF
--- a/fpdb_3_legacy/IdentifySite.py
+++ b/fpdb_3_legacy/IdentifySite.py
@@ -291,6 +291,20 @@ class IdentifySite:
         """
         return self._select_network_skin_site(path, fallback_site, "iPoker")
 
+    def _select_partypoker_skin_site(self, path, fallback_site):
+        """Return the configured PartyPoker skin site for this file.
+
+        Every Party skin (PartyPoker, the .fr/.it/.es/.de/.eu locales, Bwin,
+        Borgata, WPT, PMU Poker (PartyPoker), ...) shares the PartyPoker parser
+        class and its ``siteId = 9``, so only one survives keyed by ``site_id``
+        in ``self.sitelist``: whichever ``<hhc>`` came last in the config, which
+        has nothing to do with the room the file came from. The hand history
+        carries no skin marker either -- its ``(SITE)`` header group names the
+        network, not the skin -- so resolve the skin from the configured HH/TS
+        paths like the other multi-skin networks do.
+        """
+        return self._select_network_skin_site(path, fallback_site, "PartyPoker")
+
     def _select_network_skin_site(self, path, fallback_site, network):
         """Resolve the skin site of a multi-skin network from the file path."""
         supported = getattr(self.config, "supported_sites", None)
@@ -530,13 +544,15 @@ class IdentifySite:
                 f.archive = True
                 f.archiveHead = True
             if m:
-                # For PokerStars, WPN and iPoker, we need to determine the specific skin
+                # For PokerStars, WPN, iPoker and Party, we need to determine the specific skin
                 if filter_name == "PokerStars":
                     selected_site = self._select_pokerstars_skin_site(path, whole_file, site)
                 elif filter_name == "Winning":
                     selected_site = self._select_winning_skin_site(path, site)
                 elif filter_name == "iPoker":
                     selected_site = self._select_ipoker_skin_site(path, site)
+                elif filter_name == "PartyPoker":
+                    selected_site = self._select_partypoker_skin_site(path, site)
                 else:
                     selected_site = site
                 f.site = selected_site
@@ -569,6 +585,8 @@ class IdentifySite:
                             f.site = self._select_winning_skin_site(path, site)
                         elif site.filter_name == "iPoker":
                             f.site = self._select_ipoker_skin_site(path, site)
+                        elif site.filter_name == "PartyPoker":
+                            f.site = self._select_partypoker_skin_site(path, site)
                         else:
                             f.site = site
                         f.ftype = "summary"

--- a/regression-test-files/cash/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202602.cash.out.txt
+++ b/regression-test-files/cash/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202602.cash.out.txt
@@ -1,0 +1,36 @@
+***** Hand History For Game 1770659766668adeb0h5qfm *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Feb 09 12:55:26 EST 2026
+Table Table 7488952 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($56.64)
+Seat 2: Player1 ($19.93)
+Seat 3: Player2 ($20.20)
+Seat 4: Hero ($25.86)
+Player1 posts small blind (0.10)
+Player2 posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ 9c, 7h, 8h, 4d ]
+Hero raises 0.85 to 0.85
+Player4 folds 
+Player1 folds 
+Player2 raises 2.40 to 2.65
+Hero calls (1.80)
+** Dealing Flop ** :  [ Jc, 7d, 6c ]
+Player2 bets (5.13)
+Hero raises 20.52 to 20.52
+Player2 calls (12.42)
+Player2 is all-In.
+Creating Main Pot with $ 38.50 with Player2, Hero
+Player2 Cash-out Premium % is 1.0
+Player2 opted for cash-out
+Player2 probabilty is 60.37
+Player2 Cashout Amount is 23.01
+** Dealing Turn ** :  [ Ts ]
+** Dealing River ** :  [ Js ]
+** Summary **
+Main Pot: $38.50 Rake: $2.0
+Board: [ Jc, 7d, 6c, Ts, Js ]
+Player4 balance $56.64, didn't bet (folded)
+Player1 balance $19.83, lost $0.10 (folded)
+Player2 Cashed out  balance $23.01, bet $20.20, collected $23.01, net +$2.81[ Tc, Ac, Ad, 4c ] [ two pairs, aces and jacks -- Ac,Ad,Jc,Js,Ts ]
+Hero balance $44.16, bet $23.17, collected $41.47, net +$18.30[ 9c, 7h, 8h, 4d ] [ a straight, seven to jack -- Jc,Ts,9c,8h,7d ]

--- a/regression-test-files/cash/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202607.multi.hand.split.txt
+++ b/regression-test-files/cash/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202607.multi.hand.split.txt
@@ -1,0 +1,118 @@
+***** Hand History For Game 1784559729098bywbird3xlj *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:01:17 EDT 2026
+Table Table 7490030 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($113.97)
+Seat 2: Player1 ($12.60)
+Seat 3: Hero ($51.56)
+Seat 4: Player3 ($85.96)
+Player1 posts small blind (0.10)
+Hero posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ 7s, Tc, 5c, Jh ]
+Player3 folds 
+Player4 folds 
+Player1 calls (0.15)
+Hero checks 
+** Dealing Flop ** :  [ 8d, 5s, 8h ]
+Player1 checks 
+Hero checks 
+** Dealing Turn ** :  [ 2c ]
+Player1 bets (0.32)
+Hero calls (0.32)
+** Dealing River ** :  [ 6s ]
+Player1 checks 
+Hero checks 
+** Summary **
+Main Pot: $1.09 Rake: $0.05
+Board: [ 8d, 5s, 8h, 2c, 6s ]
+Player4 balance $113.97, didn't bet (folded)
+Player1 balance $13.12, bet $0.57, collected $1.09, net +$0.52[ 9s, 4d, 8s, Jc ] [ three of a kind, eights -- Jc,8s,8d,8h,6s ]
+Hero balance $50.99, lost $0.57[ 7s, Tc, 5c, Jh ] [ two pairs, eights and fives -- Jh,8d,8h,5c,5s ]
+Player3 balance $85.96, didn't bet (folded)
+
+
+***** Hand History For Game 17845596990673djb7na2i87 *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:00:56 EDT 2026
+Table Table 7509241 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Hero ($124.44)
+Seat 2: Player1 ($7.02)
+Seat 3: Player2 ($95.23)
+Seat 4: Player3 ($113.97)
+Player1 posts small blind (0.10)
+Player2 posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ 2c, Qs, Jh, Ac ]
+Player3 folds 
+Hero raises 0.85 to 0.85
+Player1 raises 2.70 to 2.80
+Player2 calls (2.55)
+Hero calls (1.95)
+** Dealing Flop ** :  [ 8d, 5h, Ah ]
+Player1 bets (4.22)
+Player1 is all-In.
+Player2 folds 
+Hero calls (4.22)
+Creating Main Pot with $ 16 with Player1, Hero
+** Dealing Turn ** :  [ Th ]
+** Dealing River ** :  [ 5d ]
+** Summary **
+Main Pot: $16 Rake: $0.84
+Board: [ 8d, 5h, Ah, Th, 5d ]
+Hero balance $117.42, lost $7.02[ 2c, Qs, Jh, Ac ] [ two pairs, aces and fives -- Ac,Ah,Qs,5h,5d ]
+Player1 balance $16, bet $7.02, collected $16, net +$8.98[ 8s, Ks, 3d, Ad ] [ two pairs, aces and eights -- Ad,Ah,Th,8s,8d ]
+Player2 balance $92.43, lost $2.80 (folded)
+Player3 balance $113.97, didn't bet (folded)
+
+
+***** Hand History For Game 17845596867267gpyxw6jp9t *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:00:51 EDT 2026
+Table Table 7520920 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($95.23)
+Seat 2: Hero ($32.32)
+Seat 3: Player2 ($21.95)
+Seat 4: Player3 ($7.02)
+Hero posts small blind (0.10)
+Player2 posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ Tc, Qs, 6c, Kh ]
+Player3 folds 
+Player4 folds 
+Hero raises 0.65 to 0.75
+Player2 calls (0.50)
+** Dealing Flop ** :  [ 2s, 6s, 9s ]
+Hero checks 
+Player2 bets (1.07)
+Hero folds 
+** Summary **
+Main Pot: $1.43 Rake: $0.07
+Board: [ 2s, 6s, 9s ]
+Player4 balance $95.23, didn't bet (folded)
+Hero balance $31.57, lost $0.75 (folded)
+Player2 balance $22.63, bet $1.82, collected $2.50, net +$0.68
+Player3 balance $7.02, didn't bet (folded)
+
+
+***** Hand History For Game 1784559652796h1yodv7zdsi *****
+0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:00:48 EDT 2026
+Table Table 7519720 (Real Money) -- Seat 1 is the button
+Total number of players : 4/6
+Seat 1: Player4 ($95.23)
+Seat 2: Player1 ($22.05)
+Seat 3: Hero ($124.34)
+Seat 4: Player3 ($7.02)
+Player1 posts small blind (0.10)
+Hero posts big blind (0.25)
+** Dealing down cards **
+Dealt to Hero [ Jd, 2c, 6h, As ]
+Player3 folds 
+Player4 folds 
+Player1 folds 
+** Summary **
+Main Pot: $0.20 Rake: $0.0
+Player4 balance $95.23, didn't bet (folded)
+Player1 balance $21.95, lost $0.10 (folded)
+Hero balance $124.44, bet $0.25, collected $0.35, net +$0.10
+Player3 balance $7.02, didn't bet (folded)

--- a/test/test_partypoker_parser_debt.py
+++ b/test/test_partypoker_parser_debt.py
@@ -86,95 +86,19 @@ def test_play_money_ring_is_not_read_as_a_real_currency() -> None:
     assert game_type["currency"] == "play"
 
 
-def test_partypoker_modern_hh_summary_and_splitting() -> None:
+def test_the_cash_out_summary_separates_the_payout_from_the_pot() -> None:
+    """A player insures an all-in and takes the payout instead of the pot."""
     from fpdb_3_legacy.Configuration import Config
 
-    sample_hands = """***** Hand History For Game 1770659766668adeb0h5qfm *****
-0.10/0.25 Omaha Hi Game Table (PL) - Mon Feb 09 12:55:26 EST 2026
-Table Table 7488952 (Real Money) -- Seat 1 is the button
-Total number of players : 4/6
-Seat 1: Player4 ($56.64)
-Seat 2: Player1 ($19.93)
-Seat 3: Player2 ($20.20)
-Seat 4: Hero ($25.86)
-Player1 posts small blind (0.10)
-Player2 posts big blind (0.25)
-** Dealing down cards **
-Dealt to Hero [ 9c, 7h, 8h, 4d ]
-Hero raises 0.85 to 0.85
-Player4 folds
-Player1 folds
-Player2 raises 2.40 to 2.65
-Hero calls (1.80)
-** Dealing Flop ** : [ Jc, 7d, 6c ]
-Player2 bets (5.13)
-Hero raises 20.52 to 20.52
-Player2 calls (12.42)
-Player2 is all-In.
-Creating Main Pot with $ 38.50 with Player2, Hero
-Player2 Cash-out Premium % is 1.0
-Player2 opted for cash-out
-Player2 probabilty is 60.37
-Player2 Cashout Amount is 23.01
-** Dealing Turn ** : [ Ts ]
-** Dealing River ** : [ Js ]
-** Summary **
-Main Pot: $38.50 Rake: $2.0
-Board: [ Jc, 7d, 6c, Ts, Js ]
-Player4 balance $56.64, didn't bet (folded)
-Player1 balance $19.83, lost $0.10 (folded)
-Player2 Cashed out balance $23.01, bet $20.20, collected $23.01, net +$2.81[ Tc, Ac, Ad, 4c ] [ two pairs, aces and jacks -- Ac,Ad,Jc,Js,Ts ]
-Hero balance $44.16, bet $23.17, collected $41.47, net +$18.30[ 9c, 7h, 8h, 4d ] [ a straight, seven to jack -- Jc,Ts,9c,8h,7d ]
+    path = CASH / "PLO-6max-USD-0.10-0.25-202602.cash.out.txt"
+    hands = PartyPoker(config=Config(), in_path=str(path), autostart=True).getProcessedHands()
 
-***** Hand History For Game 1784559729098bywbird3xlj *****
-0.10/0.25 Omaha Hi Game Table (PL) - Mon Jul 20 11:01:17 EDT 2026
-Table Table 7490030 (Real Money) -- Seat 1 is the button
-Total number of players : 4/6
-Seat 1: Player4 ($113.97)
-Seat 2: Player1 ($12.60)
-Seat 3: Hero ($51.56)
-Seat 4: Player3 ($85.96)
-Player1 posts small blind (0.10)
-Hero posts big blind (0.25)
-** Dealing down cards **
-Dealt to Hero [ 7s, Tc, 5c, Jh ]
-Player3 folds
-Player4 folds
-Player1 calls (0.15)
-Hero checks
-** Dealing Flop ** : [ 8d, 5s, 8h ]
-Player1 checks
-Hero checks
-** Dealing Turn ** : [ 2c ]
-Player1 bets (0.32)
-Hero calls (0.32)
-** Dealing River ** : [ 6s ]
-Player1 checks
-Hero checks
-** Summary **
-Main Pot: $1.09 Rake: $0.05
-Board: [ 8d, 5s, 8h, 2c, 6s ]
-Player4 balance $113.97, didn't bet (folded)
-Player1 balance $13.12, bet $0.57, collected $1.09, net +$0.52[ 9s, 4d, 8s, Jc ] [ three of a kind, eights -- Jc,8s,8d,8h,6s ]
-Hero balance $50.99, lost $0.57[ 7s, Tc, 5c, Jh ] [ two pairs, eights and fives -- Jh,8d,8h,5c,5s ]
-Player3 balance $85.96, didn't bet (folded)
-"""
-
-    config = Config()
-    parser = PartyPoker(config, autostart=False)
-    parser.obs = sample_hands
-    parser.in_path = "test.txt"
-    parser.readFile = lambda: None
-
-    hands_list = parser.allHandsAsList()
-    assert len(hands_list) == 2
-
-    # Process hand 1 (Cashout & Showdown)
-    hand1 = parser.processHand(hands_list[0])
-    assert hand1.handid == "1770659766668"
-    assert hand1.hero == "Hero"
-    assert "Player2" in hand1.shown
-    assert "Hero" in hand1.shown
+    assert len(hands) == 1
+    hand = hands[0]
+    assert hand.handid == "1770659766668"
+    assert hand.hero == "Hero"
+    assert "Player2" in hand.shown
+    assert "Hero" in hand.shown
 
     # The summary reports what left the table, which is two different kinds of
     # money here. Player2's 23.01 is an insurance payout that never sat in the
@@ -182,20 +106,42 @@ Player3 balance $85.96, didn't bet (folded)
     # Player2, all-in for less, could not call. Recording either as pot winnings
     # is what GGPoker's readCollectPot calls out: "cashouts are separate
     # transactions that don't affect the main pot distribution".
-    assert hand1.cashedOut is True
-    assert hand1.cashOutAmounts["Player2"] == Decimal("23.01")
-    assert "Player2" not in dict(hand1.collected)  # insurance, not the pot
-    assert ["Hero", "38.50"] in hand1.collected
-    assert hand1.pot.returned["Hero"] == Decimal("2.97")
-    assert hand1.totalpot - hand1.rake == Decimal("38.50")  # the announced Main Pot
+    assert hand.cashedOut is True
+    assert hand.cashOutAmounts["Player2"] == Decimal("23.01")
+    assert "Player2" not in dict(hand.collected)  # insurance, not the pot
+    assert ["Hero", "38.50"] in hand.collected
+    assert hand.pot.returned["Hero"] == Decimal("2.97")
+    assert hand.totalpot - hand.rake == Decimal("38.50")  # the announced Main Pot
 
-    # Process hand 2
-    hand2 = parser.processHand(hands_list[1])
-    assert hand2.handid == "1784559729098"
-    assert hand2.hero == "Hero"
-    assert ["Player1", "1.09"] in hand2.collected
-    assert "Player1" in hand2.shown
 
+def test_consecutive_modern_hands_are_split_and_parsed() -> None:
+    """The modern export concatenates hands; each one must survive the split."""
+    from fpdb_3_legacy.Configuration import Config
+
+    path = CASH / "PLO-6max-USD-0.10-0.25-202607.multi.hand.split.txt"
+
+    # allHandsAsList consumes the observed text, so split on a parser of its
+    # own rather than on the one that has already processed the file.
+    splitter = PartyPoker(config=Config(), in_path=str(path), autostart=False)
+    splitter.obs = _read(path)
+    assert len(splitter.allHandsAsList()) == 4
+
+    parser = PartyPoker(config=Config(), in_path=str(path), autostart=True)
+    hands = {hand.handid: hand for hand in parser.getProcessedHands()}
+    assert set(hands) == {"1784559729098", "1784559699067", "1784559686726", "1784559652796"}
+
+    showdown = hands["1784559729098"]
+    assert showdown.hero == "Hero"
+    assert ["Player1", "1.09"] in showdown.collected
+    assert "Player1" in showdown.shown
+
+    # Everyone folds to the big blind: no board, and the summary's "collected
+    # $0.35" is the whole 0.10 + 0.25 of blinds, including the 0.15 of his own
+    # big blind nobody called. The pot is the announced 0.20.
+    walk = hands["1784559652796"]
+    assert all(not cards for cards in walk.board.values())
+    assert ["Hero", "0.20"] in walk.collected
+    assert walk.pot.returned["Hero"] == Decimal("0.15")
 
 
 def test_the_summary_collected_keeps_its_uncalled_bet_out_of_the_pot() -> None:

--- a/test/test_partypoker_skin_selection.py
+++ b/test/test_partypoker_skin_selection.py
@@ -1,0 +1,132 @@
+"""Skin attribution for the PartyPoker network.
+
+Every Party skin shares ``PartyPokerToFpdb`` and its ``siteId = 9``, so
+``IdentifySite.generateSiteList`` keys them all on 9 and only the last ``<hhc>``
+of the config survives. Without a skin resolver, every Party import was filed
+under that arbitrary survivor -- typically a room the user never played and has
+disabled, which then never appears in the report filters, so the hands are
+imported yet invisible in the Hand Viewer.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+from xml.etree import ElementTree as ET  # noqa: S405 -- building only; parsing goes through defusedxml
+
+import defusedxml.ElementTree as DefusedET
+import pytest
+
+from fpdb_3_legacy.IdentifySite import IdentifySite
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_CONFIG = ROOT / "HUD_config.xml.example"
+CASH_HAND = ROOT / "regression-test-files" / "cash" / "PartyPoker" / "Flop" / "NLHE-EUR-0.05-0.10-201011.Sample.txt"
+
+
+def _config_site(name: str, hh_path: str, *, enabled: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        site_name=name,
+        network="PartyPoker",
+        HH_path=hh_path,
+        TS_path="",
+        enabled=enabled,
+    )
+
+
+def _selector(**sites: SimpleNamespace) -> IdentifySite:
+    idsite = object.__new__(IdentifySite)
+    idsite.config = SimpleNamespace(supported_sites={s.site_name: s for s in sites.values()})
+    return idsite
+
+
+class TestSkinSelection:
+    def test_file_is_attributed_to_the_skin_whose_path_matches(self, tmp_path: Path) -> None:
+        party_dir = tmp_path / "PartyPoker" / "HandHistory"
+        pmu_dir = tmp_path / "PMU" / "PMUPoker" / "HandHistory"
+        idsite = _selector(
+            party=_config_site("PartyPoker", str(party_dir)),
+            pmu=_config_site("PMU Poker (PartyPoker)", str(pmu_dir)),
+        )
+        fallback = SimpleNamespace(name="PartyPoker")
+
+        chosen = idsite._select_partypoker_skin_site(str(pmu_dir / "hand.txt"), fallback)
+
+        assert chosen.name == "PMU Poker (PartyPoker)"
+
+    def test_unmatched_path_falls_back_to_the_enabled_skin(self, tmp_path: Path) -> None:
+        """The reported bug: the arbitrary survivor is a disabled skin.
+
+        A file outside every configured HH path must land on the room the user
+        actually enabled, not on whichever ``<hhc>`` the config happened to end
+        with.
+        """
+        idsite = _selector(
+            party=_config_site("PartyPoker", str(tmp_path / "party")),
+            pmu=_config_site("PMU Poker (PartyPoker)", str(tmp_path / "pmu"), enabled=False),
+        )
+        fallback = SimpleNamespace(name="PMU Poker (PartyPoker)")
+
+        chosen = idsite._select_partypoker_skin_site(str(tmp_path / "elsewhere" / "hand.txt"), fallback)
+
+        assert chosen.name == "PartyPoker"
+
+    def test_unmatched_path_keeps_the_fallback_when_nothing_is_enabled(self, tmp_path: Path) -> None:
+        idsite = _selector(
+            pmu=_config_site("PMU Poker (PartyPoker)", str(tmp_path / "pmu"), enabled=False),
+        )
+        fallback = SimpleNamespace(name="PartyPoker")
+
+        chosen = idsite._select_partypoker_skin_site(str(tmp_path / "elsewhere" / "hand.txt"), fallback)
+
+        assert chosen.name == "PartyPoker"
+
+
+def _config_with_two_party_skins(tmp_path: Path) -> Path:
+    """Write a config where a disabled Party skin is the last <hhc>."""
+    tree = DefusedET.parse(EXAMPLE_CONFIG)
+    root = tree.getroot()
+
+    sites = root.find("supported_sites")
+    assert sites is not None
+    party = next(s for s in sites.iter("site") if s.get("site_name") == "PartyPoker")
+    party.set("network", "PartyPoker")
+    party.set("enabled", "True")
+    party.set("screen_name", "Hero")
+
+    pmu = copy.deepcopy(party)
+    pmu.set("site_name", "PMU Poker (PartyPoker)")
+    pmu.set("enabled", "False")
+    pmu.set("screen_name", "")
+    pmu.set("HH_path", "")
+    sites.append(pmu)
+
+    hhcs = root.find("hhcs")
+    assert hhcs is not None
+    ET.SubElement(hhcs, "hhc", {"site": "PMU Poker (PartyPoker)", "converter": "PartyPokerToFpdb"})
+
+    path = tmp_path / "HUD_config.xml"
+    tree.write(path, encoding="utf-8", xml_declaration=True)
+    return path
+
+
+def test_import_lands_on_the_enabled_skin_not_the_last_hhc(tmp_path: Path) -> None:
+    """End to end: identification of a real hand history through a full config."""
+    from fpdb_3_legacy.Configuration import Config
+
+    config = Config(file=str(_config_with_two_party_skins(tmp_path)))
+    idsite = IdentifySite(config)
+
+    # The collision itself is unchanged: both skins key on PartyPokerToFpdb.siteId.
+    assert idsite.sitelist[9].name == "PMU Poker (PartyPoker)"
+
+    path = str(CASH_HAND)
+    idsite.processFile(path)
+
+    assert idsite.filelist[path].site.name == "PartyPoker"
+    assert config.get_site_id("PartyPoker") == 9
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/fixtures/hands/live_parser_snapshots.json
+++ b/tests/fixtures/hands/live_parser_snapshots.json
@@ -1495,6 +1495,14 @@
     "hand_count": 1,
     "sha256": "fc68a787750aafdd1b424e2b3db72f7f5a90d0872990b6827d963984789b4ec4"
   },
+  "regression/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202602.cash.out.txt": {
+    "hand_count": 1,
+    "sha256": "2a0fa09ccbba82f2e92bc469aa217b16218055096b410c63866b8cd888df2d6a"
+  },
+  "regression/PartyPoker/Flop/PLO-6max-USD-0.10-0.25-202607.multi.hand.split.txt": {
+    "hand_count": 4,
+    "sha256": "9c199eab52c0aa4c63f591058ddd2af83ee9902604143ce561bfcc8307e95ad2"
+  },
   "regression/PartyPoker/Flop/PLO-6max-USD-5-10-201202.diff.format.txt": {
     "hand_count": 1,
     "sha256": "46850c545e92481f5d647f951f5a3da3608f28885a7682f687bbb3d2240060ec"


### PR DESCRIPTION
## The bug

Party hands import cleanly, land in the database, and never show up in the Hand Viewer.

Every Party skin shares `PartyPokerToFpdb` and its `siteId = 9`, so `IdentifySite.generateSiteList` keys them all on 9 and only the **last `<hhc>` of the config** survives:

```python
site_id = getattr(obj, "site_id", getattr(obj, "siteId", None))
self.sitelist[site_id] = Site(site, filter, ...)
```

On a config carrying the full skin list, that survivor is `PMU Poker (PartyPoker)` — disabled, and without a screen name. Verified against a real config:

```
sitelist[9] -> PMU Poker (PartyPoker)
party/test.txt -> PMU Poker (PartyPoker)
```

The failure is silent from there. `Filters.fillPlayerFrame` builds its hero list from `conf.get_supported_sites()`, which returns enabled sites only, so the skin never reaches the dropdown; and `handsInRangeSessionFilter` has no site predicate — it filters on `<player_test>` → `AND hp.playerId IN (…hero ids…)`. The hands exist and are unreachable.

Confirmed on the database side: the 5 hands sat under `siteId = 129` with their hero flagged `hero = t`, and replaying the viewer's query with that player id returns exactly those 5.

## The fix

PokerStars, WPN and iPoker already resolve their skin from the configured HH/TS paths through the generic `_select_network_skin_site`, and the Party `<site>` entries already declare `network="PartyPoker"`. Only the dispatch was missing — for hand histories and for summaries.

No new logic: the existing scoring `(path_len >= 0, bool(site.enabled), path_len)` settles it. Nothing matches by path here, so the enabled skin wins over the arbitrary survivor.

## Tests

`test/test_partypoker_skin_selection.py` — 4 tests, including an end-to-end one that rebuilds the situation (two Party skins, the disabled one last in `<hhc>`) and identifies a real corpus hand. Without the fix it fails with the reported symptom:

```
AssertionError: assert 'PMU Poker (PartyPoker)' == 'PartyPoker'
```

## Second commit: the hands join the corpus

The cash-out hand and the four-hand export that drove #187 lived as a 90-line string literal inside `test_partypoker_parser_debt`, invisible to the sweep in `test_live_parser_regression` and already drifted from the files it was pasted from (trailing spaces stripped, `** Dealing Flop ** :  [` collapsed).

They are now corpus files under the room's naming convention, which wires them into the sweep — hence the two snapshot entries. Neither needs a `POT_EQUATION_EXCEPTIONS` line: both balance, cash-out included.

Reading them back splits the old test in two, one per file. The walk in the second file gains assertions on the invariant the module already guards: the summary's `collected $0.35` is the blinds in full, the pot is the announced `0.20`, the uncalled `0.15` returned.

## Note for users already affected

The fix only changes future imports. Hands already filed under the wrong skin stay there, and the unique index is `(sitehandno, gametypeid)` with the `siteId` carried in the gametype — so a re-import after this change inserts them a second time rather than deduplicating. They have to be deleted first.

## Verification

Full suite: `7324 passed, 16 skipped` in 1m47. Ruff clean.