### PR TITLE
feat(replayer): add Push Equity, Call Equity, and Pot Odds ratios to hand replayer

### DIFF
--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -2226,6 +2226,8 @@ class GuiReplayer(QWidget):
 
     def _hero_odds_summary(self, frame: ReplayFrame, current_index: int) -> str:
         metrics = self._hero_decision_metrics(frame, current_index)
+        if not metrics.get("is_hero_turn"):
+            return ""
         parts = []
         if metrics.get("facing_call"):
             call_amt = format_replay_amount(metrics["call_amount"], self.currency_code)
@@ -2246,7 +2248,10 @@ class GuiReplayer(QWidget):
 
     def _draw_summary(self, painter: QPainter, frame: ReplayFrame, layout: ReplayLayout, current_index: int) -> None:
         metrics = self._hero_decision_metrics(frame, current_index)
-        has_metrics = bool(metrics.get("facing_call") or metrics.get("push_equity_pct") is not None)
+        has_metrics = bool(
+            metrics.get("is_hero_turn")
+            and (metrics.get("facing_call") or metrics.get("push_equity_pct") is not None)
+        )
         box_height = 78 if has_metrics else 56
         summary_width = min(640, max(320, layout.table_rect.width() * 0.48))
         if layout.timeline_rect.isNull():

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -2164,78 +2164,162 @@ class GuiReplayer(QWidget):
         return f"{player.name} {player.action}{allin_suffix}"
 
     def _next_actor_name(self, current_index: int) -> str | None:
+        if not getattr(self, "states", None):
+            return None
         for state in self.states[current_index + 1 :]:
             for player in state.players.values():
                 if player.justacted and player.action:
                     return player.name
         return None
 
-    def _hero_odds_summary(self, frame: ReplayFrame, current_index: int) -> str:
-        if self._next_actor_name(current_index) != self.Heroes:
-            return ""
+    def _hero_decision_metrics(self, frame: ReplayFrame, current_index: int) -> dict[str, Any]:
         hero = next((player for player in frame.players if player.name == self.Heroes), None)
         if hero is None:
-            return ""
-        call_amount = max((player.chips for player in frame.players), default=Decimal(0)) - hero.chips
-        if call_amount <= 0 or frame.pot <= 0:
-            return ""
-        pot_after_call = frame.pot + call_amount
-        if pot_after_call <= 0:
-            return ""
-        equity_needed = (call_amount / pot_after_call) * Decimal(100)
-        summary = (
-            f"Hero call {format_replay_amount(call_amount, self.currency_code)} · "
-            f"pot odds {format_number(equity_needed, 1)}%"
-        )
-        hand = self.replay_model.hand
-        category = hand.gametype.get("category", "")
+            return {}
+
+        max_chips = max((player.chips for player in frame.players if player.action != "folds"), default=Decimal(0))
+        call_amount = max(Decimal(0), max_chips - hero.chips)
+        facing_call = call_amount > 0 and frame.pot > 0
+        pot_odds_pct = None
+        pot_odds_ratio = None
+        if facing_call:
+            pot_after_call = frame.pot + call_amount
+            if pot_after_call > 0:
+                pot_odds_pct = (call_amount / pot_after_call) * Decimal(100)
+                pot_odds_ratio = frame.pot / call_amount
+
+        hand = getattr(getattr(self, "replay_model", None), "hand", None)
+        category = hand.gametype.get("category", "") if hand else ""
         game_info = Card.games.get(category)
         game = game_info[1] if game_info else None
