### PR TITLE
chore(release): prepare 3.4.2

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.4.1"
+__version__ = "3.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.4.1"
+version = "3.4.2"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.4.1"
+version = "3.4.2"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prepares the 3.4.2 release. Version bump only — no behaviour change.

## The bump

The declared version lives in three independent places, none derived from
another, so all three move together or they drift silently (v3.3.0 shipped
three releases stale for exactly that reason):

- `pyproject.toml` → `[project].version`
- `pyproject.toml` → `[tool.briefcase].version`
- `fpdb_3_legacy/__init__.py` → `__version__`

`uv.lock` follows automatically and is committed alongside.

## Verified

- `uv build --wheel` → `fpdb_3-3.4.2-py3-none-any.whl`
- `fpdb_3_legacy.__version__` → `3.4.2` (what a frozen build reports, via
  `_resolve_version()`)
- `test/test_fpdb_version_resolution.py` — 6 passed
- `ruff check fpdb_3_legacy fpdb test tests tools` — clean
- Full suite — 7394 passed, 16 skipped
- CI on `development` at `45b9446a` — **18/18 jobs green**
  ([run 31149818387](https://github.com/jejellyroll-fr/fpdb-3/actions/runs/31149818387)),
  dispatched manually because the pushes that merged #190–#198 landed during
  the GitHub Actions outage and never got a run created

## Release notes drafted for the tag

<details>
<summary>v3.4.2 — click to expand</summary>

## Performance

Opening the UI popups was slow, and could freeze the app for a long time,
most visibly in the packaged builds. Four causes, all fixed (#197):

- **Profiling is now opt-in.** `cProfile` was enabled at import and never
  gated, so every session ran under the profiler — including the PyInstaller
  and PyOxidizer builds, which gave no way to switch it off. Set
  `FPDB_PROFILE=1` when you actually want a profile.
- **Site Preferences no longer sweeps the filesystem once per site card.**
  Deciding whether a site offers auto-detection built a whole
  `DetectInstalledSites` — parsing the configuration and probing the
  filesystem for all 18 supported networks — and discarded everything but a
  static list. Building the dialog: **1142 ms → 134 ms** on a warm cache, and
  far more on a cold one.
- **Reloading the configuration keeps the live database connection** when it
  still names the same database, instead of reconnecting on the GUI thread and
  emptying the read caches. It also stops rebuilding the logging handlers when
  the log directory has not changed.
- **The shipped example configuration is parsed once** rather than twice per
  `Config()`.

`Config()` went from 27 parses in a recorded session to one or two.

## Fixes

- **PartyPoker: hands are attributed to the configured skin** instead of
  whichever `<hhc>` entry happened to be last in the config. Every Party skin
  shares `siteId = 9`, so only the last one survived site-list generation —
  silently, with imports reporting success while the hands landed under the
  wrong room (#196).
- **iPoker: a deterministic cleanup tool for duplicate session hands** on
  databases that were already imported, hardened before it deletes anything
  (#193).
- **A configuration with no `ui_language` is treated as "system" again**, not
  as English. Old or hand-edited configs were being pinned to untranslated
  strings (#198).
- Spurious log warnings for the English locale and for stub methods are gone
  (#198).

## Internal

- `DatabasePlayersMixin` extracted out of `Database.py` into
  `database_players.py` (#194).
- Real-hand coverage for `uncalledbets`, and its dead code removed (#191).
- Unit tests for the GUI formatting and business logic (#195).
- The `known_failures` list in `conftest.py` is purged — the ten tests pass
  (#190).
- The `perf` suite finally runs in CI: Linux only and advisory, because
  wall-clock budgets on shared runners fail on scheduling noise rather than on
  regressions (#192).

**Full changelog**: https://github.com/jejellyroll-fr/fpdb-3/compare/v3.4.1...v3.4.2


</details>

## Remaining steps (not done here)

1. Merge this PR into `development`.
2. Fast-forward `main` to that commit — `main` is the release branch and moves
   only when a release is cut.
3. Tag `v3.4.2` (the `v` prefix is required; a bare `3.3.0` tag was created by
   mistake once and had to be deleted).
4. Publish the GitHub release with the notes above. `ci.yml` runs on
   `release: published` and uploads the PyInstaller/PyOxidizer tarballs itself.

## Worth knowing

`docs/BACKLOG.md` still opens with "État au 2026-08-06, après la 3.4.1", and
most of its items were burned down by #190–#197. Refreshing it needs a
judgement call per item on done-vs-partial (items 5 and 6 only moved part of
the way), so it is left out of this PR rather than guessed at.
