### PR TITLE
chore(release): prepare 3.5.0

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.4.3"
+__version__ = "3.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.4.3"
+version = "3.5.0"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.4.3"
+version = "3.5.0"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.4.3"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prepares the 3.5.0 release. Version bump only — no behaviour change.

## Why 3.5.0 and not 3.4.4

The contents are two fixes, which would normally be a patch. v3.4.3 shipped a
new feature — the PLO HTML HUD — under a patch number, so this restores the
semver line rather than carrying the discrepancy forward. Decided after v3.4.3
went out.

## The bump

The declared version lives in three independent places, none derived from
another, so all three move together or they drift silently:

- `pyproject.toml` → `[project].version`
- `pyproject.toml` → `[tool.briefcase].version`
- `fpdb_3_legacy/__init__.py` → `__version__`

`uv.lock` follows automatically and is committed alongside.

## Verified

- `uv build --wheel` → `fpdb_3-3.5.0-py3-none-any.whl`
- `fpdb_3_legacy.__version__` → `3.5.0` (what a frozen build reports)
- `test/test_fpdb_version_resolution.py` — 6 passed
- `ruff check fpdb_3_legacy fpdb test tests tools` — clean
- Full suite — 7430 passed, 16 skipped
- CI on `development` at `9e3a63ca` — **17/17 jobs green**
  ([run 31182718381](https://github.com/jejellyroll-fr/fpdb-3/actions/runs/31182718381))

## What ships since v3.4.3

**#207 — the replayer no longer freezes the hand viewer.** Every double-click
built a new replayer, and every replayer opened its own database connection on
the GUI thread. An open replayer is now reused, and the replayer reads through
the viewer's existing connection.

**#206 — the PyInstaller macOS bundle declares its privacy usage
descriptions**, keeps a stable bundle identifier so macOS remembers granted
permissions, and is de-quarantined and ad-hoc signed inside-out.

Both needed fixing before merge — details in the review comments on each. The
short version: #206's re-signing imported a name that does not exist and the
ImportError went into a bare `except`, so the signing it adds had never once
run; and #207's two new tests both passed against code with neither half of
the fix.

## Remaining steps (not done here)

1. Merge this PR into `development`.
2. Fast-forward `main` to that commit.
3. Tag `v3.5.0` (the `v` prefix is required).
4. Publish the GitHub release with the notes. `ci.yml` runs on
   `release: published` and uploads the six build tarballs itself.
