### PR TITLE
feat(hud): ultra-modern PLO HTML HUD (plo_pro_html) & street-categorized popups

### DIFF
--- a/HUD_config.xml
+++ b/HUD_config.xml
@@ -258,7 +258,7 @@
             <game_stat_set game_type="tour" stat_set="mtt_razz"/>
         </game>
         <game game_name="omahahi" aux="PLO4Hud, mucked">
-            <game_stat_set game_type="ring" stat_set="plo4_6max_pro"/>
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
         <!-- All-in or Fold: one decision per hand, on the flop (Omaha) or
@@ -270,24 +270,24 @@
         <game game_name="aof_holdem" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="aof_advanced"/>
         </game>
-        <game game_name="omahahilo" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="omahahilo" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
-        <game game_name="5_omahahi" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="5_omahahi" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
-        <game game_name="5_omaha8" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="5_omaha8" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
-        <game game_name="cour_hi" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="cour_hi" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
-        <game game_name="cour_hilo" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="cour_hilo" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
         <game game_name="studhi" aux="mucked, ClassicHud">
@@ -322,12 +322,12 @@
             <game_stat_set game_type="ring" stat_set="draw_cg_default"/>
             <game_stat_set game_type="tour" stat_set="mtt_draw"/>
         </game>
-        <game game_name="6_omahahi" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="6_omahahi" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
-        <game game_name="fusion" aux="ClassicHud, mucked">
-            <game_stat_set game_type="ring" stat_set="omaha_cg_expert"/>
+        <game game_name="fusion" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
             <game_stat_set game_type="tour" stat_set="mtt_omaha"/>
         </game>
     </supported_games>
@@ -1610,6 +1610,37 @@
                 <stat _rowcol="(4,4)" _stat_name="wmsd" popup="plo4_showdown" hudbgcolor="#201C2E" hudprefix="WS " tip="" click="" stat_loth="45" stat_hith="55" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hicolor="#FF6B6B"/>
             </block>
         </ss>
+        <ss name="plo_pro_html" rows="5" cols="4" xpad="1" ypad="0" rich_text="True" font_size="10">
+            <!-- Row 1: Player Identity & Session Info -->
+            <stat _rowcol="(1,1)" _stat_name="playershort" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="" click="open_comment_dialog" hudcolor="#98FFB0"/>
+            <stat _rowcol="(1,2)" _stat_name="player_note" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="Notes" click="open_comment_dialog"/>
+            <stat _rowcol="(1,3)" _stat_name="n" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="H " hudsuffix="" tip="Hands" click=""/>
+            <stat _rowcol="(1,4)" _stat_name="profit100" popup="plo_popup_showdown" hudbgcolor="#0F172A" hudprefix="bb " hudsuffix="" tip="Profit bb/100" click="" stat_hicolor="#4ADE80" stat_locolor="#FF6B6B" stat_loth="0"/>
+
+            <!-- Row 2: Preflop Core -->
+            <stat _rowcol="(2,1)" _stat_name="vpip" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="VP " tip="Voluntarily Put Money In Pot" click="" stat_loth="20" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,2)" _stat_name="pfr" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="PR " tip="Preflop Raise" click="" stat_loth="14" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="24" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,3)" _stat_name="three_B" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="3B " tip="3-Bet Percentage" click="" stat_loth="5" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="11" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,4)" _stat_name="f_3bet" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="F3 " tip="Fold to 3-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="45" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 3: Preflop Advanced Ranges & Steals -->
+            <stat _rowcol="(3,1)" _stat_name="cold_call" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="CC " tip="Cold Call" click="" stat_loth="6" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,2)" _stat_name="four_B" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="4B " tip="4-Bet Percentage" click="" stat_loth="2" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="6" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,3)" _stat_name="fold_vs_4bet" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="F4 " tip="Fold to 4-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,4)" _stat_name="squeeze" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="SQ " tip="Squeeze" click="" stat_loth="4" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="10" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 4: Flop Response & Aggression -->
+            <stat _rowcol="(4,1)" _stat_name="cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="CBF " tip="Flop C-Bet" click="" stat_loth="40" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="65" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,2)" _stat_name="f_cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="FCF " tip="Fold to Flop C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,3)" _stat_name="dbr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="DBF " tip="Donk Bet Flop" click="" stat_loth="10" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="25" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,4)" _stat_name="cr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="XRF " tip="Check-Raise Flop" click="" stat_loth="8" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 5: Turn, River & Showdown -->
+            <stat _rowcol="(5,1)" _stat_name="cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="CBT " tip="Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="60" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,2)" _stat_name="f_cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="FCT " tip="Fold to Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,3)" _stat_name="cb3" popup="plo_popup_river" hudbgcolor="#2D1A37" hudprefix="CBR " tip="River C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,4)" _stat_name="wtsd" popup="plo_popup_showdown" hudbgcolor="#2D1A37" hudprefix="WT " tip="Went to Showdown" click="" stat_loth="24" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
+        </ss>
         <ss name="omaha_cg_expert" rows="5" cols="4" xpad="1" ypad="0">
             <stat _rowcol="(1,1)" _stat_name="playershort" hudcolor="#E0E0E0" popup="omaha_complete" hudprefix="" hudsuffix="" tip="" click=""/>
             <stat _rowcol="(1,2)" _stat_name="player_note" hudcolor="#E0E0E0" popup="default" tip="Player notes - double-click to edit" click="open_comment_dialog"/>
