### PR TITLE
chore(release): prepare 3.4.3

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.4.2"
+__version__ = "3.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.4.2"
+version = "3.4.3"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.4.2"
+version = "3.4.3"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.4.2"
+version = "3.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prepares the 3.4.3 release. Version bump only — no behaviour change.

## The bump

The declared version lives in three independent places, none derived from
another, so all three move together or they drift silently:

- `pyproject.toml` → `[project].version`
- `pyproject.toml` → `[tool.briefcase].version`
- `fpdb_3_legacy/__init__.py` → `__version__`

`uv.lock` follows automatically and is committed alongside.

## Verified

- `uv build --wheel` → `fpdb_3-3.4.3-py3-none-any.whl`
- `fpdb_3_legacy.__version__` → `3.4.3` (what a frozen build reports)
- `test/test_fpdb_version_resolution.py` — 6 passed
- `ruff check fpdb_3_legacy fpdb test tests tools` — clean
- Full suite — 7416 passed, 16 skipped
- CI on `development` at `46fdb5fc` — **17/17 jobs green**
  ([run 31164539110](https://github.com/jejellyroll-fr/fpdb-3/actions/runs/31164539110))

## What ships since v3.4.2

#201 (PyOxidizer bundle resources, mucked hands under the HUD), #202 (spurious
cross-room table detection on macOS), #203 (PLO HTML HUD and street popups),
#204 (macOS privacy usage descriptions and permission helper), #200 (backlog
refresh). Release notes are drafted for the tag.

## One thing to decide

This carries a new feature — the `plo_pro_html` HUD in #203 — so strict semver
would call it 3.5.0 rather than a patch. 3.4.3 was the number asked for and is
what this PR does; say the word if you would rather it be 3.5.0 and it is a
one-line change.

## Remaining steps (not done here)

1. Merge this PR into `development`.
2. Fast-forward `main` to that commit.
3. Tag `v3.4.3` (the `v` prefix is required).
4. Publish the GitHub release with the notes. `ci.yml` runs on
   `release: published` and uploads the six build tarballs itself.