-        if not game:
-            return summary
-        cache: dict[Any, Decimal | None] = getattr(self, "_equity_cache", None) or {}
-        self._equity_cache = cache
-        key = (
-            game,
-            tuple((player.name, tuple(player.holecards), player.action) for player in frame.players),
-            tuple(sorted(frame.render_board)),
-            tuple((street, tuple(frame.board.get(street) or [])) for street in ("FLOP", "TURN", "RIVER")),
-        )
-        if key not in cache:
-            cache[key] = replay_hero_equity(frame, self.Heroes, game)
-        equity = cache[key]
-        if equity is not None:
-            equity_pct = equity * Decimal(100)
-            edge = equity_pct - equity_needed
-            summary += f" · equity {format_number(equity_pct, 1)}% · edge {format_number(edge, 1, show_plus=True)} pts"
-        return summary
+        equity = None
+        if game:
+            cache: dict[Any, Decimal | None] = getattr(self, "_equity_cache", None) or {}
+            self._equity_cache = cache
+            key = (
+                game,
+                tuple((player.name, tuple(player.holecards), player.action) for player in frame.players),
+                tuple(sorted(frame.render_board)),
+                tuple((street, tuple(frame.board.get(street) or [])) for street in ("FLOP", "TURN", "RIVER")),
+            )
+            if key not in cache:
+                cache[key] = replay_hero_equity(frame, self.Heroes, game)
+            equity = cache[key]
+
+        call_equity_pct = (equity * Decimal(100)) if equity is not None else None
+        push_equity_pct = (equity * Decimal(100)) if equity is not None else None
+        call_edge_pts = (call_equity_pct - pot_odds_pct) if (call_equity_pct is not None and pot_odds_pct is not None) else None
+        is_allin = any(player.allin for player in frame.players if player.action != "folds")
+
+        return {
+            "hero": hero,
+            "call_amount": call_amount,
+            "facing_call": facing_call,
+            "pot_odds_pct": pot_odds_pct,
+            "pot_odds_ratio": pot_odds_ratio,
+            "call_equity_pct": call_equity_pct,
+            "call_edge_pts": call_edge_pts,
+            "push_equity_pct": push_equity_pct,
+            "is_allin": is_allin,
+            "is_hero_turn": self._next_actor_name(current_index) == self.Heroes,
+        }
+
+    def _hero_odds_summary(self, frame: ReplayFrame, current_index: int) -> str:
+        metrics = self._hero_decision_metrics(frame, current_index)
+        parts = []
+        if metrics.get("facing_call"):
+            call_amt = format_replay_amount(metrics["call_amount"], self.currency_code)
+            odds_pct = format_number(metrics["pot_odds_pct"], 1)
+            ratio = format_number(metrics["pot_odds_ratio"], 1)
+            parts.append(f"Hero call {call_amt} · pot odds {odds_pct}% ({ratio}:1)")
+        if metrics.get("call_equity_pct") is not None:
+            eq_pct = format_number(metrics["call_equity_pct"], 1)
+            parts.append(f"Call Eq {eq_pct}%")
+            if metrics.get("call_edge_pts") is not None:
+                edge = format_number(metrics["call_edge_pts"], 1, show_plus=True)
+                parts.append(f"edge {edge} pts")
+        if metrics.get("push_equity_pct") is not None:
+            push_pct = format_number(metrics["push_equity_pct"], 1)
+            label = "Push/All-in Eq" if metrics.get("is_allin") else "Push Eq"
+            parts.append(f"{label} {push_pct}%")
+        return " · ".join(parts)
 
     def _draw_summary(self, painter: QPainter, frame: ReplayFrame, layout: ReplayLayout, current_index: int) -> None:
-        summary_width = min(620, max(300, layout.table_rect.width() * 0.46))
+        metrics = self._hero_decision_metrics(frame, current_index)
+        has_metrics = bool(metrics.get("facing_call") or metrics.get("push_equity_pct") is not None)
+        box_height = 78 if has_metrics else 56
+        summary_width = min(640, max(320, layout.table_rect.width() * 0.48))
         if layout.timeline_rect.isNull():
             x = self.width() - summary_width - 28
         else:
             x = layout.timeline_rect.x() - summary_width - 16
         x = max(28, x)
-        rect = QRectF(x, 14, summary_width, 64)
+        rect = QRectF(x, 12, summary_width, box_height)
         painter.setPen(QPen(QColor("#46505a"), 1))
         painter.setBrush(QColor("#171d22"))
-        painter.drawRoundedRect(rect, 7, 7)
+        painter.drawRoundedRect(rect, 8, 8)
+
+        # Line 1: Action Summary
         painter.setFont(QFont("Helvetica", 10, QFont.Weight.Bold))
         painter.setPen(QColor("#eef3f7"))
         painter.drawText(
-            rect.adjusted(12, 8, -12, -34),
+            QRectF(rect.x() + 12, rect.y() + 6, rect.width() - 24, 20),
             Qt.AlignmentFlag.AlignLeft,
             self._current_action_summary(frame),
         )
