### PR TITLE
fix(l10n, partypoker): suppress spurious log warnings for English locale and stub methods

### DIFF
--- a/fpdb_3_legacy/L10n.py
+++ b/fpdb_3_legacy/L10n.py
@@ -201,17 +201,21 @@ def set_locale_translation(config_path: str | None = None) -> None:
     resolved_locale = set_format_locale(ui_language)
     log.info("Display format locale: %s", resolved_locale)
 
-    try:
-        fr_translation = gettext.translation(
-            "fpdb",
-            path_string,
-            languages=[ui_language] if ui_language and ui_language != "system" else None,
-        )
-        fr_translation.install()
-    except (FileNotFoundError, OSError):
+    if not ui_language or ui_language == "en" or ui_language.startswith("en_"):
         gettext.NullTranslations().install()
-        log.warning(
-            "No translation file found for domain 'fpdb' in %s for language %s; using source strings.",
-            path_string,
-            ui_language,
-        )
+        log.info("Using source strings for language: %s", ui_language or "en")
+    else:
+        try:
+            fr_translation = gettext.translation(
+                "fpdb",
+                path_string,
+                languages=[ui_language] if ui_language != "system" else None,
+            )
+            fr_translation.install()
+        except (FileNotFoundError, OSError):
+            gettext.NullTranslations().install()
+            log.warning(
+                "No translation file found for domain 'fpdb' in %s for language %s; using source strings.",
+                path_string,
+                ui_language,
+            )

--- a/fpdb_3_legacy/L10n.py
+++ b/fpdb_3_legacy/L10n.py
@@ -201,15 +201,19 @@ def set_locale_translation(config_path: str | None = None) -> None:
     resolved_locale = set_format_locale(ui_language)
     log.info("Display format locale: %s", resolved_locale)
 
-    if not ui_language or ui_language == "en" or ui_language.startswith("en_"):
+    # English is the language the source strings are written in, so there is no
+    # catalogue to find and never was: asking for one only produced a warning on
+    # every start. A missing ui_language is not English, though -- it means the
+    # same as "system", and has to keep falling through to the environment.
+    if ui_language == "en" or (ui_language or "").startswith("en_"):
         gettext.NullTranslations().install()
-        log.info("Using source strings for language: %s", ui_language or "en")
+        log.info("Using source strings for language: %s", ui_language)
     else:
         try:
             fr_translation = gettext.translation(
                 "fpdb",
                 path_string,
-                languages=[ui_language] if ui_language != "system" else None,
+                languages=[ui_language] if ui_language and ui_language != "system" else None,
             )
             fr_translation.install()
         except (FileNotFoundError, OSError):

--- a/fpdb_3_legacy/PartyPokerToFpdb.py
+++ b/fpdb_3_legacy/PartyPokerToFpdb.py
@@ -508,9 +508,6 @@ class PartyPoker(HandHistoryConverter):
 
     def readSTP(self, hand) -> None:
         log.debug(f"Starting STP read hand_id: {hand.handid}, status: not_implemented")
-        log.warning(
-            f"STP functionality not implemented hand_id: {hand.handid}, method: readSTP",
-        )
 
     def _determineCurrency(self, stakeSymbol: str, handText: str) -> str:
         """Resolve the currency a ring game's amounts are expressed in.
@@ -1476,7 +1473,7 @@ class PartyPoker(HandHistoryConverter):
 
     def readBringIn(self, hand) -> None:
         log.info("Entering readBringIn method")
-        log.warning("Method not implemented")
+        log.debug("Method not implemented")
 
     def readHoleCards(self, hand) -> None:
         log.info("Entering readHoleCards method")
@@ -1624,7 +1621,7 @@ class PartyPoker(HandHistoryConverter):
 
     def readShowdownActions(self, hand) -> None:
         log.debug("Entering readShowdownActions method")
-        log.warning("Method not implemented")
+        log.debug("Method not implemented")
 
     def readCollectPot(self, hand) -> None:
         log.info("Entering readCollectPot method")
@@ -1730,7 +1727,7 @@ class PartyPoker(HandHistoryConverter):
 
     def readSummaryInfo(self, summaryInfoList) -> bool:
         log.debug("Entering readSummaryInfo method")
-        log.warning("Method not implemented")
+        log.debug("Method not implemented")
         return True
 
     def convert_to_decimal(self, string):

--- a/test/test_l10n_config_path.py
+++ b/test/test_l10n_config_path.py
@@ -68,6 +68,53 @@ def test_explicit_missing_path_falls_back_to_get_config(tmp_path, monkeypatch) -
     L10n.set_locale_translation(str(tmp_path / "does-not-exist.xml"))  # must not raise
 
 
+def _config_with(tmp_path, general_attrs: str):
+    cfg = tmp_path / "HUD_config.xml"
+    cfg.write_text(f"<config><general {general_attrs}></general></config>")
+    return cfg
+
+
+def test_english_does_not_look_for_a_catalogue(tmp_path, monkeypatch, caplog) -> None:
+    """English is the source language, so there is no catalogue to miss.
+
+    Asking gettext for one only ever produced a warning on every start.
+    """
+    asked = []
+    monkeypatch.setattr(
+        L10n.gettext,
+        "translation",
+        lambda *args, **kwargs: asked.append(kwargs.get("languages")),
+    )
+
+    with caplog.at_level("WARNING"):
+        L10n.set_locale_translation(str(_config_with(tmp_path, 'ui_language="en"')))
+
+    assert asked == []
+    assert "No translation file found" not in caplog.text
+
+
+def test_a_missing_ui_language_still_follows_the_environment(tmp_path, monkeypatch) -> None:
+    """No ui_language means the same as "system", not English.
+
+    Both have to reach gettext with languages=None so it reads the environment;
+    treating a missing value as English would silently pin such a config to
+    untranslated strings.
+    """
+    asked = []
+
+    def fake_translation(_domain, _localedir=None, languages=None, **_kwargs):
+        asked.append(languages)
+        msg = "no catalogue"
+        raise FileNotFoundError(msg)
+
+    monkeypatch.setattr(L10n.gettext, "translation", fake_translation)
+
+    L10n.set_locale_translation(str(_config_with(tmp_path, 'other="x"')))
+    L10n.set_locale_translation(str(_config_with(tmp_path, 'ui_language="system"')))
+
+    assert asked == [None, None]
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Description

This PR fixes two sources of spurious `WARNING` logs during FPDB-3 execution:

1. **L10n / Translation warning**:
   - `No translation file found for domain 'fpdb' in .../locale for language en; using source strings.`
   - When `ui_language` is English (`en` or `en_*`), `set_locale_translation()` attempted to load a non-existent `locale/fpdb-en.po` catalog file. English is the source language of FPDB-3 string literals.
   - **Fix**: Skip calling `gettext.translation()` when `ui_language` is English and install `gettext.NullTranslations()` quietly.

2. **PartyPoker parser warnings**:
   - `STP functionality not implemented hand_id: ..., method: readSTP`
   - `Method not implemented`
   - `readSTP` and `readShowdownActions` are stub methods called on every hand by `Hand.py`. In `PartyPokerToFpdb.py`, these methods logged a `WARNING` on every single hand import, cluttering the logs.
   - **Fix**: Lower log verbosity from `log.warning` to `log.debug` in `readSTP`, `readShowdownActions`, `readBringIn`, and `readSummaryInfo`.

## Verification
- Ran `uv run pytest test/test_partypoker_parser_debt.py test/test_partypoker_summary.py`
- Ran `uv run pytest -k "l10n or translation"`
- All unit tests pass cleanly.