### PR TITLE
fix(pyoxidizer, hud): resolve macOS bundle resource path and position mucked hands under HUD

### DIFF
--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -85,7 +85,12 @@ def _frozen_resource_root() -> str:
     bundle_dir = getattr(sys, "_MEIPASS", None)
     if bundle_dir:
         return os.path.abspath(os.fspath(bundle_dir))
-    return os.path.dirname(os.path.abspath(sys.executable))
+    exe_dir = os.path.dirname(os.path.abspath(sys.executable))
+    if os.path.basename(exe_dir) == "MacOS":
+        resources_dir = os.path.join(os.path.dirname(exe_dir), "Resources")
+        if os.path.isdir(resources_dir):
+            return resources_dir
+    return exe_dir
 
 
 if hasattr(sys, "frozen"):

--- a/fpdb_3_legacy/Mucked.py
+++ b/fpdb_3_legacy/Mucked.py
@@ -315,15 +315,15 @@ class Flop_Mucked(Aux_Base.AuxSeats, QObject):
             x, y = self._table_position(i)
         else:
             geometry = anchor.frameGeometry()
-            x = geometry.right() + margin
-            y = geometry.top()
+            x = geometry.left()
+            y = geometry.bottom() + margin
 
             screen = container.screen() or anchor.screen()
             if screen is not None:
                 available = screen.availableGeometry()
-                if x + width > available.right():
-                    x = geometry.left() - width - margin
-                y = max(available.top(), min(y, available.bottom() - height + 1))
+                if y + height > available.bottom():
+                    y = geometry.top() - height - margin
+                x = max(available.left(), min(x, available.right() - width + 1))
 
         x, y = Aux_Base.clamp_to_screen(x, y, width, height)
         container.move(x, y)

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -745,6 +745,44 @@ class TestMuckedCards(unittest.TestCase):
         assert mucked.card_width == int(56 * 0.7)  # 39
         assert mucked.card_height == int(78 * 0.7)  # 54
 
+    def test_mucked_cards_positioned_under_hud(self) -> None:
+        """Test that Flop_Mucked positions card container below the anchor HUD window."""
+        from PySide6.QtCore import QRect
+        from fpdb_3_legacy.Mucked import Flop_Mucked
+
+        mock_parent = Mock()
+        mock_parent.hud_params = {"card_ht": "50", "card_wd": "30"}
+        mock_hud = Mock()
+        mock_hud.parent = mock_parent
+        mock_config = Mock()
+
+        mucked = Flop_Mucked(mock_hud, mock_config, {})
+
+        anchor_window = Mock()
+        anchor_window.windowTitle.return_value = "HUD - stats"
+        anchor_window.frameGeometry.return_value = QRect(100, 200, 150, 80)
+        anchor_window.screen.return_value = None
+
+        stat_aux = Mock()
+        stat_aux.uses_timer = False
+        stat_aux.m_windows = {1: anchor_window}
+
+        mucked.hud.aux_windows = [mucked, stat_aux]
+
+        hint = Mock()
+        hint.width.return_value = 60
+        hint.height.return_value = 40
+        container = Mock()
+        container.width.return_value = 60
+        container.height.return_value = 40
+        container.sizeHint.return_value = hint
+        container.screen.return_value = None
+
+        mucked._move_next_to_hud(container, 1)
+
+        # Left = 100, Bottom = 200 + 80 - 1 = 279, Margin = 6 -> y = 285
+        container.move.assert_called_once_with(100, 285)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -748,6 +748,7 @@ class TestMuckedCards(unittest.TestCase):
     def test_mucked_cards_positioned_under_hud(self) -> None:
         """Test that Flop_Mucked positions card container below the anchor HUD window."""
         from PySide6.QtCore import QRect
+
         from fpdb_3_legacy.Mucked import Flop_Mucked
 
         mock_parent = Mock()

--- a/test/unit_legacy/test_configuration_legacy.py
+++ b/test/unit_legacy/test_configuration_legacy.py
@@ -191,6 +191,19 @@ def test_frozen_resource_root_falls_back_to_executable(tmp_path, monkeypatch) ->
     assert Configuration._frozen_resource_root() == str(executable.parent)
 
 
+def test_frozen_resource_root_macos_app_bundle_resources(tmp_path, monkeypatch) -> None:
+    macos_dir = tmp_path / "Contents" / "MacOS"
+    resources_dir = tmp_path / "Contents" / "Resources"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    executable = macos_dir / "fpdb"
+
+    monkeypatch.delattr(Configuration.sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(Configuration.sys, "executable", str(executable))
+
+    assert Configuration._frozen_resource_root() == str(resources_dir)
+
+
 def test_get_config_bootstraps_user_file_from_source_example(tmp_path, monkeypatch) -> None:
     config_dir = tmp_path / "config"
     source_dir = tmp_path / "source"


### PR DESCRIPTION
## Description

1. **Fix PyOxidizer HUD Menu Icon & Mucked Cards**:
   - `_frozen_resource_root()` in `Configuration.py` previously returned `os.path.dirname(os.path.abspath(sys.executable))`.
   - In PyOxidizer macOS `.app` bundles (`Contents/MacOS/fpdb`), assets like `gfx/tribal.jpg` and `gfx/cards/*` sit in `Contents/Resources/gfx`.
   - `_frozen_resource_root()` now detects `Contents/Resources` when running inside a macOS bundle, ensuring `GRAPHICS_PATH` resolves correctly so HUD menu icons and mucked card SVG images are properly loaded.

2. **Position Mucked Hands Under Player HUD**:
   - Updated `Flop_Mucked._move_next_to_hud` in `fpdb_3_legacy/Mucked.py` to position mucked cards directly under each player's HUD block (`geometry.left()`, `geometry.bottom() + margin`) instead of to the right.
   - Includes fallback positioning above the HUD block if near the bottom screen edge.

3. **Unit Tests**:
   - Added unit test for macOS app bundle resource root resolution in `test/unit_legacy/test_configuration_legacy.py`.
   - Added unit test for mucked cards placement under HUD in `test/test_hud.py`.