-        odds = self._hero_odds_summary(frame, current_index)
-        painter.setFont(QFont("Helvetica", 9, QFont.Weight.DemiBold))
-        painter.setPen(QColor("#ffe769") if odds else QColor("#9aa5ad"))
-        painter.drawText(
-            rect.adjusted(12, 32, -12, -8),
-            Qt.AlignmentFlag.AlignLeft,
-            odds or "Use arrows/space to review decisions",
-        )
+
+        if not has_metrics:
+            painter.setFont(QFont("Helvetica", 9, QFont.Weight.DemiBold))
+            painter.setPen(QColor("#9aa5ad"))
+            painter.drawText(
+                QRectF(rect.x() + 12, rect.y() + 28, rect.width() - 24, 20),
+                Qt.AlignmentFlag.AlignLeft,
+                "Use arrows/space to review decisions",
+            )
+            return
+
+        # Line 2: Pot Odds & Call Equity
+        line2_parts = []
+        if metrics.get("facing_call"):
+            call_amt = format_replay_amount(metrics["call_amount"], self.currency_code)
+            odds_pct = format_number(metrics["pot_odds_pct"], 1)
+            ratio = format_number(metrics["pot_odds_ratio"], 1)
+            line2_parts.append(f"Pot Odds: {odds_pct}% ({ratio}:1) [Call {call_amt}]")
+        if metrics.get("call_equity_pct") is not None:
+            eq_pct = format_number(metrics["call_equity_pct"], 1)
+            line2_parts.append(f"Call Eq: {eq_pct}%")
+            if metrics.get("call_edge_pts") is not None:
+                edge = format_number(metrics["call_edge_pts"], 1, show_plus=True)
+                line2_parts.append(f"Edge: {edge} pts")
+
+        if line2_parts:
+            painter.setFont(QFont("Helvetica", 9, QFont.Weight.DemiBold))
+            edge_val = metrics.get("call_edge_pts")
+            color = QColor("#ffe769")
+            if edge_val is not None:
+                color = QColor("#4ade80") if edge_val >= 0 else QColor("#ff6b6b")
+            painter.setPen(color)
+            painter.drawText(
+                QRectF(rect.x() + 12, rect.y() + 28, rect.width() - 24, 20),
+                Qt.AlignmentFlag.AlignLeft,
+                "  ·  ".join(line2_parts),
+            )
+
+        # Line 3: Push / All-in Equity
+        line3_parts = []
+        if metrics.get("push_equity_pct") is not None:
+            push_pct = format_number(metrics["push_equity_pct"], 1)
+            label = "Push/All-in Eq" if metrics.get("is_allin") else "Push Eq"
+            line3_parts.append(f"{label}: {push_pct}%")
+
+        if line3_parts:
+            painter.setFont(QFont("Helvetica", 9, QFont.Weight.DemiBold))
+            painter.setPen(QColor("#a78bfa"))
+            painter.drawText(
+                QRectF(rect.x() + 12, rect.y() + 50, rect.width() - 24, 20),
+                Qt.AlignmentFlag.AlignLeft,
+                "  ·  ".join(line3_parts),
+            )
 
     def _draw_timeline(self, painter: QPainter, layout: ReplayLayout) -> None:
         if layout.timeline_rect.isNull():

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -2191,7 +2191,7 @@ class GuiReplayer(QWidget):
         hand = getattr(getattr(self, "replay_model", None), "hand", None)
         category = hand.gametype.get("category", "") if hand else ""
         game_info = Card.games.get(category)
-        game = game_info[1] if game_info else None
+        game = (game_info[1] if game_info else None) or category or (hand.gametype.get("base", "") if hand else "")
         equity = None
         if game:
             cache: dict[Any, Decimal | None] = getattr(self, "_equity_cache", None) or {}

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -81,3 +81,31 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
     assert "Call Eq 60.0%" in summary
     assert "edge +35.0 pts" in summary
     assert "Push Eq 60.0%" in summary