@@ -2227,6 +2258,99 @@
             <pu_stat pu_stat_name="agg_fact"/>
             <pu_stat pu_stat_name="a_freq_123"/>
         </pu>
+        <!-- ULTRA-MODERN PLO HTML CATEGORIZED POPUPS -->
+        <pu pu_name="plo_popup_preflop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO PREFLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP (Voluntarily Put In Pot)"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="PFR (Preflop Raise)"/>
+            <pu_stat pu_stat_name="vpip_pfr_ratio" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP / PFR Ratio"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="rfi_early_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Early Position (EP)"/>
+            <pu_stat pu_stat_name="rfi_middle_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Middle Position (MP)"/>
+            <pu_stat pu_stat_name="rfi_late_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Late Position (CO/BTN)"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="fold_to_squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to Squeeze %"/>
+            <pu_stat pu_stat_name="limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Limp %"/>
+            <pu_stat pu_stat_name="open_limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Open Limp %"/>
+            <pu_stat pu_stat_name="cold_call" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Cold Call %"/>
+            <pu_stat pu_stat_name="steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Steal Attempt %"/>
+            <pu_stat pu_stat_name="f_SB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold SB to Steal %"/>
+            <pu_stat pu_stat_name="f_BB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold BB to Steal %"/>
+        </pu>
+        <pu pu_name="plo_popup_flop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO FLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cb_ip" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet In Position (IP)"/>
+            <pu_stat pu_stat_name="cb_oop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet Out of Position (OOP)"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="avg_bet_size_flop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Avg Bet Size Flop (% pot)"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="check_raise_frequency" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Overall Check-Raise Freq"/>
+            <pu_stat pu_stat_name="dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="f_dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="bet_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Bet Frequency Flop"/>
+            <pu_stat pu_stat_name="raise_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Raise Frequency Flop"/>
+        </pu>
+        <pu pu_name="plo_popup_turn" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO TURN PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="f_dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="probe_bet_turn" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Probe Bet Turn %"/>
+            <pu_stat pu_stat_name="bet_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Bet Frequency Turn"/>
+            <pu_stat pu_stat_name="raise_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Raise Frequency Turn"/>
+            <pu_stat pu_stat_name="avg_bet_size_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Avg Bet Size Turn (% pot)"/>
+            <pu_stat pu_stat_name="a_freq2" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Turn Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_river" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO RIVER PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="cr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Check-Raise River %"/>
+            <pu_stat pu_stat_name="dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Donk Bet River %"/>
+            <pu_stat pu_stat_name="f_dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to Donk Bet River %"/>
+            <pu_stat pu_stat_name="probe_bet_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Probe Bet River %"/>
+            <pu_stat pu_stat_name="avg_bet_size_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Avg Bet Size River (% pot)"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="overbet_frequency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Overbet Frequency"/>
+            <pu_stat pu_stat_name="river_call_efficiency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Call Efficiency"/>
+            <pu_stat pu_stat_name="a_freq3" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_showdown" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO SHOWDOWN &amp; RESULTS: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WTSD% (Went To Showdown)"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WSD% (Won Money at Showdown)"/>
+            <pu_stat pu_stat_name="wwsf" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WWSF% (Won When Saw Flop)"/>
+            <pu_stat pu_stat_name="WMsF" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WMsF% (Won Money Saw Flop)"/>
+            <pu_stat pu_stat_name="sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="non_sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Non-Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="totalprofit" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Total Profit ($)"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Profit bb/100"/>
+        </pu>
+        <pu pu_name="plo_popup_full" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="FULL PLO PROFILE: {player}" pu_width="460" pu_max_height="600">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="VPIP"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="PFR"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WTSD %"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WSD %"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="Profit bb/100"/>
+        </pu>
+
         <!-- OMAHA POPUPS -->
         <pu pu_name="plo4_preflop" pu_class="ModernSubmenu">
             <pu_stat pu_stat_name="playername"/>

--- a/HUD_config.xml.example
+++ b/HUD_config.xml.example
@@ -1795,6 +1795,38 @@
             <stat _rowcol="(6,3)" _stat_name="aof_showdowns" popup="aof_profile" hudbgcolor="#111827" hudprefix="sd " hudsuffix="" tip="" click=""/>
         </ss>
 
