### PR TITLE
fix(macos): update PyInstaller bundling to declare privacy keys, strip quarantine & ad-hoc sign

### DIFF
--- a/test/test_bundle_pyinstaller_hud.py
+++ b/test/test_bundle_pyinstaller_hud.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import os
+import plistlib
 from pathlib import Path
 
 import pytest
 
-from tools.bundle_pyinstaller_hud import bundle_pyinstaller_hud
+from tools.bundle_pyinstaller_hud import _update_mac_info_plist, bundle_pyinstaller_hud
 
 
 @pytest.mark.parametrize("executable_name", ["HUD_main", "HUD_main.exe"])
@@ -54,6 +55,36 @@ def test_bundles_macos_hud_inside_main_app(tmp_path: Path) -> None:
     assert (fpdb_contents / "Frameworks" / "hud_only" / "module.dylib").is_file()
     assert (fpdb_contents / "Resources" / "hud_data" / "config.xml").is_file()
     assert not (dist / "HUD_main.app").exists()
+
+
+def test_info_plist_gains_the_privacy_descriptions(tmp_path: Path) -> None:
+    # macOS only remembers a granted permission when the bundle declares why it
+    # wants it and keeps a stable identifier, so these four keys are the whole
+    # point of the step.
+    info_plist = tmp_path / "Info.plist"
+    with info_plist.open("wb") as handle:
+        plistlib.dump({"CFBundleName": "fpdb", "CFBundleIdentifier": "com.example.fpdb"}, handle)
+
+    assert _update_mac_info_plist(info_plist) is True
+
+    with info_plist.open("rb") as handle:
+        info = plistlib.load(handle)
+    assert info["CFBundleIdentifier"] == "org.fpdb.fpdb3"
+    assert "AppleScript" in info["NSAppleEventsUsageDescription"]
+    assert info["NSScreenCaptureUsageDescription"]
+    assert info["NSAccessibilityUsageDescription"]
+    # Untouched keys survive the rewrite.
+    assert info["CFBundleName"] == "fpdb"
+
+
+def test_a_missing_or_unreadable_info_plist_is_reported(tmp_path: Path, capsys) -> None:
+    assert _update_mac_info_plist(tmp_path / "absent.plist") is False
+    assert "No Info.plist" in capsys.readouterr().out
+
+    broken = tmp_path / "Info.plist"
+    broken.write_text("not a plist", encoding="utf-8")
+    assert _update_mac_info_plist(broken) is False
+    assert "Could not update" in capsys.readouterr().out
 
 
 def test_rejects_incomplete_macos_outputs(tmp_path: Path) -> None:

--- a/test/test_bundle_pyinstaller_hud.py
+++ b/test/test_bundle_pyinstaller_hud.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import plistlib
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -85,6 +87,47 @@ def test_a_missing_or_unreadable_info_plist_is_reported(tmp_path: Path, capsys) 
     broken.write_text("not a plist", encoding="utf-8")
     assert _update_mac_info_plist(broken) is False
     assert "Could not update" in capsys.readouterr().out