+
+
+def test_hero_decision_metrics_supports_stud_and_draw() -> None:
+    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer.Heroes = "Hero"
+    replayer.currency_code = "USD"
+    # Stud/Draw gametypes: studhi, 7stud8, razz, 27_3draw, badugi
+    hand = SimpleNamespace(gametype={"category": "studhi", "base": "stud"})
+    replayer.replay_model = SimpleNamespace(hand=hand)
+
+    frame = SimpleNamespace(
+        players=[
+            ReplayPlayer("Hero", 1, Decimal(0), Decimal(20), "calls", False, ["As", "Kd", "Qc", "Jh", "Ts"]),
+            ReplayPlayer("Villain", 2, Decimal(0), Decimal(40), "bets", False, ["2s", "3d", "4c", "5h", "7s"]),
+        ],
+        pot=Decimal(60),
+        board={},
+        render_board=set(),
+    )
+
+    metrics = replayer._hero_decision_metrics(frame, 0)
+
+    # Pot Odds are computed from chips & pot regardless of variant
+    assert metrics["facing_call"] is True
+    assert metrics["call_amount"] == Decimal(20)
+    assert metrics["pot_odds_pct"] == Decimal(25)  # 20 / (60 + 20) = 25%
+    assert metrics["pot_odds_ratio"] == Decimal(3)  # 60 / 20 = 3:1
+

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -10,7 +10,7 @@ from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer
 
 
 def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
-    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer = cast(Any, GuiReplayer).__new__(GuiReplayer)  # pylint: disable=no-value-for-parameter
     replayer.Heroes = "Hero"
     replayer.currency_code = "USD"
 
@@ -44,7 +44,7 @@ def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
 
 
 def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
-    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer = cast(Any, GuiReplayer).__new__(GuiReplayer)  # pylint: disable=no-value-for-parameter
     replayer.Heroes = "Hero"
     replayer.currency_code = "USD"
     replayer.replay_model = cast(Any, SimpleNamespace(hand=SimpleNamespace(gametype={"category": "holdem"})))
@@ -73,7 +73,7 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
 
 
 def test_hero_decision_metrics_supports_stud_and_draw() -> None:
-    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer = cast(Any, GuiReplayer).__new__(GuiReplayer)  # pylint: disable=no-value-for-parameter
     replayer.Heroes = "Hero"
     replayer.currency_code = "USD"
     # Stud/Draw gametypes: studhi, 7stud8, razz, 27_3draw, badugi
@@ -97,4 +97,3 @@ def test_hero_decision_metrics_supports_stud_and_draw() -> None:
     assert metrics["call_amount"] == Decimal(20)
     assert metrics["pot_odds_pct"] == Decimal(25)  # 20 / (60 + 20) = 25%
     assert metrics["pot_odds_ratio"] == Decimal(3)  # 60 / 20 = 3:1
-

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -48,6 +48,10 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
     replayer.Heroes = "Hero"
     replayer.currency_code = "USD"
     replayer.replay_model = cast(Any, SimpleNamespace(hand=SimpleNamespace(gametype={"category": "holdem"})))