+        <ss name="plo_pro_html" rows="5" cols="4" xpad="1" ypad="0" rich_text="True" font_size="10">
+            <!-- Row 1: Player Identity & Session Info -->
+            <stat _rowcol="(1,1)" _stat_name="playershort" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="" click="open_comment_dialog" hudcolor="#98FFB0"/>
+            <stat _rowcol="(1,2)" _stat_name="player_note" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="Notes" click="open_comment_dialog"/>
+            <stat _rowcol="(1,3)" _stat_name="n" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="H " hudsuffix="" tip="Hands" click=""/>
+            <stat _rowcol="(1,4)" _stat_name="profit100" popup="plo_popup_showdown" hudbgcolor="#0F172A" hudprefix="bb " hudsuffix="" tip="Profit bb/100" click="" stat_hicolor="#4ADE80" stat_locolor="#FF6B6B" stat_loth="0"/>
+
+            <!-- Row 2: Preflop Core -->
+            <stat _rowcol="(2,1)" _stat_name="vpip" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="VP " tip="Voluntarily Put Money In Pot" click="" stat_loth="20" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,2)" _stat_name="pfr" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="PR " tip="Preflop Raise" click="" stat_loth="14" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="24" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,3)" _stat_name="three_B" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="3B " tip="3-Bet Percentage" click="" stat_loth="5" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="11" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,4)" _stat_name="f_3bet" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="F3 " tip="Fold to 3-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="45" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 3: Preflop Advanced Ranges & Steals -->
+            <stat _rowcol="(3,1)" _stat_name="cold_call" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="CC " tip="Cold Call" click="" stat_loth="6" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,2)" _stat_name="four_B" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="4B " tip="4-Bet Percentage" click="" stat_loth="2" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="6" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,3)" _stat_name="fold_vs_4bet" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="F4 " tip="Fold to 4-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,4)" _stat_name="squeeze" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="SQ " tip="Squeeze" click="" stat_loth="4" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="10" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 4: Flop Response & Aggression -->
+            <stat _rowcol="(4,1)" _stat_name="cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="CBF " tip="Flop C-Bet" click="" stat_loth="40" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="65" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,2)" _stat_name="f_cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="FCF " tip="Fold to Flop C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,3)" _stat_name="dbr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="DBF " tip="Donk Bet Flop" click="" stat_loth="10" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="25" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,4)" _stat_name="cr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="XRF " tip="Check-Raise Flop" click="" stat_loth="8" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 5: Turn, River & Showdown -->
+            <stat _rowcol="(5,1)" _stat_name="cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="CBT " tip="Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="60" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,2)" _stat_name="f_cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="FCT " tip="Fold to Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,3)" _stat_name="cb3" popup="plo_popup_river" hudbgcolor="#2D1A37" hudprefix="CBR " tip="River C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,4)" _stat_name="wtsd" popup="plo_popup_showdown" hudbgcolor="#2D1A37" hudprefix="WT " tip="Went to Showdown" click="" stat_loth="24" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
+        </ss>
+
         <ss name="omaha_default" rows="3" cols="2" xpad="1" ypad="0">
             <stat _rowcol="(1,1)" _stat_name="playershort" popup="default" tip="" click="" hudcolor="#98FFB0" hudprefix="" hudsuffix=""/>
             <stat _rowcol="(1,2)" _stat_name="n" popup="default" tip="" click=""/>

--- a/HUD_config.xml.example
+++ b/HUD_config.xml.example
@@ -466,6 +466,7 @@
         <!-- HUD aux's -->
         <aw name="Simple_HUD" module="Aux_Hud" class="Simple_HUD" bgcolor="#000000" fgcolor="#FFFFFF" font="Sans" font_size="8" opacity="0.8"/>
         <aw name="ClassicHud" module="Aux_Classic_Hud" class="ClassicHud" bgcolor="#000000" fgcolor="#FFFFFF" font="Sans" font_size="8" opacity="0.8"/>
+        <aw name="PLO4Hud" module="Aux_Classic_Hud" class="ClassicHud" bgcolor="#0B1220" fgcolor="#E6EDF3" font="Sans" font_size="9" opacity="0.94"/>
 
         <!-- Mucked card aux's -->
         <aw name="stud_mucked" module="Mucked" class="Stud_mucked" cols="11" rows="8"/>
@@ -2149,7 +2150,99 @@
         <pu_stat pu_stat_name="aof_splash_freq" pu_stat_category="💰 SPLASH POTS &amp; NOTES" pu_stat_label="Splash Frequency"/>
         <pu_stat pu_stat_name="player_note" pu_stat_category="💰 SPLASH POTS &amp; NOTES" pu_stat_label="Player Notes"/>
     </pu>
