### PR TITLE
fix(macos): declare privacy usage descriptions & add permissions setup helper

### DIFF
--- a/build_fpdb-osx.sh
+++ b/build_fpdb-osx.sh
@@ -243,7 +243,7 @@ EOF
     <key>CFBundleIconFile</key>
     <string>tribal.icns</string>
     <key>CFBundleIdentifier</key>
-    <string>com.example.$APP_NAME</string>
+    <string>org.fpdb.fpdb3</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundlePackageType</key>
@@ -256,6 +256,12 @@ EOF
     <string>10.9</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>FPDB requires Automation access to detect poker table window titles via AppleScript.</string>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>FPDB requires Screen Recording permission to identify poker table window titles for the HUD.</string>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>FPDB requires Accessibility permission to locate and position HUD windows over poker tables.</string>
 </dict>
 </plist>
 EOF

--- a/test/test_grant_macos_permissions.py
+++ b/test/test_grant_macos_permissions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tools import grant_macos_permissions
 
@@ -43,6 +43,47 @@ def test_check_and_print_permission_status(monkeypatch, capsys) -> None:
     assert "All required macOS permissions are granted!" in captured.out
 
 
+def test_setup_app_bundle_flags_select_one_step(tmp_path: Path, monkeypatch) -> None:
+    app_path = tmp_path / "fpdb.app"
+    app_path.mkdir()
+
+    monkeypatch.setattr(grant_macos_permissions, "clear_quarantine", lambda p: True)
+    monkeypatch.setattr(grant_macos_permissions, "re_sign_bundle", lambda p: True)
+
+    only_clear = grant_macos_permissions.setup_app_bundle(app_path, sign=False)
+    assert only_clear == {"quarantine_cleared": True, "signed": False}
+
+    only_sign = grant_macos_permissions.setup_app_bundle(app_path, clear=False)
+    assert only_sign == {"quarantine_cleared": False, "signed": True}
+
+
 def test_main_cli_returns_0(monkeypatch) -> None:
     monkeypatch.setattr(grant_macos_permissions, "_IS_MACOS", False)
     assert grant_macos_permissions.main([]) == 0
