### PR TITLE
fix(replayer): resolve UI freeze when launching hand replayer from hand viewer

### DIFF
--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -681,11 +681,19 @@ class GuiHandViewer(QSplitter):
             handlist = sorted(self.hands.keys())
             hand_index = handlist.index(hand_id)
 
+            if getattr(self, "replayer", None) is not None and self.replayer.isVisible():
+                self.replayer.handlist = handlist
+                self.replayer.play_hand(hand_index)
+                self.replayer.raise_()
+                self.replayer.activateWindow()
+                return
+
             self.replayer = GuiReplayer.GuiReplayer(
                 self.config,
                 self.sql,
                 self.main_window,
                 handlist,
+                db=self.db,
             )
             self.replayer.play_hand(hand_index)
             self.replayer.raise_()

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -626,7 +626,7 @@ def order_players_clockwise(players: list[ReplayPlayer], hero_name: str | None =
 class GuiReplayer(QWidget):
     """A Replayer to replay hands."""
 
-    def __init__(self, config, querylist, mainwin, handlist) -> None:
+    def __init__(self, config, querylist, mainwin, handlist, db=None) -> None:
         QWidget.__init__(self, None)
         self.resize(1800, 1080)
         self.setMinimumSize(800, 600)
@@ -634,7 +634,12 @@ class GuiReplayer(QWidget):
         self.main_window = mainwin
         self.sql = querylist
         self.newpot = Decimal()
-        self.db = Database.Database(self.conf, sql=self.sql)
+        if db is not None:
+            self.db = db
+        elif hasattr(mainwin, "db") and mainwin.db is not None:
+            self.db = mainwin.db
+        else:
+            self.db = Database.Database(self.conf, sql=self.sql)
         self.states: list[Any] = []  # List with all table states.
         self.handlist = handlist
         self.handidx = 0
@@ -2298,6 +2303,9 @@ class GuiReplayer(QWidget):
             self.replay_model = self._build_ofc_replay_model(ofc_hand)
         else:
             hand = Hand.hand_factory(entry, self.conf, self.db)
+            if hand is None:
+                log.error("Could not load hand ID %s for replayer", entry)
+                return
             self.currency = hand.sym
             self.currency_code = str(hand.gametype.get("currency", "USD"))
             self.Heroes = hand.hero or self._resolve_hero(hand.sitename)

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -623,6 +623,23 @@ def order_players_clockwise(players: list[ReplayPlayer], hero_name: str | None =
     return ordered
 
 
+def resolve_replayer_db(config, querylist, mainwin, db=None):
+    """Return the database the replayer should read through.
+
+    Opening one of its own is the last resort: a fresh Database connects and
+    builds its caches on the GUI thread, which is what froze the window every
+    time a hand was double-clicked in the hand viewer. The caller's connection
+    is reused instead, and the replayer only ever reads through it -- it never
+    disconnects what it was handed.
+    """
+    if db is not None:
+        return db
+    caller_db = getattr(mainwin, "db", None)
+    if caller_db is not None:
+        return caller_db
+    return Database.Database(config, sql=querylist)
+
+
 class GuiReplayer(QWidget):
     """A Replayer to replay hands."""
 
@@ -634,12 +651,7 @@ class GuiReplayer(QWidget):
         self.main_window = mainwin
         self.sql = querylist
         self.newpot = Decimal()
-        if db is not None:
-            self.db = db
-        elif hasattr(mainwin, "db") and mainwin.db is not None:
-            self.db = mainwin.db
-        else:
-            self.db = Database.Database(self.conf, sql=self.sql)
+        self.db = resolve_replayer_db(self.conf, self.sql, mainwin, db)
         self.states: list[Any] = []  # List with all table states.
         self.handlist = handlist
         self.handidx = 0

--- a/fpdb_3_legacy/GuiTourHandViewer.py
+++ b/fpdb_3_legacy/GuiTourHandViewer.py
@@ -472,11 +472,19 @@ class TourHandViewer(QSplitter):
             handlist = sorted(self.hands.keys())
             hand_index = handlist.index(hand_id)
 
+            if getattr(self, "replayer", None) is not None and self.replayer.isVisible():
+                self.replayer.handlist = handlist
+                self.replayer.play_hand(hand_index)
+                self.replayer.raise_()
+                self.replayer.activateWindow()
+                return
+
             self.replayer = GuiReplayer.GuiReplayer(
                 self.config,
                 self.sql,
                 self.main_window,
                 handlist,
+                db=self.db,
             )
             self.replayer.play_hand(hand_index)
             self.replayer.raise_()

--- a/test/test_guihandviewer_replayer.py
+++ b/test/test_guihandviewer_replayer.py
@@ -1,0 +1,53 @@
+"""Unit tests for Hand Viewer to Replayer launching and database sharing logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fpdb_3_legacy.GuiHandViewer import GuiHandViewer
+from fpdb_3_legacy.GuiReplayer import GuiReplayer
+
+
+def test_replayer_init_uses_passed_db() -> None:
+    fake_config = MagicMock()
+    fake_sql = MagicMock()
+    fake_mainwin = MagicMock()
+    fake_db = MagicMock()
+
+    # Instantiate GuiReplayer without running GUI loop
+    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer.conf = fake_config
+    replayer.sql = fake_sql
+    replayer.main_window = fake_mainwin
+
+    # Test passing db explicitly
+    if hasattr(replayer, "__init__"):
+        # Invoke __init__ logic check with db
+        replayer.db = fake_db
+        assert replayer.db is fake_db
+
+
+def test_guihandviewer_row_activated_reuses_replayer(monkeypatch) -> None:
+    viewer = GuiHandViewer.__new__(GuiHandViewer)
+    viewer.hands = {101: MagicMock(), 102: MagicMock()}
+    viewer.colnum = {"HandId": 0}
+    viewer.config = MagicMock()
+    viewer.sql = MagicMock()
+    viewer.main_window = MagicMock()
+    viewer.db = MagicMock()
+
+    mock_index = MagicMock()
+    mock_sibling = MagicMock()
+    mock_sibling.data.return_value = "101"
+    mock_index.sibling.return_value = mock_sibling
+
+    # Mock open replayer
+    mock_replayer = MagicMock()
+    mock_replayer.isVisible.return_value = True
+    viewer.replayer = mock_replayer
+
+    viewer.row_activated(mock_index)
+
+    assert mock_replayer.play_hand.called
+    mock_replayer.raise_.assert_called_once()
+    mock_replayer.activateWindow.assert_called_once()

--- a/test/test_guihandviewer_replayer.py
+++ b/test/test_guihandviewer_replayer.py
@@ -1,53 +1,118 @@
-"""Unit tests for Hand Viewer to Replayer launching and database sharing logic."""
+"""Opening the replayer from a hand viewer must not stall the window.
+
+Two things caused it. Every double-click built a fresh GuiReplayer, and every
+GuiReplayer opened its own Database -- a connection and its caches, built on
+the GUI thread. So the fix has two halves, and each is checked here: an open
+replayer is reused rather than rebuilt, and the replayer reads through the
+caller's connection rather than opening one.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from fpdb_3_legacy import GuiReplayer as replayer_module
 from fpdb_3_legacy.GuiHandViewer import GuiHandViewer
-from fpdb_3_legacy.GuiReplayer import GuiReplayer
+from fpdb_3_legacy.GuiReplayer import resolve_replayer_db
+from fpdb_3_legacy.GuiTourHandViewer import TourHandViewer
 
 
-def test_replayer_init_uses_passed_db() -> None:
-    fake_config = MagicMock()
-    fake_sql = MagicMock()
-    fake_mainwin = MagicMock()
-    fake_db = MagicMock()
+class TestResolveReplayerDb:
+    def test_an_explicit_connection_is_used_as_is(self) -> None:
+        handed_over = MagicMock()
+        mainwin = MagicMock(db=MagicMock())
 
-    # Instantiate GuiReplayer without running GUI loop
-    replayer = GuiReplayer.__new__(GuiReplayer)
-    replayer.conf = fake_config
-    replayer.sql = fake_sql
-    replayer.main_window = fake_mainwin
+        assert resolve_replayer_db(MagicMock(), MagicMock(), mainwin, handed_over) is handed_over
 
-    # Test passing db explicitly
-    if hasattr(replayer, "__init__"):
-        # Invoke __init__ logic check with db
-        replayer.db = fake_db
-        assert replayer.db is fake_db
+    def test_the_main_window_connection_is_the_next_choice(self) -> None:
+        mainwin = MagicMock()
+        mainwin.db = MagicMock()
+
+        assert resolve_replayer_db(MagicMock(), MagicMock(), mainwin, None) is mainwin.db
+
+    def test_a_connection_is_opened_only_when_there_is_none_to_borrow(self, monkeypatch) -> None:
+        # The expensive path, and the one the freeze came from: it must be
+        # reached only when neither the caller nor the main window has one.
+        opened = MagicMock()
+        monkeypatch.setattr(replayer_module.Database, "Database", MagicMock(return_value=opened))
+        mainwin = MagicMock()
+        mainwin.db = None
+
+        assert resolve_replayer_db(MagicMock(), MagicMock(), mainwin, None) is opened
+
+    def test_a_main_window_without_a_db_attribute_falls_through(self, monkeypatch) -> None:
+        opened = MagicMock()
+        monkeypatch.setattr(replayer_module.Database, "Database", MagicMock(return_value=opened))
+
+        class Bare:
+            pass
+
+        assert resolve_replayer_db(MagicMock(), MagicMock(), Bare(), None) is opened
 
 
-def test_guihandviewer_row_activated_reuses_replayer(monkeypatch) -> None:
-    viewer = GuiHandViewer.__new__(GuiHandViewer)
+def _viewer(cls):
+    """A viewer with just the attributes row_activated reads."""
+    viewer = cls.__new__(cls)
     viewer.hands = {101: MagicMock(), 102: MagicMock()}
     viewer.colnum = {"HandId": 0}
     viewer.config = MagicMock()
     viewer.sql = MagicMock()
     viewer.main_window = MagicMock()
     viewer.db = MagicMock()
+    return viewer
 
-    mock_index = MagicMock()
-    mock_sibling = MagicMock()
-    mock_sibling.data.return_value = "101"
-    mock_index.sibling.return_value = mock_sibling
 
-    # Mock open replayer
-    mock_replayer = MagicMock()
-    mock_replayer.isVisible.return_value = True
-    viewer.replayer = mock_replayer
+def _index_for(hand_id: int):
+    index = MagicMock()
+    sibling = MagicMock()
+    sibling.data.return_value = str(hand_id)
+    index.sibling.return_value = sibling
+    return index
 
-    viewer.row_activated(mock_index)
 
-    assert mock_replayer.play_hand.called
-    mock_replayer.raise_.assert_called_once()
-    mock_replayer.activateWindow.assert_called_once()
+@pytest.mark.parametrize("viewer_cls", [GuiHandViewer, TourHandViewer])
+class TestRowActivated:
+    def test_an_open_replayer_is_reused(self, viewer_cls, monkeypatch) -> None:
+        built = MagicMock()
+        monkeypatch.setattr(replayer_module, "GuiReplayer", built)
+        viewer = _viewer(viewer_cls)
+        open_replayer = MagicMock()
+        open_replayer.isVisible.return_value = True
+        viewer.replayer = open_replayer
+
+        viewer.row_activated(_index_for(102))
+
+        built.assert_not_called()
+        # Reused, pointed at the newly selected hand, and brought to the front.
+        assert open_replayer.handlist == [101, 102]
+        open_replayer.play_hand.assert_called_once_with(1)
+        open_replayer.raise_.assert_called_once()
+        open_replayer.activateWindow.assert_called_once()
+
+    def test_a_closed_replayer_is_rebuilt_on_the_shared_connection(self, viewer_cls, monkeypatch) -> None:
+        built = MagicMock()
+        monkeypatch.setattr(replayer_module, "GuiReplayer", built)
+        viewer = _viewer(viewer_cls)
+        closed = MagicMock()
+        closed.isVisible.return_value = False
+        viewer.replayer = closed
+
+        viewer.row_activated(_index_for(101))
+
+        built.assert_called_once()
+        # The viewer's own connection is handed over rather than a new one opened.
+        assert built.call_args.kwargs["db"] is viewer.db
+        closed.play_hand.assert_not_called()
+        built.return_value.play_hand.assert_called_once_with(0)
+
+    def test_the_first_open_builds_one(self, viewer_cls, monkeypatch) -> None:
+        built = MagicMock()
+        monkeypatch.setattr(replayer_module, "GuiReplayer", built)
+        viewer = _viewer(viewer_cls)
+
+        viewer.row_activated(_index_for(101))
+
+        built.assert_called_once()
+        assert built.call_args.kwargs["db"] is viewer.db


### PR DESCRIPTION
## Description
Fixes a freeze in the PySide6 UI when double-clicking a hand in `GuiHandViewer` or `GuiTourHandViewer` to launch the hand replayer.

### Cause & Solution
1. **SQLite Database Connection Lock**:
   - `GuiReplayer` previously opened a new, unshared `Database.Database` connection instance. Under SQLite on the main GUI thread, executing queries while `GuiHandViewer` had open transactions resulted in database locks that froze the entire application interface.
   - **Fix**: Updated `GuiReplayer.__init__` to accept an optional `db` connection or reuse `mainwin.db`, and updated `GuiHandViewer` / `GuiTourHandViewer` to pass `db=self.db`.
2. **Replayer Instance Reuse**:
   - Updated `row_activated` in `GuiHandViewer` and `GuiTourHandViewer` to check if `self.replayer` is already open and visible. If so, it updates the handlist and plays the selected hand, bringing the window to front rather than spawning orphaned locked widgets.
3. **Null Hand Guard**:
   - Added a safety check in `play_hand` if `Hand.hand_factory` returns `None`.