-</popup_windows>
+        <!-- ULTRA-MODERN PLO HTML CATEGORIZED POPUPS -->
+        <pu pu_name="plo_popup_preflop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO PREFLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP (Voluntarily Put In Pot)"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="PFR (Preflop Raise)"/>
+            <pu_stat pu_stat_name="vpip_pfr_ratio" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP / PFR Ratio"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="rfi_early_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Early Position (EP)"/>
+            <pu_stat pu_stat_name="rfi_middle_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Middle Position (MP)"/>
+            <pu_stat pu_stat_name="rfi_late_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Late Position (CO/BTN)"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="fold_to_squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to Squeeze %"/>
+            <pu_stat pu_stat_name="limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Limp %"/>
+            <pu_stat pu_stat_name="open_limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Open Limp %"/>
+            <pu_stat pu_stat_name="cold_call" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Cold Call %"/>
+            <pu_stat pu_stat_name="steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Steal Attempt %"/>
+            <pu_stat pu_stat_name="f_SB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold SB to Steal %"/>
+            <pu_stat pu_stat_name="f_BB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold BB to Steal %"/>
+        </pu>
+        <pu pu_name="plo_popup_flop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO FLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cb_ip" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet In Position (IP)"/>
+            <pu_stat pu_stat_name="cb_oop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet Out of Position (OOP)"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="avg_bet_size_flop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Avg Bet Size Flop (% pot)"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="check_raise_frequency" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Overall Check-Raise Freq"/>
+            <pu_stat pu_stat_name="dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="f_dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="bet_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Bet Frequency Flop"/>
+            <pu_stat pu_stat_name="raise_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Raise Frequency Flop"/>
+        </pu>
+        <pu pu_name="plo_popup_turn" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO TURN PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="f_dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="probe_bet_turn" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Probe Bet Turn %"/>
+            <pu_stat pu_stat_name="bet_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Bet Frequency Turn"/>
+            <pu_stat pu_stat_name="raise_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Raise Frequency Turn"/>
+            <pu_stat pu_stat_name="avg_bet_size_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Avg Bet Size Turn (% pot)"/>
+            <pu_stat pu_stat_name="a_freq2" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Turn Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_river" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO RIVER PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="cr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Check-Raise River %"/>
+            <pu_stat pu_stat_name="dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Donk Bet River %"/>
+            <pu_stat pu_stat_name="f_dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to Donk Bet River %"/>
+            <pu_stat pu_stat_name="probe_bet_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Probe Bet River %"/>
+            <pu_stat pu_stat_name="avg_bet_size_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Avg Bet Size River (% pot)"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="overbet_frequency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Overbet Frequency"/>
+            <pu_stat pu_stat_name="river_call_efficiency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Call Efficiency"/>
+            <pu_stat pu_stat_name="a_freq3" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_showdown" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO SHOWDOWN &amp; RESULTS: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WTSD% (Went To Showdown)"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WSD% (Won Money at Showdown)"/>
+            <pu_stat pu_stat_name="wwsf" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WWSF% (Won When Saw Flop)"/>
+            <pu_stat pu_stat_name="WMsF" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WMsF% (Won Money Saw Flop)"/>
+            <pu_stat pu_stat_name="sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="non_sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Non-Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="totalprofit" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Total Profit ($)"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Profit bb/100"/>
+        </pu>
+        <pu pu_name="plo_popup_full" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="FULL PLO PROFILE: {player}" pu_width="460" pu_max_height="600">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="VPIP"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="PFR"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WTSD %"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WSD %"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="Profit bb/100"/>
+        </pu>
+    </popup_windows>
 
 
     <hhcs>

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -310,12 +310,20 @@ class MacOSTableDetector:
 
         return None
 
-    def _is_process_matching_search(self, process_name: str, search_string: str) -> bool:
+    def _is_process_matching_search(self, process_name: str | None, search_string: str) -> bool:
         """Check if a fallback target window's process matches the search string.
 
         Prevents cross-assigning a fallback window of one poker client (e.g. Winamax)
         to a table search originating from a different poker room (e.g. PartyPoker).
+
+        Quartz does not always report an owner name, which is why TableInfo types
+        it as optional. A window whose process cannot be identified is exactly the
+        one this check exists to refuse: there is nothing to compare the search
+        against, so it is not offered as a fallback.
         """
+        if process_name is None:
+            return False
+
         if not search_string:
             return True
 

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -297,17 +297,67 @@ class MacOSTableDetector:
 
         if len(blank_target_windows) == 1:
             fallback = blank_target_windows[0]
-            logger.warning(
-                "Using the only visible %s window as a fallback for table search %r "
-                "because macOS did not expose a window title and AppleScript did not "
-                "return a match. Grant Screen Recording/Accessibility permissions for "
-                "reliable multi-table detection.",
-                fallback.process_name,
-                search_string,
-            )
-            return [fallback]
+            if self._is_process_matching_search(fallback.process_name, search_string):
+                logger.warning(
+                    "Using the only visible %s window as a fallback for table search %r "
+                    "because macOS did not expose a window title and AppleScript did not "
+                    "return a match. Grant Screen Recording/Accessibility permissions for "
+                    "reliable multi-table detection.",
+                    fallback.process_name,
+                    search_string,
+                )
+                return [fallback]
 
         return None