+
+
+def test_the_signing_helper_exposes_what_the_bundler_imports() -> None:
+    # The bundler imported a name that does not exist ('adhoc_sign' instead of
+    # 'sign'), and the ImportError went into a bare except, so the signing it
+    # was meant to add silently never ran.
+    from tools import adhoc_sign_macos
+
+    assert callable(adhoc_sign_macos.sign)
+    assert callable(adhoc_sign_macos.find_mach_o_files)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="the macOS branch only runs on macOS")
+def test_runs_as_a_script_the_way_ci_invokes_it(tmp_path: Path) -> None:
+    # CI runs "python tools/bundle_pyinstaller_hud.py dist", which puts tools/
+    # on sys.path instead of the repository root -- so importing the sibling
+    # module as tools.adhoc_sign_macos raised ModuleNotFoundError and took the
+    # macOS build down. Importing this file from a test cannot catch that.
+    repo_root = Path(__file__).resolve().parent.parent
+    dist = tmp_path / "dist"
+    fpdb_contents = dist / "fpdb.app" / "Contents"
+    hud_contents = dist / "HUD_main.app" / "Contents"
+    for directory in ("MacOS", "Frameworks", "Resources"):
+        (fpdb_contents / directory).mkdir(parents=True)
+    (hud_contents / "MacOS").mkdir(parents=True)
+    (hud_contents / "MacOS" / "HUD_main").write_text("executable", encoding="utf-8")
+    with (fpdb_contents / "Info.plist").open("wb") as handle:
+        plistlib.dump({"CFBundleName": "fpdb"}, handle)
+
+    result = subprocess.run(
+        [sys.executable, "tools/bundle_pyinstaller_hud.py", str(dist)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    with (fpdb_contents / "Info.plist").open("rb") as handle:
+        info = plistlib.load(handle)
+    assert info["CFBundleIdentifier"] == "org.fpdb.fpdb3"
 
 
 def test_rejects_incomplete_macos_outputs(tmp_path: Path) -> None:

--- a/tools/bundle_pyinstaller_hud.py
+++ b/tools/bundle_pyinstaller_hud.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import os
+import plistlib
 import shutil
 import stat
+import subprocess
 from pathlib import Path
 
 
@@ -31,6 +33,28 @@ def _copy_executable(source: Path, destination: Path) -> None:
     destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
+def _update_mac_info_plist(info_plist: Path) -> None:
+    if not info_plist.is_file():
+        return
+    try:
+        with info_plist.open("rb") as handle:
+            info = plistlib.load(handle)
+        info["CFBundleIdentifier"] = "org.fpdb.fpdb3"
+        info["NSAppleEventsUsageDescription"] = (
+            "FPDB requires Automation access to detect poker table window titles via AppleScript."
+        )
+        info["NSScreenCaptureUsageDescription"] = (
+            "FPDB requires Screen Recording permission to identify poker table window titles for the HUD."
+        )
+        info["NSAccessibilityUsageDescription"] = (
+            "FPDB requires Accessibility permission to locate and position HUD windows over poker tables."
+        )
+        with info_plist.open("wb") as handle:
+            plistlib.dump(info, handle)
+    except Exception:
+        pass
+
+
 def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
     """Merge the HUD PyInstaller output into fpdb and return the bundled executable."""
     fpdb_app = dist_dir / "fpdb.app"
@@ -50,6 +74,24 @@ def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
         bundled_executable = fpdb_contents / "MacOS" / "HUD_main"
         _copy_executable(hud_contents / "MacOS" / "HUD_main", bundled_executable)
         shutil.rmtree(hud_app)
+
+        # Update Info.plist privacy usage descriptions & bundle ID
+        _update_mac_info_plist(fpdb_contents / "Info.plist")
+
+        # Strip quarantine extended attribute so Gatekeeper does not block execution
+        subprocess.run(["/usr/bin/xattr", "-cr", str(fpdb_app)], check=False)
+
+        # Re-sign the merged bundle inside-out
+        try:
+            from tools.adhoc_sign_macos import adhoc_sign, find_mach_o_files
+
+            adhoc_sign(find_mach_o_files(fpdb_contents / "Resources"))
+        except Exception:
+            pass
+
+        codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
+        subprocess.run([codesign_bin, "--force", "--deep", "--sign", "-", str(fpdb_app)], check=False)
+
         return bundled_executable
 
     fpdb_dir = dist_dir / "fpdb"

--- a/tools/bundle_pyinstaller_hud.py
+++ b/tools/bundle_pyinstaller_hud.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def _merge_tree(source: Path, destination: Path) -> None:
     """Copy missing entries from source into destination without replacing fpdb files."""
@@ -85,9 +87,18 @@ def _sign_macos_bundle(fpdb_app: Path, resources: Path) -> None:
     Gatekeeper assesses a bundle as a unit, so the nested binaries the merge
     just moved in have to be signed before the bundle itself is sealed.
     """
-    from tools.adhoc_sign_macos import find_mach_o_files, sign
+    # CI runs this file as a script ("python tools/bundle_pyinstaller_hud.py"),
+    # which puts tools/ on sys.path rather than the repository root, so the
+    # sibling module is not reachable as tools.adhoc_sign_macos. The tests
+    # import this file as tools.bundle_pyinstaller_hud, where it is. Add the
+    # root when it is missing so both ways of running work.
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
 
-    sign(find_mach_o_files(resources))
+    from tools.adhoc_sign_macos import find_mach_o_files
+    from tools.adhoc_sign_macos import sign as adhoc_sign
+
+    adhoc_sign(find_mach_o_files(resources))
 
     codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
     _run_macos_tool([codesign_bin, "--force", "--deep", "--sign", "-", str(fpdb_app)])

--- a/tools/bundle_pyinstaller_hud.py
+++ b/tools/bundle_pyinstaller_hud.py
@@ -9,6 +9,7 @@ import plistlib
 import shutil
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -33,9 +34,17 @@ def _copy_executable(source: Path, destination: Path) -> None:
     destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _update_mac_info_plist(info_plist: Path) -> None:
+def _update_mac_info_plist(info_plist: Path) -> bool:
+    """Write the privacy usage descriptions and bundle id into an Info.plist.
+
+    Returns whether the file was rewritten. A failure here is reported rather
+    than swallowed: the whole point of this step is that macOS remembers the
+    permissions the user grants, and a bundle shipped without the keys asks
+    again on every launch -- the exact symptom, arriving silently.
+    """
     if not info_plist.is_file():
-        return
+        print(f"No Info.plist at {info_plist}; privacy descriptions not written")
+        return False
     try:
         with info_plist.open("rb") as handle:
             info = plistlib.load(handle)
@@ -51,8 +60,37 @@ def _update_mac_info_plist(info_plist: Path) -> None:
         )
         with info_plist.open("wb") as handle:
             plistlib.dump(info, handle)
-    except Exception:
-        pass
+    except (OSError, plistlib.InvalidFileException) as exc:
+        print(f"Could not update {info_plist}: {exc}")
+        return False
+    return True
+
+
+def _run_macos_tool(command: list[str]) -> None:
+    """Run a macOS-only build tool, reporting rather than raising if it is absent.
+
+    subprocess.run(check=False) only forgives a non-zero exit; a missing binary
+    still raises, which is how /usr/bin/xattr took the Linux test run down with
+    it once this ran on a bundle built anywhere but macOS.
+    """
+    try:
+        subprocess.run(command, check=False)
+    except OSError as exc:
+        print(f"Could not run {command[0]}: {exc}")
+
+
+def _sign_macos_bundle(fpdb_app: Path, resources: Path) -> None:
+    """Ad-hoc sign the merged bundle, innermost Mach-O files first.
+
+    Gatekeeper assesses a bundle as a unit, so the nested binaries the merge
+    just moved in have to be signed before the bundle itself is sealed.
+    """
+    from tools.adhoc_sign_macos import find_mach_o_files, sign
+
+    sign(find_mach_o_files(resources))
+
+    codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
+    _run_macos_tool([codesign_bin, "--force", "--deep", "--sign", "-", str(fpdb_app)])
 
 
 def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
@@ -78,19 +116,13 @@ def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
         # Update Info.plist privacy usage descriptions & bundle ID
         _update_mac_info_plist(fpdb_contents / "Info.plist")
 
-        # Strip quarantine extended attribute so Gatekeeper does not block execution
-        subprocess.run(["/usr/bin/xattr", "-cr", str(fpdb_app)], check=False)
-
-        # Re-sign the merged bundle inside-out
-        try:
-            from tools.adhoc_sign_macos import adhoc_sign, find_mach_o_files
-
-            adhoc_sign(find_mach_o_files(fpdb_contents / "Resources"))
-        except Exception:
-            pass
-
-        codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
-        subprocess.run([codesign_bin, "--force", "--deep", "--sign", "-", str(fpdb_app)], check=False)
+        # xattr and codesign only exist on macOS, and signing a bundle assembled
+        # anywhere else is meaningless. The tests build an .app tree on whatever
+        # host they run on, so this branch is reached off-Darwin too.
+        if sys.platform == "darwin":
+            # Strip quarantine so Gatekeeper does not block execution
+            _run_macos_tool(["/usr/bin/xattr", "-cr", str(fpdb_app)])
+            _sign_macos_bundle(fpdb_app, fpdb_contents / "Resources")
 
         return bundled_executable
 


### PR DESCRIPTION
## Description
Resolves recurring TCC permission prompts and Gatekeeper blocking on PyInstaller macOS builds.

### Key Highlights
- Updates `tools/bundle_pyinstaller_hud.py` to automatically update `fpdb.app/Contents/Info.plist` with `NSAppleEventsUsageDescription`, `NSScreenCaptureUsageDescription`, `NSAccessibilityUsageDescription`, and `CFBundleIdentifier` = `org.fpdb.fpdb3`.
- Strips `com.apple.quarantine` from the merged `fpdb.app` bundle via `xattr -cr`.
- Re-seals the merged `.app` bundle inside-out with `codesign`.