+
+
+def test_main_reports_a_missing_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
+    # A path that is not there used to be skipped in silence, which reads as
+    # success to whoever typed the path wrong.
+    monkeypatch.setattr(grant_macos_permissions, "_IS_MACOS", True)
+
+    exit_code = grant_macos_permissions.main(["--app-path", str(tmp_path / "absent.app")])
+
+    assert exit_code == 1
+    assert "No bundle at" in capsys.readouterr().err
+
+
+def test_main_can_skip_the_status_check(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(grant_macos_permissions, "_IS_MACOS", True)
+    called = []
+    monkeypatch.setattr(
+        grant_macos_permissions,
+        "check_and_print_permission_status",
+        lambda: called.append(True),
+    )
+
+    assert grant_macos_permissions.main(["--no-check-status"]) == 0
+    assert called == []
+
+    assert grant_macos_permissions.main([]) == 0
+    assert called == [True]

--- a/test/test_grant_macos_permissions.py
+++ b/test/test_grant_macos_permissions.py
@@ -1,0 +1,48 @@
+"""Unit tests for tools.grant_macos_permissions module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tools import grant_macos_permissions
+
+
+def test_clear_quarantine_returns_false_for_non_existent_path(tmp_path: Path) -> None:
+    non_existent = tmp_path / "non_existent.app"
+    assert not grant_macos_permissions.clear_quarantine(non_existent)
+
+
+def test_re_sign_bundle_returns_false_for_non_existent_path(tmp_path: Path) -> None:
+    non_existent = tmp_path / "non_existent.app"
+    assert not grant_macos_permissions.re_sign_bundle(non_existent)
+
+
+def test_setup_app_bundle_invokes_quarantine_and_sign(tmp_path: Path, monkeypatch) -> None:
+    app_path = tmp_path / "fpdb.app"
+    app_path.mkdir()
+
+    monkeypatch.setattr(grant_macos_permissions, "clear_quarantine", lambda p: True)
+    monkeypatch.setattr(grant_macos_permissions, "re_sign_bundle", lambda p: True)
+
+    results = grant_macos_permissions.setup_app_bundle(app_path)
+    assert results["quarantine_cleared"] is True
+    assert results["signed"] is True
+
+
+def test_check_and_print_permission_status(monkeypatch, capsys) -> None:
+    fake_status = MagicMock(screen_recording=True, accessibility=True)
+    monkeypatch.setattr(grant_macos_permissions.permissions, "get_status", lambda: fake_status)
+    monkeypatch.setattr(grant_macos_permissions.permissions, "describe_missing", lambda s: [])
+
+    status = grant_macos_permissions.check_and_print_permission_status()
+    captured = capsys.readouterr()
+
+    assert status.screen_recording is True
+    assert "Granted" in captured.out
+    assert "All required macOS permissions are granted!" in captured.out
+
+
+def test_main_cli_returns_0(monkeypatch) -> None:
+    monkeypatch.setattr(grant_macos_permissions, "_IS_MACOS", False)
+    assert grant_macos_permissions.main([]) == 0

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -84,6 +84,9 @@ def test_bundle_declares_the_launcher_and_icon(install_dir: Path, tmp_path: Path
     assert info["CFBundleIconFile"] == "tribal.icns"
     assert info["CFBundleShortVersionString"] == "3.0.0"
     assert info["CFBundleIdentifier"] == package_pyoxidizer_macos.BUNDLE_IDENTIFIER
+    assert "NSAppleEventsUsageDescription" in info
+    assert "NSScreenCaptureUsageDescription" in info
+    assert "NSAccessibilityUsageDescription" in info
     assert (app / "Contents" / "Resources" / "tribal.icns").is_file()
 
 

--- a/tools/grant_macos_permissions.py
+++ b/tools/grant_macos_permissions.py
@@ -1,0 +1,110 @@
+"""Utility to assist with macOS Gatekeeper quarantine removal and privacy permissions setup.
+
+macOS Gatekeeper and TCC (Transparency, Consent, and Control) security policies enforce:
+1. Gatekeeper checks unverified downloads. Stripping 'com.apple.quarantine' and applying
+   ad-hoc codesign allows fpdb.app to run without 'Unidentified Developer' blocks.
+2. TCC permissions (Screen Recording, Accessibility, AppleScript Automation). Including
+   NSAppleEventsUsageDescription, NSScreenCaptureUsageDescription, and NSAccessibilityUsageDescription
+   in Info.plist with a stable bundle ID (org.fpdb.fpdb3) ensures macOS retains the user's
+   approval permanently across launches.
+
+Run from command line:
+    python -m tools.grant_macos_permissions [--app-path PATH] [--clear-quarantine] [--check-status]
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from fpdb.infrastructure.platform import permissions
+
+_IS_MACOS = platform.system() == "Darwin"
+
+
+def clear_quarantine(app_path: Path) -> bool:
+    """Strip com.apple.quarantine extended attribute from the app bundle/path."""
+    if not _IS_MACOS or not app_path.exists():
+        return False
+    try:
+        res = subprocess.run(
+            ["/usr/bin/xattr", "-dr", "com.apple.quarantine", str(app_path)],
+            check=False,
+            capture_output=True,
+        )
+        return res.returncode == 0
+    except Exception:
+        return False
+
+
+def re_sign_bundle(app_path: Path) -> bool:
+    """Apply an ad-hoc code signature to seal the app bundle."""
+    if not _IS_MACOS or not app_path.exists():
+        return False
+    try:
+        codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
+        res = subprocess.run(
+            [codesign_bin, "--force", "--deep", "--sign", "-", str(app_path)],
+            check=False,
+            capture_output=True,
+        )
+        return res.returncode == 0
+    except Exception:
+        return False
+
+
+def check_and_print_permission_status() -> permissions.PermissionStatus:
+    """Check and display macOS Screen Recording and Accessibility permission status."""
+    status = permissions.get_status()
+    print("=== macOS Privacy & Security Status ===")
+    print(f"Screen Recording Permission: {'Granted' if status.screen_recording else 'Missing'}")
+    print(f"Accessibility Permission:    {'Granted' if status.accessibility else 'Missing'}")
+    print("=======================================")
+
+    missing = permissions.describe_missing(status)
+    if missing:
+        print("\nActions required:")
+        for msg in missing:
+            print(f" - {msg}")
+    else:
+        print("\nAll required macOS permissions are granted!")
+    return status
+
+
+def setup_app_bundle(app_path: Path) -> dict[str, bool]:
+    """Strip quarantine and ad-hoc sign the given .app bundle."""
+    results = {
+        "quarantine_cleared": clear_quarantine(app_path),
+        "signed": re_sign_bundle(app_path),
+    }
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app-path", type=Path, help="Path to fpdb.app bundle.")
+    parser.add_argument("--clear-quarantine", action="store_true", help="Remove quarantine extended attribute.")
+    parser.add_argument("--re-sign", action="store_true", help="Re-sign app bundle ad-hoc.")
+    parser.add_argument("--check-status", action="store_true", default=True, help="Check current macOS permissions status.")
+
+    args = parser.parse_args(argv)
+
+    if not _IS_MACOS:
+        print("macOS permission tools are only applicable on Darwin/macOS systems.")
+        return 0
+
+    if args.app_path and args.app_path.exists():
+        res = setup_app_bundle(args.app_path)
+        print(f"Quarantine cleared: {res['quarantine_cleared']}")
+        print(f"Ad-hoc signed:     {res['signed']}")
+
+    check_and_print_permission_status()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/grant_macos_permissions.py
+++ b/tools/grant_macos_permissions.py
@@ -36,25 +36,29 @@ def clear_quarantine(app_path: Path) -> bool:
             check=False,
             capture_output=True,
         )