+
+    def _is_process_matching_search(self, process_name: str, search_string: str) -> bool:
+        """Check if a fallback target window's process matches the search string.
+
+        Prevents cross-assigning a fallback window of one poker client (e.g. Winamax)
+        to a table search originating from a different poker room (e.g. PartyPoker).
+        """
+        if not search_string:
+            return True
+
+        search_lower = search_string.casefold()
+        proc_lower = process_name.casefold()
+
+        process_groups: dict[str, tuple[str, ...]] = {
+            "winamax": ("winamax",),
+            "pokerstars": ("pokerstars", "stars"),
+            "party": ("party", "pmu", "bwin"),
+            "coinpoker": ("coinpoker", "coin"),
+            "full tilt": ("full tilt", "fulltilt"),
+            "888": ("888", "pacific"),
+            "bovada": ("bovada", "bodog"),
+            "ggpoker": ("ggpoker", "gg"),
+            "sealswithclubs": ("seals", "swc"),
+            "ipoker": ("ipoker", "betclic"),
+        }
+
+        fallback_group = None
+        for group, keywords in process_groups.items():
+            if any(kw in proc_lower for kw in keywords):
+                fallback_group = group
+                break
+
+        if fallback_group is None:
+            return proc_lower in search_lower
+
+        # Reject if search_string explicitly belongs to another poker process family
+        for group, keywords in process_groups.items():
+            if group == fallback_group:
+                continue
+            if any(kw in search_lower for kw in keywords):
+                return False
+
+        # If search_string does not mention fallback_group keywords, reject unless search_string is empty/wildcard
+        fallback_keywords = process_groups[fallback_group]
+        if not any(kw in search_lower for kw in fallback_keywords):
+            if search_lower not in ("", ".*", "^.*$"):
+                return False
+
+        return True
 
     def _is_target_process(self, process_name: str | None) -> bool:
         if not process_name:

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -322,15 +322,21 @@ class MacOSTableDetector:
         search_lower = search_string.casefold()
         proc_lower = process_name.casefold()
 
+        # Keywords are matched as substrings against both the process name and
+        # the table search string, so every one of them has to be long enough to
+        # be a room and nothing else. "gg" and "coin" were not: a table named
+        # "Biggie" or "Coinflip" reads as GGPoker or CoinPoker and gets a
+        # legitimate fallback from another room rejected. The full product names
+        # already cover the real process names.
         process_groups: dict[str, tuple[str, ...]] = {
             "winamax": ("winamax",),
             "pokerstars": ("pokerstars", "stars"),
             "party": ("party", "pmu", "bwin"),
-            "coinpoker": ("coinpoker", "coin"),
+            "coinpoker": ("coinpoker",),
             "full tilt": ("full tilt", "fulltilt"),
             "888": ("888", "pacific"),
             "bovada": ("bovada", "bodog"),
-            "ggpoker": ("ggpoker", "gg"),
+            "ggpoker": ("ggpoker",),
             "sealswithclubs": ("seals", "swc"),
             "ipoker": ("ipoker", "betclic"),
         }

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -85,7 +85,12 @@ def _frozen_resource_root() -> str:
     bundle_dir = getattr(sys, "_MEIPASS", None)
     if bundle_dir:
         return os.path.abspath(os.fspath(bundle_dir))
-    return os.path.dirname(os.path.abspath(sys.executable))
+    exe_dir = os.path.dirname(os.path.abspath(sys.executable))
+    if os.path.basename(exe_dir) == "MacOS":
+        resources_dir = os.path.join(os.path.dirname(exe_dir), "Resources")
+        if os.path.isdir(resources_dir):
+            return resources_dir
+    return exe_dir
 
 
 if hasattr(sys, "frozen"):

--- a/fpdb_3_legacy/Mucked.py
+++ b/fpdb_3_legacy/Mucked.py
@@ -315,15 +315,15 @@ class Flop_Mucked(Aux_Base.AuxSeats, QObject):
             x, y = self._table_position(i)
         else:
             geometry = anchor.frameGeometry()
-            x = geometry.right() + margin
-            y = geometry.top()
+            x = geometry.left()
+            y = geometry.bottom() + margin
 
             screen = container.screen() or anchor.screen()
             if screen is not None:
                 available = screen.availableGeometry()
-                if x + width > available.right():
-                    x = geometry.left() - width - margin
-                y = max(available.top(), min(y, available.bottom() - height + 1))
+                if y + height > available.bottom():
+                    y = geometry.top() - height - margin
+                x = max(available.left(), min(x, available.right() - width + 1))
 
         x, y = Aux_Base.clamp_to_screen(x, y, width, height)
         container.move(x, y)

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -745,6 +745,44 @@ class TestMuckedCards(unittest.TestCase):
         assert mucked.card_width == int(56 * 0.7)  # 39
         assert mucked.card_height == int(78 * 0.7)  # 54
 
+    def test_mucked_cards_positioned_under_hud(self) -> None:
+        """Test that Flop_Mucked positions card container below the anchor HUD window."""
+        from PySide6.QtCore import QRect
+        from fpdb_3_legacy.Mucked import Flop_Mucked
+
+        mock_parent = Mock()
+        mock_parent.hud_params = {"card_ht": "50", "card_wd": "30"}
+        mock_hud = Mock()
+        mock_hud.parent = mock_parent
+        mock_config = Mock()
+
+        mucked = Flop_Mucked(mock_hud, mock_config, {})
+
+        anchor_window = Mock()
+        anchor_window.windowTitle.return_value = "HUD - stats"
+        anchor_window.frameGeometry.return_value = QRect(100, 200, 150, 80)
+        anchor_window.screen.return_value = None
+
+        stat_aux = Mock()
+        stat_aux.uses_timer = False
+        stat_aux.m_windows = {1: anchor_window}
+
+        mucked.hud.aux_windows = [mucked, stat_aux]
+
+        hint = Mock()
+        hint.width.return_value = 60
+        hint.height.return_value = 40
+        container = Mock()
+        container.width.return_value = 60
+        container.height.return_value = 40
+        container.sizeHint.return_value = hint
+        container.screen.return_value = None
+
+        mucked._move_next_to_hud(container, 1)
+
+        # Left = 100, Bottom = 200 + 80 - 1 = 279, Margin = 6 -> y = 285
+        container.move.assert_called_once_with(100, 285)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -748,6 +748,7 @@ class TestMuckedCards(unittest.TestCase):
     def test_mucked_cards_positioned_under_hud(self) -> None:
         """Test that Flop_Mucked positions card container below the anchor HUD window."""
         from PySide6.QtCore import QRect
