### PR TITLE
chore(release): prepare 3.6.0

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.5.0"
+version = "3.6.0"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.5.0"
+version = "3.6.0"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prépare la release **3.6.0**. Version bump uniquement — aucun changement de comportement supplémentaire.

## Pourquoi 3.6.0

Cette livraison ajoute plusieurs fonctionnalités depuis v3.5.0 :

- équité de push/call et pot odds dans le replayer (#209) ;
- détection Winamax Expresso/Nitro corrigée (#210) ;
- notes HUD lisibles et complètes (#211) ;
- moteur HUD Fast-Fold temps réel (#212) ;
- support Winamax Escape, Splash/Drop Pot et lecture du journal client (#213).

Il s'agit donc d'une version mineure SemVer.

## Bump

- `pyproject.toml` → `[project].version`
- `pyproject.toml` → `[tool.briefcase].version`
- `fpdb_3_legacy/__init__.py` → `__version__`
- `uv.lock`

## Vérifications locales

- `uv lock --check`
- `test/test_fpdb_version_resolution.py` — 6 tests réussis
- `ruff check fpdb_3_legacy fpdb test tests tools` — propre
- `uv build --wheel` → `fpdb_3-3.6.0-py3-none-any.whl`

## Après fusion

1. Avancer `main` sur le commit de release.
2. Créer le tag annoté `v3.6.0`.
3. Publier la GitHub Release.
4. Attendre le workflow `release: published` et vérifier les six archives.