### PR TITLE
perf: stop re-parsing the config and sweeping the filesystem on every popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Full explanation in [docs/macos-gatekeeper.md](docs/macos-gatekeeper.md).
 # or: export FPDB_FORCE_X11=1
 ```
 
+### Profiling
+
+Profiling is off by default. To record a session, set `FPDB_PROFILE=1`; fpdb
+then writes a `.prof` and a readable summary to `~/fpdb_profiles` on exit.
+
+```bash
+FPDB_PROFILE=1 python fpdb_3_legacy/fpdb.pyw
+```
+
 ## 🧪 Tests
 
 From the repository root:

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -259,6 +259,48 @@ def _find_example_config(file_name: str) -> str:
     return os.path.join(CONFIG_PATH, example_name).replace("\\", "/")
 
 
+# Parsed example configs, keyed by path -> ((mtime, size), document).
+_EXAMPLE_DOC_CACHE: dict[str, tuple[tuple[float, int], Any]] = {}
+
+
+def _parse_example_config(path: str) -> Any | None:
+    """Return the parsed example config at ``path``, reusing an earlier parse.
+
+    Every ``Config()`` used to parse the ~120 KB example twice -- once for
+    ``add_missing_elements()`` and once for the AoF Omaha migration -- and a
+    single popup that rebuilds several ``Config`` objects paid for it each
+    time. The example ships with the application and only ever gets read
+    (migrations import copies of its nodes into the user document), so one
+    parse can serve every caller. The cache is keyed on the file's mtime and
+    size so a replaced example -- an upgrade dropping a new file in place -- is
+    picked up rather than served stale.
+
+    Returns None when the file is missing or unparsable; callers treat that as
+    "no example available" exactly as they did before.
+    """
+    if not path or not os.path.exists(path):
+        return None
+
+    try:
+        stat = os.stat(path)
+        stamp = (stat.st_mtime, stat.st_size)
+    except OSError:
+        return None
+
+    cached = _EXAMPLE_DOC_CACHE.get(path)
+    if cached is not None and cached[0] == stamp:
+        return cached[1]
+
+    try:
+        doc = defusedxml.minidom.parse(path)
+    except XML_PARSE_ERRORS as e:
+        log.exception(f"Error parsing example configuration file {path}. Exception: {e}")
+        return None
+
+    _EXAMPLE_DOC_CACHE[path] = (stamp, doc)
+    return doc
+
+
 def get_config(file_name, fallback=True):
     """Resolve a user config and optionally bootstrap it from an example file."""
     config_path = os.path.join(CONFIG_PATH, file_name).replace("\\", "/")
@@ -1822,10 +1864,9 @@ class Config:
             if not os.path.exists(source_path):
                 log.info("Example config file %s not found, skipping AoF Omaha HUD migration", source_path)
                 return False
-            try:
-                source_doc = defusedxml.minidom.parse(source_path)
-            except XML_PARSE_ERRORS as exc:
-                log.exception("Could not read the shipped AoF Omaha HUD profile from %s: %s", source_path, exc)
+            source_doc = _parse_example_config(source_path)
+            if source_doc is None:
+                log.warning("Could not read the shipped AoF Omaha HUD profile from %s", source_path)
                 return False
 
         source_profiles = [
@@ -1975,12 +2016,8 @@ class Config:
             log.info(f"Example configuration file {example_file} not found. Skipping missing elements addition.")
             return nodes_added
 
-        try:
-            example_doc = defusedxml.minidom.parse(example_file)
-        except XML_PARSE_ERRORS as e:
-            log.exception(
-                f"Error parsing example configuration file {example_file}. See error log file. Exception: {e}",
-            )
+        example_doc = _parse_example_config(example_file)
+        if example_doc is None:
             return nodes_added
 
         for cnode in doc.getElementsByTagName("FreePokerToolsConfig"):

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -323,6 +323,41 @@ class Database(
 
     # end def __init__
 
+    def connection_params_changed(self, c) -> bool:
+        """Return whether ``c`` points at a different database than the live one."""
+        db_params = c.get_db_parameters()
+        return (
+            db_params["db-backend"] != self.backend
+            or db_params["db-server"] != self.db_server
+            or db_params["db-databaseName"] != self.database
+            or db_params["db-host"] != self.host
+        )
+
+    def rebind_config(self, c) -> bool:
+        """Adopt a freshly parsed config on the open connection, or refuse.
+
+        Reloading the configuration -- which fpdb does before opening most of
+        its dialogs -- used to disconnect and reconnect unconditionally. On a
+        networked backend that is a connect round trip on the GUI thread, and
+        it also throws away the read caches this object keeps for the HUD.
+        When the reloaded config still names the same database there is nothing
+        to reconnect to, so refresh only the values ``__init__`` derives from
+        the config and keep the connection.
+
+        Returns False when the connection is down or the config points
+        somewhere else; the caller then builds a new Database as before.
+        """
+        if not self.is_connected() or self.connection_params_changed(c):
+            return False
+
+        self.config = c
+        self.import_options = c.get_import_parameters()
+        gen = c.get_general_params()
+        self.day_start = float(gen["day_start"]) if "day_start" in gen else 0.0
+        self.sessionTimeout = float(self.import_options["sessionTimeout"])
+        self.publicDB = self.import_options["publicDB"]
+        return True
+
     def _connect_and_configure(self, c) -> None:
         """Open the connection, then set up what needs an open connection."""
         # connect to db

--- a/fpdb_3_legacy/DetectInstalledSites.py
+++ b/fpdb_3_legacy/DetectInstalledSites.py
@@ -1254,6 +1254,38 @@ class CPNDetector(SiteDetector):
         return {"detected": False, "hhpath": "", "heroname": "", "tspath": ""}
 
 
+# Networks this module knows how to look for, in priority order. Kept at module
+# level so callers that only need the list -- "does this site offer auto-detect?"
+# -- can read it without building a DetectInstalledSites, whose constructor
+# parses the configuration and sweeps the filesystem for every network.
+SUPPORTED_SITES = (
+    "PokerStars",
+    "Winamax",
+    "iPoker",
+    "ACR",
+    "SealsWithClubs",
+    # Legacy sites (keeping for compatibility)
+    "PartyPoker",
+    "PartyGaming",
+    "Merge",
+    "Full Tilt Poker",
+    "PacificPoker",
+    "Cake",
+    "CPN",
+    "Everygame",
+    "Bovada",
+    "GGPoker",
+    "Unibet",
+    "KingsClub",
+    "BetOnline",
+)
+
+
+def is_network_detectable(network_name: str) -> bool:
+    """Return whether ``network_name`` has an auto-detection implementation."""
+    return network_name in SUPPORTED_SITES
+
+
 class DetectInstalledSites:
     """Main class for detecting installed poker sites."""
 
@@ -1268,27 +1300,7 @@ class DetectInstalledSites:
         self.detected = ""
 
         # Modern supported sites with priority order
-        self.supported_sites = [
-            "PokerStars",
-            "Winamax",
-            "iPoker",
-            "ACR",
-            "SealsWithClubs",
-            # Legacy sites (keeping for compatibility)
-            "PartyPoker",
-            "PartyGaming",
-            "Merge",
-            "Full Tilt Poker",
-            "PacificPoker",
-            "Cake",
-            "CPN",
-            "Everygame",
-            "Bovada",
-            "GGPoker",
-            "Unibet",
-            "KingsClub",
-            "BetOnline",
-        ]
+        self.supported_sites = list(SUPPORTED_SITES)
 
         # Initialize detectors
         self.detectors = {

--- a/fpdb_3_legacy/ModernSitePreferences.py
+++ b/fpdb_3_legacy/ModernSitePreferences.py
@@ -263,10 +263,16 @@ class ModernSiteCard(QFrame):
                 self.enable_toggle.setChecked(True)
 
     def is_site_detectable(self):
-        """Check if the site is detectable."""
-        detector = DetectInstalledSites.DetectInstalledSites()
+        """Check if the site is detectable.
+
+        Answering this only needs the static list of networks that have a
+        detector. Building a DetectInstalledSites to read that list re-parsed
+        the whole configuration and swept the filesystem for all networks --
+        roughly 1700 stat() calls -- once per site card, so opening this dialog
+        did that work a dozen times over and threw every result away.
+        """
         network_name = self.get_network_for_skin(self.site_name)
-        return network_name in detector.supportedSites
+        return DetectInstalledSites.is_network_detectable(network_name)
 
     def get_network_for_skin(self, site_name):
         """Map a skin to its parent network for detection."""
@@ -289,8 +295,11 @@ class ModernSiteCard(QFrame):
 
     def detect_clicked(self) -> None:
         """Automatically detect paths."""
-        detector = DetectInstalledSites.DetectInstalledSites()
         detection_site = self.get_network_for_skin(self.site_name)
+        # Scope the sweep to the network this card is about: the default "All"
+        # probes every supported network, and "Detect all sites" calls this once
+        # per card, which made detection quadratic in the number of sites shown.
+        detector = DetectInstalledSites.DetectInstalledSites(sitename=detection_site)
 
         if detection_site == "PokerStars":
             all_variants = detector.get_all_pokerstars_variants()

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -128,10 +128,20 @@ sqlite_version = sqlite3.sqlite_version
 
 
 PROFILE_OUTPUT_DIR = os.path.join(os.path.expanduser("~"), "fpdb_profiles")
-os.makedirs(PROFILE_OUTPUT_DIR, exist_ok=True)
 
-profiler = cProfile.Profile()
-profiler.enable()
+# Profiling is opt-in through FPDB_PROFILE=1. It used to be unconditional, so
+# every session -- including the packaged PyInstaller and PyOxidizer builds,
+# which have no way to turn it off -- ran under cProfile. That roughly doubles
+# the cost of the call-heavy Python paths (config parsing, widget building),
+# and each exit dumped a stats file, which is how ~/fpdb_profiles reached a
+# thousand files. Set the variable when you actually want a profile.
+PROFILING_ENABLED = os.environ.get("FPDB_PROFILE", "") not in ("", "0", "false", "False")
+
+profiler = None
+if PROFILING_ENABLED:
+    os.makedirs(PROFILE_OUTPUT_DIR, exist_ok=True)
+    profiler = cProfile.Profile()
+    profiler.enable()
 
 
 # Set up initial console logging to capture early logs
@@ -1284,13 +1294,18 @@ class fpdb(QMainWindow):
             )
             sys.exit()
 
-        # Now reconfigure logging with the log directory from the configuration
-        setup_logging(log_dir=self.config.dir_log)
-        if options.log_level != "EMPTY":
-            level = getattr(logging, options.log_level)
-            logging.getLogger().setLevel(level)
-            for handler in logging.getLogger().handlers:
-                handler.setLevel(level)
+        # Now reconfigure logging with the log directory from the configuration.
+        # Only when it actually changed: setup_logging() tears down the root
+        # handlers and reopens the rotating log file, and load_profile() runs on
+        # nearly every dialog the menus open.
+        if self.config.dir_log != getattr(self, "_configured_log_dir", None):
+            setup_logging(log_dir=self.config.dir_log)
+            self._configured_log_dir = self.config.dir_log
+            if options.log_level != "EMPTY":
+                level = getattr(logging, options.log_level)
+                logging.getLogger().setLevel(level)
+                for handler in logging.getLogger().handlers:
+                    handler.setLevel(level)
 
         log.info(f"Logfile is {os.path.join(self.config.dir_log, 'fpdb-log.txt')}")
         log.info(f"load profiles {self.config.example_copy}")
@@ -1352,46 +1367,57 @@ class fpdb(QMainWindow):
         self.settings.update(self.config.get_import_parameters())
         self.settings.update(self.config.get_default_paths())
 
-        # Disconnect from the database if already connected
-        if self.db is not None and self.db.is_connected():
-            self.db.disconnect()
-
         # Set up SQL and connect to the database
         self.sql = SQL.Sql(db_server=self.settings["db-server"])
         err_msg = None
-        try:
-            self.db = Database.Database(self.config, sql=self.sql)
-            if self.db.get_backend_name() == "SQLite":
-                # Inform SQLite users where the database file is located
-                log.info(f"Connected to SQLite: {self.db.db_path}")
-        except Exceptions.FpdbMySQLAccessDenied:
-            err_msg = "MySQL Server reports: Access denied. Are your permissions set correctly?"
-        except Exceptions.FpdbMySQLNoDatabase:
-            err_msg = (
-                "MySQL client reports: 2002 or 2003 error."
-                " Unable to connect - Please check that the MySQL service has been started."
-            )
-        except Exceptions.FpdbPostgresqlAccessDenied:
-            err_msg = "PostgreSQL Server reports: Access denied. Are your permissions set correctly?"
-        except Exceptions.FpdbPostgresqlNoDatabase:
-            err_msg = (
-                "PostgreSQL client reports: Unable to connect - "
-                "Please check that the PostgreSQL service has been started."
-            )
-        except Exceptions.FpdbError as e:
-            # Any other connection failure (e.g. host cannot be resolved). Catch
-            # it here so a bad database config does not crash fpdb at startup.
-            err_msg = str(e)
-        self._db_connect_error = err_msg
-        if err_msg is not None:
-            self.db = None
-            # During startup recovery (_ensure_database_or_prompt) a single
-            # recovery dialog is shown instead of this warning; warn directly
-            # otherwise (e.g. reloads triggered from the menus).
-            if not getattr(self, "_suppress_db_warning", False):
-                self.warning_box(err_msg)
-        if self.db is not None and not self.db.is_connected():
-            self.db = None
+
+        # Reuse the live connection when the reloaded config still names the
+        # same database: the menus call load_profile() on nearly every dialog,
+        # and reconnecting each time cost a round trip on the GUI thread and
+        # dropped the database read caches for no gain.
+        reused_connection = self.db is not None and self.db.rebind_config(self.config)
+        if reused_connection:
+            self.db.sql = self.sql
+            self._db_connect_error = None
+            log.debug("Configuration reloaded; keeping the existing database connection")
+        else:
+            # Disconnect from the database if already connected
+            if self.db is not None and self.db.is_connected():
+                self.db.disconnect()
+
+            try:
+                self.db = Database.Database(self.config, sql=self.sql)
+                if self.db.get_backend_name() == "SQLite":
+                    # Inform SQLite users where the database file is located
+                    log.info(f"Connected to SQLite: {self.db.db_path}")
+            except Exceptions.FpdbMySQLAccessDenied:
+                err_msg = "MySQL Server reports: Access denied. Are your permissions set correctly?"
+            except Exceptions.FpdbMySQLNoDatabase:
+                err_msg = (
+                    "MySQL client reports: 2002 or 2003 error."
+                    " Unable to connect - Please check that the MySQL service has been started."
+                )
+            except Exceptions.FpdbPostgresqlAccessDenied:
+                err_msg = "PostgreSQL Server reports: Access denied. Are your permissions set correctly?"
+            except Exceptions.FpdbPostgresqlNoDatabase:
+                err_msg = (
+                    "PostgreSQL client reports: Unable to connect - "
+                    "Please check that the PostgreSQL service has been started."
+                )
+            except Exceptions.FpdbError as e:
+                # Any other connection failure (e.g. host cannot be resolved). Catch
+                # it here so a bad database config does not crash fpdb at startup.
+                err_msg = str(e)
+            self._db_connect_error = err_msg
+            if err_msg is not None:
+                self.db = None
+                # During startup recovery (_ensure_database_or_prompt) a single
+                # recovery dialog is shown instead of this warning; warn directly
+                # otherwise (e.g. reloads triggered from the menus).
+                if not getattr(self, "_suppress_db_warning", False):
+                    self.warning_box(err_msg)
+            if self.db is not None and not self.db.is_connected():
+                self.db = None
 
         # Check for database version issues
         if self.db is not None and self.db.wrongDbVersion:
@@ -2048,17 +2074,19 @@ if __name__ == "__main__":
 
         app.exec()
     finally:
-        profiler.disable()
-        s = io.StringIO()
-        ps = pstats.Stats(profiler, stream=s).sort_stats("cumulative")
-        ps.print_stats()
+        if profiler is not None:
+            profiler.disable()
+            s = io.StringIO()
+            ps = pstats.Stats(profiler, stream=s).sort_stats("cumulative")
+            ps.print_stats()
 
-        # Use timestamp or process ID for unique filenames
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
-        results_file = os.path.join(PROFILE_OUTPUT_DIR, f"fpdb_profile_results_{timestamp}.txt")
-        profile_file = os.path.join(PROFILE_OUTPUT_DIR, f"fpdb_profile_{timestamp}.prof")
+            # Use timestamp or process ID for unique filenames
+            timestamp = time.strftime("%Y%m%d-%H%M%S")
+            results_file = os.path.join(PROFILE_OUTPUT_DIR, f"fpdb_profile_results_{timestamp}.txt")
+            profile_file = os.path.join(PROFILE_OUTPUT_DIR, f"fpdb_profile_{timestamp}.prof")
 
-        with open(results_file, "w") as f:
-            f.write(s.getvalue())
+            with open(results_file, "w") as f:
+                f.write(s.getvalue())
 
-        profiler.dump_stats(profile_file)
+            profiler.dump_stats(profile_file)
+            log.info(f"Profile written to {profile_file}")

--- a/tests/qt/test_modern_site_preferences.py
+++ b/tests/qt/test_modern_site_preferences.py
@@ -24,6 +24,41 @@ def test_site_card_prefills_extra_aliases(qtbot) -> None:
 
 
 @pytest.mark.qt
+def test_site_card_does_not_scan_the_filesystem_to_offer_auto_detect(qtbot, monkeypatch) -> None:
+    """Building a card must not run site detection.
+
+    Whether a site offers auto-detection is a lookup in a static list, but it
+    used to be answered by constructing a DetectInstalledSites -- which parses
+    the configuration and probes the filesystem for every supported network.
+    One card did that once; a dialog full of them froze the UI for seconds, and
+    on a cold cache far longer.
+    """
+    from fpdb_3_legacy import DetectInstalledSites
+    from fpdb_3_legacy.ModernSitePreferences import ModernSiteCard
+
+    def explode(*args, **kwargs):
+        msg = "site detection must not run while building a site card"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(DetectInstalledSites, "DetectInstalledSites", explode)
+
+    site_config = types.SimpleNamespace(
+        enabled=True,
+        screen_name="main",
+        hero_aliases=["main"],
+        HH_path="/tmp/hh",
+        TS_path="",
+    )
+    card = ModernSiteCard("PokerStars", site_config)
+    qtbot.addWidget(card)
+
+    # PokerStars has a detector, so the button is still offered.
+    assert card.is_site_detectable() is True
+    # A site with no detector still gets no button.
+    assert not ModernSiteCard("Some Unknown Room", site_config).is_site_detectable()
+
+
+@pytest.mark.qt
 def test_site_card_get_values_returns_deduped_hero_aliases(qtbot) -> None:
     from fpdb_3_legacy.ModernSitePreferences import ModernSiteCard
 

--- a/tests/test_config_reload_cost.py
+++ b/tests/test_config_reload_cost.py
@@ -1,0 +1,154 @@
+"""Opening a dialog should not re-do work that has already been done.
+
+fpdb reloads its configuration before opening most of its dialogs, and each
+reload used to re-parse the shipped example configuration and reconnect to the
+database. Neither is free: the example is a ~120 KB XML file, and the reconnect
+is a round trip on the GUI thread that also empties the database read caches.
+The tests here pin the cheap behaviour so it does not quietly come back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import fpdb_3_legacy.Configuration as config_module
+from fpdb_3_legacy.Database import Database
+
+EXAMPLE = """<?xml version="1.0"?>
+<FreePokerToolsConfig>
+  <hud_ui label="From the example"/>
+</FreePokerToolsConfig>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_example_cache() -> Any:
+    """Keep the module-level parse cache from leaking between tests."""
+    config_module._EXAMPLE_DOC_CACHE.clear()
+    yield
+    config_module._EXAMPLE_DOC_CACHE.clear()
+
+
+def write_example(tmp_path: Path, body: str = EXAMPLE) -> str:
+    path = tmp_path / "HUD_config.xml.example"
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+class TestExampleConfigCache:
+    def test_second_parse_reuses_the_first(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        example = write_example(tmp_path)
+        parses = []
+        real_parse = config_module.defusedxml.minidom.parse
+
+        def counting_parse(path: str, *args: Any, **kwargs: Any) -> Any:
+            parses.append(path)
+            return real_parse(path, *args, **kwargs)
+
+        monkeypatch.setattr(config_module.defusedxml.minidom, "parse", counting_parse)
+
+        first = config_module._parse_example_config(example)
+        second = config_module._parse_example_config(example)
+
+        assert first is second
+        assert parses == [example]
+
+    def test_a_replaced_example_is_re_read(self, tmp_path: Path) -> None:
+        example = write_example(tmp_path)
+        first = config_module._parse_example_config(example)
+
+        # A new file at the same path -- an upgrade dropping in a newer example
+        # -- must not be served from the cache. Force a distinct mtime so the
+        # test does not depend on filesystem timestamp resolution.
+        Path(example).write_text(EXAMPLE.replace("From the example", "Updated"), encoding="utf-8")
+        stat = Path(example).stat()
+        import os
+
+        os.utime(example, (stat.st_atime + 10, stat.st_mtime + 10))
+
+        second = config_module._parse_example_config(example)
+
+        assert second is not first
+        assert second.getElementsByTagName("hud_ui")[0].getAttribute("label") == "Updated"
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert config_module._parse_example_config(str(tmp_path / "absent.xml")) is None
+
+    def test_unparsable_file_returns_none(self, tmp_path: Path) -> None:
+        broken = tmp_path / "broken.xml.example"
+        broken.write_text("<not-closed>", encoding="utf-8")
+        assert config_module._parse_example_config(str(broken)) is None
+
+
+class FakeConfig:
+    """Just the two accessors Database reads back out of a config."""
+
+    def __init__(self, **db_params: Any) -> None:
+        self._db_params = {
+            "db-backend": 4,
+            "db-server": "sqlite",
+            "db-databaseName": "fpdb.db3",
+            "db-host": "localhost",
+            **db_params,
+        }
+
+    def get_db_parameters(self) -> dict[str, Any]:
+        return dict(self._db_params)
+
+    def get_import_parameters(self) -> dict[str, Any]:
+        return {"sessionTimeout": "45", "publicDB": True}
+
+    def get_general_params(self) -> dict[str, Any]:
+        return {"day_start": "6"}
+
+
+def make_db(*, connected: bool) -> Database:
+    """A Database with the attributes rebind_config touches, and nothing else."""
+    db = Database.__new__(Database)
+    db.backend = 4
+    db.db_server = "sqlite"
+    db.database = "fpdb.db3"
+    db.host = "localhost"
+    db.config = FakeConfig()
+    db.import_options = {"sessionTimeout": "30", "publicDB": False}
+    db.day_start = 0.0
+    db.sessionTimeout = 30.0
+    db.publicDB = False
+    db._Database__connected = connected
+    return db
+
+
+class TestRebindConfig:
+    def test_same_database_keeps_the_connection_and_refreshes_values(self) -> None:
+        db = make_db(connected=True)
+        new_config = FakeConfig()
+
+        assert db.rebind_config(new_config) is True
+        assert db.config is new_config
+        # The values __init__ derives from the config follow the reload, so a
+        # kept connection never serves stale import settings.
+        assert db.sessionTimeout == 45.0
+        assert db.publicDB is True
+        assert db.day_start == 6.0
+
+    def test_a_different_database_refuses_the_rebind(self) -> None:
+        db = make_db(connected=True)
+        moved = FakeConfig(**{"db-databaseName": "other.db3"})
+
+        assert db.rebind_config(moved) is False
+        assert db.config is not moved
+
+    def test_a_different_host_refuses_the_rebind(self) -> None:
+        db = make_db(connected=True)
+        assert db.rebind_config(FakeConfig(**{"db-host": "remote"})) is False
+
+    def test_a_different_backend_refuses_the_rebind(self) -> None:
+        db = make_db(connected=True)
+        assert db.rebind_config(FakeConfig(**{"db-backend": 2, "db-server": "postgresql"})) is False
+
+    def test_a_closed_connection_refuses_the_rebind(self) -> None:
+        db = make_db(connected=False)
+        assert db.rebind_config(FakeConfig()) is False

--- a/tests/test_detect_installed_sites.py
+++ b/tests/test_detect_installed_sites.py
@@ -714,6 +714,28 @@ def test_each_detected_room_reports_a_hand_history_path(detector) -> None:
         assert info["hhpath"]
 
 
+def test_the_rooms_it_can_look_for_are_known_without_building_a_detector(detector) -> None:
+    # The auto-detect button in Site Preferences only needs this list, and asking
+    # a whole DetectInstalledSites for it meant one config parse and one
+    # filesystem sweep per site card.
+    assert list(detect_module.SUPPORTED_SITES) == detector.supportedSites
+    assert detect_module.is_network_detectable("PokerStars")
+    assert not detect_module.is_network_detectable("A Room That Does Not Exist")
+
+
+@pytest.mark.parametrize("network", ["PokerStars", "iPoker", "PartyGaming"])
+def test_looking_for_one_room_still_answers_for_that_room(network) -> None:
+    # Site Preferences detects the network of the card that was clicked, rather
+    # than sweeping all of them, so the scoped construction has to fill in
+    # everything the caller reads back.
+    scoped = DetectInstalledSites(sitename=network)
+
+    assert network in scoped.sitestatusdict
+    assert set(scoped.sitestatusdict[network]) >= {"detected", "hhpath", "heroname", "tspath"}
+    for accessor in ("get_all_pokerstars_variants", "get_all_ipoker_skins", "get_all_partypoker_skins"):
+        assert isinstance(getattr(scoped, accessor)(), list)
+
+
 @pytest.mark.parametrize(
     "accessor", ["get_all_pokerstars_variants", "get_all_ipoker_skins", "get_all_partypoker_skins"]
 )


### PR DESCRIPTION
## Why

Opening the various UI popups was slow, and sometimes froze the app for a long
time, most visibly in the packaged PyInstaller/PyOxidizer builds. Profiles taken
from real sessions (`~/fpdb_profiles`) showed a single session doing **27 full
parses of the 300 KB `HUD_config.xml`**, 23 of them triggered by one opening of
Site Preferences, and `dia_site_preferences` accounting for 34 s of a 277 s
session.

## What changed

**1. Profiling is opt-in.** `cProfile` was enabled at import in `fpdb.pyw` and
never gated, so *every* session ran under the profiler — including the packaged
builds, which give the user no way to switch it off. Measured overhead on the
call-heavy paths: `Configuration.Config()` 70 ms → 133 ms (1.9x). It also wrote
a stats file on every exit (my `~/fpdb_profiles` had reached 1148 files /
364 MB). Now behind `FPDB_PROFILE=1`, documented in the README.

**2. Site Preferences no longer sweeps the filesystem per card.**
`ModernSiteCard.is_site_detectable()` built a whole `DetectInstalledSites` —
which parses the configuration and probes the filesystem for all 18 supported
networks, ~1700 `stat()` calls — just to read a static list of network names,
then discarded everything else. It ran once per site card. The list is now a
module-level `SUPPORTED_SITES` with an `is_network_detectable()` helper.
"Auto-Detect Paths" also scopes its sweep to that card's network instead of all
of them, so "Detect all sites" stops being quadratic.

**3. Reloading the config keeps the database connection.** `load_profile()` runs
before nearly every dialog the menus open, and unconditionally disconnected and
reconnected — a round trip on the GUI thread that also emptied the database read
caches. New `Database.rebind_config()` adopts the freshly parsed config on the
open connection when it still names the same database (refreshing the values
`__init__` derives from the config, so nothing goes stale) and refuses when the
backend, host or database name changed, in which case the old reconnect path
runs unchanged. `load_profile()` also stops rebuilding the logging handlers when
the log directory has not changed.

**4. The example configuration is parsed once.** Each `Config()` parsed the
~120 KB example twice — once for `add_missing_elements()`, once for the AoF
Omaha migration. Both only read it, so it is now cached on the file's mtime and
size (a replaced example is still picked up).

## Measured

| | before | after |
|---|---|---|
| Build `ModernSitePreferencesDialog` (warm cache) | 1142 ms | **134 ms** |
| `Config()` parses while doing so | 10 | **0** |
| XML parses per `Config()` (steady state) | 3 | **1** |
| `Config()` cost, repeat calls | 107 ms | **69 ms** |
| Profiler overhead on `Config()` | 1.9x | **none** |

On a cold filesystem cache the win is far larger: in one measurement the first
`DetectInstalledSites()` of a process took **137 s** (subsequent ones ~90 ms),
and that construction was being repeated once per site card.

## Deliberately not in this PR

Replacing minidom with ElementTree in `Configuration`. It would cut the one
remaining parse from ~19 ms to ~3 ms, but minidom's DOM is reachable from 35
files including the config *write* path, so it is a cross-cutting refactor with
real regression risk on config persistence — and after the changes above,
`Config()` runs once or twice per session instead of 27 times, which makes the
remaining gain marginal. Worth its own PR with dedicated round-trip coverage.

Also worth knowing, though not a code issue: the downloaded macOS build still
carried `com.apple.quarantine` on 3344 files and was running under App
Translocation (`/private/var/…/AppTranslocation/…` shows up in the profiles),
which adds Gatekeeper validation on first touch of every resource each new popup
loads. `docs/macos-gatekeeper.md` already covers the fix.

## Tests

`ruff check` clean. Full suite: 7328 passed, plus 29 Qt tests. New coverage for
the example-config cache and its invalidation, `Database.rebind_config()`
accepting/refusing, the scoped site detection, and a Qt regression test that
fails if building a site card ever runs detection again.