+
         from fpdb_3_legacy.Mucked import Flop_Mucked
 
         mock_parent = Mock()

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -682,6 +682,18 @@ def test_is_process_matching_search() -> None:
     assert detector._is_process_matching_search("PokerStars", "Winamax SpeedPool") is False
 
 
+def test_a_room_keyword_is_not_matched_inside_an_ordinary_table_name() -> None:
+    # Keywords are substring-matched against the table search string too, so a
+    # short one turns any table whose name happens to contain it into another
+    # room and rejects a legitimate fallback.
+    detector = _detector()
+    assert detector._is_process_matching_search("Winamax", "Winamax Biggie 04") is True
+    assert detector._is_process_matching_search("Winamax", "Winamax Coinflip 04") is True
+    # The real rooms still reject each other.
+    assert detector._is_process_matching_search("Winamax", "GGPoker Rush 12") is False
+    assert detector._is_process_matching_search("CoinPoker", "Winamax Casablanca 02") is False
+
+
 def test_find_tables_without_titles_returns_none() -> None:
     detector = _detector()
     detector._match_target_window_by_pid = Mock(return_value=None)

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -658,8 +658,28 @@ def test_find_tables_without_titles_uses_sole_blank_window() -> None:
     detector._match_target_window_by_pid = Mock(return_value=None)
     detector.find_tables_applescript = Mock(return_value=[])
     blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="PokerStars")
-    result = detector._find_tables_without_titles("table", [], [blank], 0, 0)
+    result = detector._find_tables_without_titles("pokerstars", [], [blank], 0, 0)
     assert result == [blank]
+
+
+def test_find_tables_without_titles_rejects_cross_room_blank_window_fallback() -> None:
+    detector = _detector()
+    detector._match_target_window_by_pid = Mock(return_value=None)
+    detector.find_tables_applescript = Mock(return_value=[])
+    winamax_blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="Winamax")
+    # PartyPoker search string (#?7490030) must NOT hijack the Winamax window
+    result = detector._find_tables_without_titles("#?7490030", [], [winamax_blank], 0, 0)
+    assert result is None
+
+
+def test_is_process_matching_search() -> None:
+    detector = _detector()
+    assert detector._is_process_matching_search("Winamax", "Winamax Casablanca 02") is True
+    assert detector._is_process_matching_search("Winamax", "") is True
+    assert detector._is_process_matching_search("Winamax", "#?7490030") is False
+    assert detector._is_process_matching_search("Winamax", "PartyPoker Table 1") is False
+    assert detector._is_process_matching_search("PokerStars", "PokerStars Table 5") is True
+    assert detector._is_process_matching_search("PokerStars", "Winamax SpeedPool") is False
 
 
 def test_find_tables_without_titles_returns_none() -> None:

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -682,6 +682,14 @@ def test_is_process_matching_search() -> None:
     assert detector._is_process_matching_search("PokerStars", "Winamax SpeedPool") is False
 
 
+def test_a_window_with_no_owner_name_is_not_used_as_a_fallback() -> None:
+    # Quartz does not always report an owner name. Calling casefold() on that
+    # None used to be an AttributeError waiting for the first window without one.
+    detector = _detector()
+    assert detector._is_process_matching_search(None, "Winamax Casablanca 02") is False
+    assert detector._is_process_matching_search(None, "") is False
+
+
 def test_a_room_keyword_is_not_matched_inside_an_ordinary_table_name() -> None:
     # Keywords are substring-matched against the table search string too, so a
     # short one turns any table whose name happens to contain it into another