+    replayer.states = [
+        SimpleNamespace(players={}),
+        SimpleNamespace(players={1: SimpleNamespace(name="Hero", justacted=True, action="calls")}),
+    ]
 
     frame = cast(Any, SimpleNamespace(
         players=[
@@ -70,6 +74,9 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
     assert "Call Eq 60.0%" in summary
     assert "edge +35.0 pts" in summary
     assert "Push Eq 60.0%" in summary
+
+    replayer.states[1].players[1].name = "Villain"
+    assert replayer._hero_odds_summary(frame, 0) == ""
 
 
 def test_hero_decision_metrics_supports_stud_and_draw() -> None:

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -1,0 +1,83 @@
+"""Unit tests for Replayer Push Equity, Call Equity, and Pot Odds metrics."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer
+
+
+class _FakeEquityBackend:
+    def poker_eval(self, **kwargs):
+        return {
+            "info": (1000, 0, 1),
+            "eval": [
+                {"ev": 600, "winhi": 550, "tiehi": 100, "losehi": 350},
+                {"ev": 400, "winhi": 350, "tiehi": 100, "losehi": 550},
+            ],
+        }
+
+
+def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
+    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer.Heroes = "Hero"
+    replayer.currency_code = "USD"
+
+    hand = SimpleNamespace(gametype={"category": "holdem", "base": "hold"})
+    replayer.replay_model = SimpleNamespace(hand=hand)
+
+    # Hero facing a $5 call into a $15 pot ($20 pot after call -> 25% pot odds, 3:1 ratio)
+    frame = SimpleNamespace(
+        players=[
+            ReplayPlayer("Hero", 1, Decimal(0), Decimal(10), "calls", False, ["As", "Ah"]),
+            ReplayPlayer("Villain", 2, Decimal(0), Decimal(15), "bets", False, ["Ks", "Kh"]),
+        ],
+        pot=Decimal(15),
+        board={"FLOP": ["2c", "3d", "4h"]},
+        render_board={"FLOP"},
+    )
+
+    monkeypatch.setattr("fpdb_3_legacy.GuiReplayer.calculate_equity", lambda *args, **kwargs: SimpleNamespace(
+        players=[SimpleNamespace(equity=Decimal("0.60")), SimpleNamespace(equity=Decimal("0.40"))]
+    ))
+
+    metrics = replayer._hero_decision_metrics(frame, 0)
+
+    assert metrics["facing_call"] is True
+    assert metrics["call_amount"] == Decimal(5)
+    assert metrics["pot_odds_pct"] == Decimal(25)  # 5 / 20 * 100
+    assert metrics["pot_odds_ratio"] == Decimal(3)  # 15 / 5 = 3:1
+    assert metrics["call_equity_pct"] == Decimal(60)
+    assert metrics["call_edge_pts"] == Decimal(35)  # 60 - 25 = 35
+    assert metrics["push_equity_pct"] == Decimal(60)
+
+
+def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
+    replayer = GuiReplayer.__new__(GuiReplayer)
+    replayer.Heroes = "Hero"
+    replayer.currency_code = "USD"
+    replayer.replay_model = SimpleNamespace(hand=SimpleNamespace(gametype={"category": "holdem"}))
+
+    frame = SimpleNamespace(
+        players=[
+            ReplayPlayer("Hero", 1, Decimal(0), Decimal(10), "calls", False, ["As", "Ah"]),
+            ReplayPlayer("Villain", 2, Decimal(0), Decimal(15), "bets", False, ["Ks", "Kh"]),
+        ],
+        pot=Decimal(15),
+        board={"FLOP": ["2c", "3d", "4h"]},
+        render_board={"FLOP"},
+    )
+
+    monkeypatch.setattr("fpdb_3_legacy.GuiReplayer.calculate_equity", lambda *args, **kwargs: SimpleNamespace(
+        players=[SimpleNamespace(equity=Decimal("0.60")), SimpleNamespace(equity=Decimal("0.40"))]
+    ))
+
+    summary = replayer._hero_odds_summary(frame, 0)
+
+    assert "Hero call $5.00" in summary
+    assert "pot odds 25.0% (3.0:1)" in summary
+    assert "Call Eq 60.0%" in summary
+    assert "edge +35.0 pts" in summary
+    assert "Push Eq 60.0%" in summary

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -9,17 +9,6 @@ from typing import Any, cast
 from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer
 
 
-class _FakeEquityBackend:
-    def poker_eval(self, **kwargs):
-        return {
-            "info": (1000, 0, 1),
-            "eval": [
-                {"ev": 600, "winhi": 550, "tiehi": 100, "losehi": 350},
-                {"ev": 400, "winhi": 350, "tiehi": 100, "losehi": 550},
-            ],
-        }
-
-
 def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
     replayer = GuiReplayer.__new__(GuiReplayer)
     replayer.Heroes = "Hero"

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from typing import Any, cast
 
 from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer
 
@@ -26,10 +26,10 @@ def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
     replayer.currency_code = "USD"
 
     hand = SimpleNamespace(gametype={"category": "holdem", "base": "hold"})
-    replayer.replay_model = SimpleNamespace(hand=hand)
+    replayer.replay_model = cast(Any, SimpleNamespace(hand=hand))
 
     # Hero facing a $5 call into a $15 pot ($20 pot after call -> 25% pot odds, 3:1 ratio)
-    frame = SimpleNamespace(
+    frame = cast(Any, SimpleNamespace(
         players=[
             ReplayPlayer("Hero", 1, Decimal(0), Decimal(10), "calls", False, ["As", "Ah"]),
             ReplayPlayer("Villain", 2, Decimal(0), Decimal(15), "bets", False, ["Ks", "Kh"]),
@@ -37,7 +37,7 @@ def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:
         pot=Decimal(15),
         board={"FLOP": ["2c", "3d", "4h"]},
         render_board={"FLOP"},
-    )
+    ))
 
     monkeypatch.setattr("fpdb_3_legacy.GuiReplayer.calculate_equity", lambda *args, **kwargs: SimpleNamespace(
         players=[SimpleNamespace(equity=Decimal("0.60")), SimpleNamespace(equity=Decimal("0.40"))]
@@ -58,9 +58,9 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
     replayer = GuiReplayer.__new__(GuiReplayer)
     replayer.Heroes = "Hero"
     replayer.currency_code = "USD"
-    replayer.replay_model = SimpleNamespace(hand=SimpleNamespace(gametype={"category": "holdem"}))
+    replayer.replay_model = cast(Any, SimpleNamespace(hand=SimpleNamespace(gametype={"category": "holdem"})))
 
-    frame = SimpleNamespace(
+    frame = cast(Any, SimpleNamespace(
         players=[
             ReplayPlayer("Hero", 1, Decimal(0), Decimal(10), "calls", False, ["As", "Ah"]),
             ReplayPlayer("Villain", 2, Decimal(0), Decimal(15), "bets", False, ["Ks", "Kh"]),
@@ -68,7 +68,7 @@ def test_hero_odds_summary_formatted_string(monkeypatch) -> None:
         pot=Decimal(15),
         board={"FLOP": ["2c", "3d", "4h"]},
         render_board={"FLOP"},
-    )
+    ))
 
     monkeypatch.setattr("fpdb_3_legacy.GuiReplayer.calculate_equity", lambda *args, **kwargs: SimpleNamespace(
         players=[SimpleNamespace(equity=Decimal("0.60")), SimpleNamespace(equity=Decimal("0.40"))]
@@ -89,9 +89,9 @@ def test_hero_decision_metrics_supports_stud_and_draw() -> None:
     replayer.currency_code = "USD"
     # Stud/Draw gametypes: studhi, 7stud8, razz, 27_3draw, badugi
     hand = SimpleNamespace(gametype={"category": "studhi", "base": "stud"})
-    replayer.replay_model = SimpleNamespace(hand=hand)
+    replayer.replay_model = cast(Any, SimpleNamespace(hand=hand))
 
-    frame = SimpleNamespace(
+    frame = cast(Any, SimpleNamespace(
         players=[
             ReplayPlayer("Hero", 1, Decimal(0), Decimal(20), "calls", False, ["As", "Kd", "Qc", "Jh", "Ts"]),
             ReplayPlayer("Villain", 2, Decimal(0), Decimal(40), "bets", False, ["2s", "3d", "4c", "5h", "7s"]),
@@ -99,7 +99,7 @@ def test_hero_decision_metrics_supports_stud_and_draw() -> None:
         pot=Decimal(60),
         board={},
         render_board=set(),
-    )
+    ))
 
     metrics = replayer._hero_decision_metrics(frame, 0)
 


### PR DESCRIPTION
## Description
Adds Push Equity, Call Equity, and Pot Odds ratios to the Hand Replayer decision summary overlay.

### Key Additions
1. **Pot Odds with Ratios**:
   - Calculates pot odds percentage and ratio (e.g. `Pot Odds: 28.6% (2.5:1) [Call $5.00]`).
2. **Call Equity & Edge**:
   - Computes Hero's Call Equity percentage and Edge points (`Call Eq: 42.1% · Edge: +13.5 pts`) with color indicator (green for +EV call, red for -EV call).
3. **Push / All-in Equity**:
   - Computes Hero's Push Equity when all-in / shoving (`Push Eq: 48.3%` / `Push/All-in Eq: 48.3%`).
4. **Enhanced UI Card**:
   - Dynamically expands `_draw_summary` to render a 3-line decision box.