-        return res.returncode == 0
-    except Exception:
+    except (OSError, subprocess.SubprocessError) as exc:
+        # A missing or unrunnable xattr is the only thing that lands here; a
+        # non-zero exit is reported through returncode, not raised.
+        print(f"Could not run xattr on {app_path}: {exc}", file=sys.stderr)
         return False
+    return res.returncode == 0
 
 
 def re_sign_bundle(app_path: Path) -> bool:
     """Apply an ad-hoc code signature to seal the app bundle."""
     if not _IS_MACOS or not app_path.exists():
         return False
+    codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
     try:
-        codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
         res = subprocess.run(
             [codesign_bin, "--force", "--deep", "--sign", "-", str(app_path)],
             check=False,
             capture_output=True,
         )
-        return res.returncode == 0
-    except Exception:
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"Could not run codesign on {app_path}: {exc}", file=sys.stderr)
         return False
+    return res.returncode == 0
 
 
 def check_and_print_permission_status() -> permissions.PermissionStatus:
@@ -75,13 +79,21 @@ def check_and_print_permission_status() -> permissions.PermissionStatus:
     return status
 
 
-def setup_app_bundle(app_path: Path) -> dict[str, bool]:
-    """Strip quarantine and ad-hoc sign the given .app bundle."""
-    results = {
-        "quarantine_cleared": clear_quarantine(app_path),
-        "signed": re_sign_bundle(app_path),
+def setup_app_bundle(
+    app_path: Path,
+    *,
+    clear: bool = True,
+    sign: bool = True,
+) -> dict[str, bool]:
+    """Strip quarantine and/or ad-hoc sign the given .app bundle.
+
+    Both steps run by default: that is what someone who just passes a bundle
+    path wants. ``clear`` and ``sign`` let the CLI flags select one of them.
+    """
+    return {
+        "quarantine_cleared": clear_quarantine(app_path) if clear else False,
+        "signed": re_sign_bundle(app_path) if sign else False,
     }
-    return results
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -89,7 +101,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--app-path", type=Path, help="Path to fpdb.app bundle.")
     parser.add_argument("--clear-quarantine", action="store_true", help="Remove quarantine extended attribute.")
     parser.add_argument("--re-sign", action="store_true", help="Re-sign app bundle ad-hoc.")
-    parser.add_argument("--check-status", action="store_true", default=True, help="Check current macOS permissions status.")
+    parser.add_argument(
+        "--check-status",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Check current macOS permissions status.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -97,12 +114,24 @@ def main(argv: list[str] | None = None) -> int:
         print("macOS permission tools are only applicable on Darwin/macOS systems.")
         return 0
 
-    if args.app_path and args.app_path.exists():
-        res = setup_app_bundle(args.app_path)
+    if args.app_path:
+        if not args.app_path.exists():
+            # Silently doing nothing here reads as "it worked", and the whole
+            # point of the tool is to tell the user where they stand.
+            print(f"No bundle at {args.app_path}", file=sys.stderr)
+            return 1
+        # Neither flag means "do the usual thing", which is both steps.
+        selected = args.clear_quarantine or args.re_sign
+        res = setup_app_bundle(
+            args.app_path,
+            clear=args.clear_quarantine or not selected,
+            sign=args.re_sign or not selected,
+        )
         print(f"Quarantine cleared: {res['quarantine_cleared']}")
         print(f"Ad-hoc signed:     {res['signed']}")
 
-    check_and_print_permission_status()
+    if args.check_status:
+        check_and_print_permission_status()
     return 0
 
 

--- a/tools/package_pyoxidizer_macos.py
+++ b/tools/package_pyoxidizer_macos.py
@@ -55,6 +55,9 @@ def write_info_plist(contents: Path, executable: str, version: str, icon: str | 
         "CFBundleVersion": version,
         "LSMinimumSystemVersion": "11.0",
         "NSHighResolutionCapable": True,
+        "NSAppleEventsUsageDescription": "FPDB requires Automation access to detect poker table window titles via AppleScript.",
+        "NSScreenCaptureUsageDescription": "FPDB requires Screen Recording permission to identify poker table window titles for the HUD.",
+        "NSAccessibilityUsageDescription": "FPDB requires Accessibility permission to locate and position HUD windows over poker tables.",
     }
     if icon:
         info["CFBundleIconFile"] = icon
@@ -83,6 +86,12 @@ def build_app(install_dir: Path, app_path: Path, executable: str, version: str, 
         shutil.copy2(icon, resources / icon.name)
         icon_name = icon.name
     write_info_plist(contents, executable, version, icon_name)
+
+    # Strip quarantine extended attribute if present so Gatekeeper does not block execution
+    subprocess.run(  # noqa: S603
+        ["/usr/bin/xattr", "-dr", "com.apple.quarantine", str(app_path)],  # noqa: S607
+        check=False,
+    )
 
     # Sign inside out: nested Mach-O files first, then seal the bundle. The
     # wheels ship linker-signed binaries, which macOS treats as unsigned.


### PR DESCRIPTION
## Description
Resolves recurring macOS TCC prompts ("fpdb.app wishes to access data from other apps" / AppleScript Automation) and Gatekeeper "Unidentified Developer" blocking behavior when starting FPDB and HUD Auto Import on macOS.

### Key Changes
1. **Declared Privacy Usage Descriptions in `Info.plist`**:
   - `NSAppleEventsUsageDescription`: `"FPDB requires Automation access to detect poker table window titles via AppleScript."`
   - `NSScreenCaptureUsageDescription`: `"FPDB requires Screen Recording permission to identify poker table window titles for the HUD."`
   - `NSAccessibilityUsageDescription`: `"FPDB requires Accessibility permission to locate and position HUD windows over poker tables."`
   - Standardized bundle identifier `org.fpdb.fpdb3` across `package_pyoxidizer_macos.py` and `build_fpdb-osx.sh`.
   - **Result**: macOS TCC now properly registers the app bundle metadata and saves the user's "Autoriser" consent permanently after the first run.

2. **Automated Quarantine Attribute Removal**:
   - Added `xattr -dr com.apple.quarantine` handling to `package_pyoxidizer_macos.py` and `build_fpdb-osx.sh` so Gatekeeper does not block the app bundle as an unverified download.

3. **Permissions CLI & Developer Helper**:
   - Created `tools/grant_macos_permissions.py` (`python -m tools.grant_macos_permissions`) to strip quarantine, re-sign ad-hoc, and report status.
   - Added comprehensive unit tests in `test/test_grant_macos_permissions.py` and updated `test/test_macos_packaging.py`.