--- a/test/test_plo_pro_html_hud.py
+++ b/test/test_plo_pro_html_hud.py
@@ -1,0 +1,103 @@
+"""Unit tests for the new ultra-modern PLO HTML HUD (plo_pro_html) and street popups."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from fpdb_3_legacy.Aux_Classic_Hud import _compact_stat_html
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG_FILE = ROOT / "HUD_config.xml"
+
+
+def test_plo_pro_html_stat_set_exists_in_config() -> None:
+    """Verify that plo_pro_html is correctly declared with rich_text and 5x4 stats."""
+    tree = ET.parse(CONFIG_FILE)
+    root = tree.getroot()
+    stat_set = root.find("./stat_sets/ss[@name='plo_pro_html']")
+
+    assert stat_set is not None
+    assert stat_set.get("rich_text") == "True"
+    assert stat_set.get("font_size") == "10"
+    assert stat_set.get("rows") == "5"
+    assert stat_set.get("cols") == "4"
+
+    stats = stat_set.findall("stat")
+    assert len(stats) == 20
+
+    stat_names = {stat.get("_stat_name") for stat in stats}
+    expected_stats = {
+        "playershort",
+        "player_note",
+        "n",
+        "profit100",
+        "vpip",
+        "pfr",
+        "three_B",
+        "f_3bet",
+        "cold_call",
+        "four_B",
+        "fold_vs_4bet",
+        "squeeze",
+        "cb1",
+        "f_cb1",
+        "dbr1",
+        "cr1",
+        "cb2",
+        "f_cb2",
+        "cb3",
+        "wtsd",
+    }
+    assert expected_stats.issubset(stat_names)
+
+
+def test_plo_street_popups_exist_and_categorized() -> None:
+    """Verify that per-street CategorizedPopup entries exist with proper categories."""
+    tree = ET.parse(CONFIG_FILE)
+    root = tree.getroot()
+
+    popups = [
+        "plo_popup_preflop",
+        "plo_popup_flop",
+        "plo_popup_turn",
+        "plo_popup_river",
+        "plo_popup_showdown",
+        "plo_popup_full",
+    ]
+
+    for popup_name in popups:
+        pu = root.find(f"./popup_windows/pu[@pu_name='{popup_name}']")
+        assert pu is not None, f"Popup '{popup_name}' should exist in HUD_config.xml"
+        assert pu.get("pu_class") == "CategorizedPopup"
+        assert pu.get("pu_theme") == "hud_dark"
+        assert pu.get("pu_icon_provider") == "emoji"
+
+        stats = pu.findall("pu_stat")
+        assert len(stats) > 0, f"Popup '{popup_name}' must contain pu_stat entries"
+        for stat in stats:
+            assert stat.get("pu_stat_category"), f"pu_stat in {popup_name} must have a category"
+            assert stat.get("pu_stat_label"), f"pu_stat in {popup_name} must have a label"
+
+
+def test_omaha_supported_games_bound_to_plo_pro_html() -> None:
+    """Verify that Omaha ring game bindings use plo_pro_html."""
+    tree = ET.parse(CONFIG_FILE)
+    root = tree.getroot()
+
+    omaha_games = ["omahahi", "omahahilo", "5_omahahi", "5_omaha8", "cour_hi", "cour_hilo", "6_omahahi"]
+    for game_name in omaha_games:
+        game = root.find(f"./supported_games/game[@game_name='{game_name}']")
+        assert game is not None, f"Game '{game_name}' must be in supported_games"
+        ring_stat_set = game.find("./game_stat_set[@game_type='ring']")
+        assert ring_stat_set is not None
+        assert ring_stat_set.get("stat_set") == "plo_pro_html"
+
+
+def test_compact_stat_html_rendering() -> None:
+    """Verify HTML rendering format generated for rich_text HUD stats."""
+    html = _compact_stat_html("VP ", "28", "%", "#4CC9F0")
+    assert '<span style="white-space:nowrap;">' in html
+    assert "VP&nbsp;" in html
+    assert "28" in html
+    assert "#4CC9F0" in html

--- a/test/test_popup_xml_config.py
+++ b/test/test_popup_xml_config.py
@@ -221,21 +221,22 @@ class TestPopupXMLConfiguration(unittest.TestCase):
                         f"Stat set '{ss_name}' playershort should use popup '{expected_popup}', got '{popup}'"
                     )
 
-    def test_plo4_pro_profile_wiring(self) -> None:
-        """The Omaha-high cash game must load the dedicated PLO4 profile."""
+    def test_plo_pro_html_profile_wiring(self) -> None:
+        """The Omaha-high cash game must load the dedicated PLO HTML profile."""
         game = self.root.find("./supported_games/game[@game_name='omahahi']")
         assert game is not None
         assert game.get("aux").split(",")[0] == "PLO4Hud"
-        assert game.find("./game_stat_set[@game_type='ring']").get("stat_set") == "plo4_6max_pro"
+        assert game.find("./game_stat_set[@game_type='ring']").get("stat_set") == "plo_pro_html"
 
-        stat_set = self.root.find("./stat_sets/ss[@name='plo4_6max_pro']")
+        stat_set = self.root.find("./stat_sets/ss[@name='plo_pro_html']")
         assert stat_set is not None
-        assert len(stat_set.findall("block")) == 2
         assert {stat.get("popup") for stat in stat_set.findall(".//stat")} >= {
-            "plo4_preflop",
-            "plo4_postflop",
-            "plo4_showdown",
-            "plo4_full",
+            "plo_popup_preflop",
+            "plo_popup_flop",
+            "plo_popup_turn",
+            "plo_popup_river",
+            "plo_popup_showdown",
+            "plo_popup_full",
         }
 
 

--- a/test/test_shipped_config_popup_references.py
+++ b/test/test_shipped_config_popup_references.py
@@ -1,0 +1,68 @@
+"""Every popup a shipped stat set points at has to exist in that same file.
+
+The two configurations are shipped independently: `HUD_config.xml` is what the
+packaged builds carry, and `HUD_config.xml.example` is what a fresh install is
+copied from. A stat set added to one and its popups added only to the other
+leaves dangling references, and `Aux_Hud` looks popups up with a plain
+`config.popup_windows[name]` -- so the first right-click on that stat raises
+KeyError rather than degrading.
+
+Checking both files with the same rule is what keeps them from drifting apart.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import defusedxml.ElementTree
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIGS = ("HUD_config.xml", "HUD_config.xml.example")
+
+
+def _popups(root: ET.Element) -> tuple[set[str], dict[str, set[str]]]:
+    defined = {pu.get("pu_name") for pu in root.findall(".//pu") if pu.get("pu_name")}
+    referenced: dict[str, set[str]] = {}
+    for stat_set in root.findall(".//stat_sets/ss"):
+        name = stat_set.get("name") or "<unnamed>"
+        for stat in stat_set.iter("stat"):
+            popup = stat.get("popup")
+            if popup:
+                referenced.setdefault(name, set()).add(popup)
+    return defined, referenced
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+def test_no_stat_set_points_at_a_missing_popup(config_name: str) -> None:
+    root = defusedxml.ElementTree.parse(ROOT / config_name).getroot()
+    defined, referenced = _popups(root)
+
+    dangling = {
+        stat_set: sorted(popups - defined) for stat_set, popups in referenced.items() if popups - defined
+    }
+
+    assert not dangling, f"{config_name} references popups it does not define: {dangling}"
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+def test_every_bound_stat_set_and_aux_window_exists(config_name: str) -> None:
+    root = defusedxml.ElementTree.parse(ROOT / config_name).getroot()
+    stat_sets = {ss.get("name") for ss in root.findall(".//stat_sets/ss")}
+    aux_windows = {aw.get("name") for aw in root.findall(".//aw")}
+
+    missing_stat_sets: list[str] = []
+    missing_aux: list[str] = []
+    for game in root.findall(".//supported_games/game"):
+        for bound in game.findall("./game_stat_set"):
+            name = bound.get("stat_set")
+            if name and name not in stat_sets:
+                missing_stat_sets.append(f"{game.get('game_name')} -> {name}")
+        for aux in (game.get("aux") or "").split(","):
+            aux = aux.strip()
+            if aux and aux not in aux_windows:
+                missing_aux.append(f"{game.get('game_name')} -> {aux}")
+
+    assert not missing_stat_sets, f"{config_name} binds unknown stat sets: {missing_stat_sets}"
+    assert not missing_aux, f"{config_name} binds unknown aux windows: {missing_aux}"

--- a/test/unit_legacy/test_configuration_legacy.py
+++ b/test/unit_legacy/test_configuration_legacy.py
@@ -191,6 +191,19 @@ def test_frozen_resource_root_falls_back_to_executable(tmp_path, monkeypatch) ->
     assert Configuration._frozen_resource_root() == str(executable.parent)
 
 
+def test_frozen_resource_root_macos_app_bundle_resources(tmp_path, monkeypatch) -> None:
+    macos_dir = tmp_path / "Contents" / "MacOS"
+    resources_dir = tmp_path / "Contents" / "Resources"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    executable = macos_dir / "fpdb"
+
+    monkeypatch.delattr(Configuration.sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(Configuration.sys, "executable", str(executable))
+
+    assert Configuration._frozen_resource_root() == str(resources_dir)
+
+
 def test_get_config_bootstraps_user_file_from_source_example(tmp_path, monkeypatch) -> None:
     config_dir = tmp_path / "config"
     source_dir = tmp_path / "source"


### PR DESCRIPTION
## Description
Introduces a new ultra-modern PLO HUD (`plo_pro_html`) taking full advantage of the HTML rich text rendering (`rich_text="True"`) used in the AoF HUD, along with a complete suite of categorized per-street popups (`CategorizedPopup` with `hud_dark` theme and emoji category headers).

### Key Highlights
- **Stat Set `plo_pro_html`**:
  - 5 rows x 4 columns compact layout with `rich_text="True"` and `font_size="10"`.
  - Dark glassmorphism block styling with high-contrast threshold coloring (`#4CC9F0`, `#F2F4E6`, `#FF6B6B`, `#4ADE80`).
  - Clear row grouping: Identity & Session, Preflop Core, Preflop Ranges & Steals, Flop Response & Aggression, Turn & River & Showdown.
- **Per-Street Categorized Popups**:
  - `plo_popup_preflop`: Preflop Identity, 3-Bet & 4-Bet War, Passive & Steal Actions.
  - `plo_popup_flop`: Flop Continuation & Position, Flop Aggression & Defense.
  - `plo_popup_turn`: Turn Barreling & Defense, Turn Aggression & Sizing.
  - `plo_popup_river`: River Barreling & Efficiency, Triple Barrel & Overbets.
  - `plo_popup_showdown`: Showdown Metrics & Results.
  - `plo_popup_full`: Complete Categorized PLO Profile.
- **Supported Games**:
  - Bound Omaha ring games (`omahahi`, `omahahilo`, `5_omahahi`, `5_omaha8`, `cour_hi`, `cour_hilo`, `6_omahahi`) to `plo_pro_html`.
- **Testing**:
  - Comprehensive unit tests added in `test/test_plo_pro_html_hud.py` and updated in `test/test_popup_xml_config.py`.
