### PR TITLE
feat(tools): produce screenshots that carry no real player names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ tests/fixtures/expected/
 
 # Personal capture files (contain user-specific data)
 CoinPoker_*_Cash.txt
+
+# Reproducible wiki screenshot output
+/wiki-images/

--- a/tools/anonymize_screenshot.py
+++ b/tools/anonymize_screenshot.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Redact player names and other identifying regions from a screenshot.
+
+Screenshots of the HUD are only useful over a *real* table window, and a real
+table window carries other people's screen names. This paints chosen rectangles
+out of an image before it is published to the wiki, and strips the metadata the
+capture tool wrote into the file.
+
+    python tools/anonymize_screenshot.py table.png -o table-wiki.png \
+        --box 120,340,180,22 --box 410,190,180,22
+
+Coordinates are ``x,y,width,height`` in pixels from the top-left. Pass
+``--relative`` to give them as fractions of the image instead (``0.1,0.3,0.2,
+0.04``), which survives rescaling the source capture.
+
+Why no blur
+-----------
+Gaussian blur is a linear, low-pass filter: it attenuates detail rather than
+discarding it, and text is the easiest case to bring back -- a short screen name
+drawn from a small alphabet in a known font can be recovered by deconvolution or
+simply by re-rendering candidates until one blurs to the same pixels. The same
+argument applies to fine-grained pixelation, which is just box-filter blur with
+a coarse grid: if a glyph spans several blocks, the block averages still encode
+which glyph it was.
+
+So this tool offers two modes and neither is a blur:
+
+``fill`` (default)
+    Paint the region a solid colour. Nothing survives, and that is the point.
+
+``pixelate``
+    Reduce the region to a handful of blocks. Kept for when a flat rectangle
+    would hide the layout being illustrated. ``--block`` is a *minimum*: the
+    block size is enlarged as needed so that no region is ever reduced to more
+    than :data:`MAX_BLOCKS_PER_AXIS` blocks on either axis, because that is the
+    grid coarseness at which per-block averages stop carrying the glyph.
+
+Both modes rewrite the pixels, so the redaction survives being cropped,
+re-encoded, or screenshotted again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - depends on the environment
+    print("Pillow is required: pip install pillow (it also ships with matplotlib)", file=sys.stderr)
+    raise SystemExit(1) from None
+
+MAX_BLOCKS_PER_AXIS = 4
+"""Coarsest grid a pixelated region may keep, per axis.
+
+Four blocks across a name plate leaves the eye a smear and leaves an attacker
+sixteen averages for a string of several characters -- far less information than
+the string contains.
+"""
+
+DEFAULT_FILL = "#101418"
+"""A dark neutral, so redactions read as part of a poker client rather than as
+white holes punched in the picture."""
+
+
+@dataclass(frozen=True)
+class Box:
+    """A rectangle to redact, in absolute pixels."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def bounds(self) -> tuple[int, int, int, int]:
+        """``(left, upper, right, lower)`` as Pillow wants it."""
+        return (self.x, self.y, self.x + self.width, self.y + self.height)
+
+    def clamped(self, image_width: int, image_height: int) -> Box | None:
+        """This box cropped to the image, or None when it falls entirely outside."""
+        left = max(0, min(self.x, image_width))
+        upper = max(0, min(self.y, image_height))
+        right = max(0, min(self.x + self.width, image_width))
+        lower = max(0, min(self.y + self.height, image_height))
+        if right <= left or lower <= upper:
+            return None
+        return Box(left, upper, right - left, lower - upper)
+
+
+def parse_box(spec: str, *, relative: bool, size: tuple[int, int]) -> Box:
+    """Turn an ``x,y,w,h`` argument into a :class:`Box`.
+
+    With ``relative``, the four numbers are fractions of the image's width and
+    height rather than pixels.
+    """
+    parts = spec.split(",")
+    if len(parts) != 4:
+        msg = f"expected x,y,width,height -- got {spec!r}"
+        raise argparse.ArgumentTypeError(msg)
+    try:
+        numbers = [float(part) for part in parts]
+    except ValueError:
+        msg = f"box coordinates must be numbers -- got {spec!r}"
+        raise argparse.ArgumentTypeError(msg) from None
+
+    if relative:
+        width, height = size
+        scales = (width, height, width, height)
+        numbers = [value * scale for value, scale in zip(numbers, scales, strict=True)]
+
+    x, y, w, h = (int(round(value)) for value in numbers)
+    if w <= 0 or h <= 0:
+        msg = f"box width and height must be positive -- got {spec!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return Box(x, y, w, h)
+
+
+def block_size_for(box: Box, requested: int) -> int:
+    """The block size to pixelate ``box`` with, never finer than the cap.
+
+    ``requested`` is a floor, not a setting: a caller asking for 8-pixel blocks
+    on a 400-pixel-wide plate would leave fifty blocks across a name, which is a
+    thumbnail of the name rather than a redaction.
+    """
+    needed = max(box.width, box.height) / MAX_BLOCKS_PER_AXIS
+    return max(1, int(max(requested, needed)))
+
+
+def pixelate(image: Image.Image, box: Box, requested_block: int) -> None:
+    """Replace ``box`` in ``image`` with a coarse grid of block averages."""
+    block = block_size_for(box, requested_block)
+    region = image.crop(box.bounds)
+    columns = max(1, region.width // block)
+    rows = max(1, region.height // block)
+    # BOX on the way down averages each block; NEAREST on the way up keeps the
+    # blocks flat instead of interpolating detail back in.
+    small = region.resize((columns, rows), Image.Resampling.BOX)
+    image.paste(small.resize(region.size, Image.Resampling.NEAREST), box.bounds)
+
+
+def fill(image: Image.Image, box: Box, colour: str) -> None:
+    """Paint ``box`` in ``image`` a solid colour."""
+    image.paste(Image.new(image.mode, (box.width, box.height), colour), box.bounds)
+
+
+def redact(image: Image.Image, boxes: list[Box], *, mode: str, block: int, colour: str) -> int:
+    """Apply every box that intersects the image. Returns how many were applied."""
+    applied = 0
+    for box in boxes:
+        clamped = box.clamped(image.width, image.height)
+        if clamped is None:
+            print(f"warning: box {box.x},{box.y},{box.width},{box.height} is outside the image", file=sys.stderr)
+            continue
+        if mode == "pixelate":
+            pixelate(image, clamped, block)
+        else:
+            fill(image, clamped, colour)
+        applied += 1
+    return applied
+
+
+def save_without_metadata(image: Image.Image, path: Path) -> None:
+    """Write the image with no EXIF, ICC or PNG text chunks carried over.
+
+    Capture tools record the machine name, the window title and sometimes the
+    file path in there, none of which is visible in the picture that gets
+    reviewed before publishing.
+    """
+    clean = Image.new(image.mode, image.size)
+    clean.putdata(list(image.getdata()))
+    clean.save(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("source", type=Path, help="image to redact")
+    parser.add_argument("-o", "--output", type=Path, help="where to write (default: <source>-anon<ext>)")
+    parser.add_argument(
+        "--box",
+        action="append",
+        default=[],
+        metavar="X,Y,W,H",
+        help="rectangle to redact; repeat for each one",
+    )
+    parser.add_argument(
+        "--relative",
+        action="store_true",
+        help="read box coordinates as fractions of the image size rather than pixels",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("fill", "pixelate"),
+        default="fill",
+        help="fill paints a solid rectangle (default); pixelate keeps a coarse shape",
+    )
+    parser.add_argument(
+        "--block",
+        type=int,
+        default=16,
+        help="minimum pixelation block size; raised automatically when a region needs it",
+    )
+    parser.add_argument("--colour", "--color", dest="colour", default=DEFAULT_FILL, help="fill colour")
+    args = parser.parse_args(argv)
+
+    if not args.source.is_file():
+        print(f"no such image: {args.source}", file=sys.stderr)
+        return 1
+    if not args.box:
+        print("nothing to redact: pass at least one --box X,Y,W,H", file=sys.stderr)
+        return 1
+
+    with Image.open(args.source) as opened:
+        image = opened.convert("RGB")
+
+    try:
+        boxes = [parse_box(spec, relative=args.relative, size=image.size) for spec in args.box]
+    except argparse.ArgumentTypeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    applied = redact(image, boxes, mode=args.mode, block=args.block, colour=args.colour)
+    if not applied:
+        print("no box intersected the image; nothing written", file=sys.stderr)
+        return 1
+
+    destination = args.output or args.source.with_name(f"{args.source.stem}-anon{args.source.suffix}")
+    save_without_metadata(image, destination)
+    print(f"{applied} region(s) redacted with '{args.mode}' -> {destination}")
+    print("Check the result before publishing: this tool paints where it is told, it does not find names.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/capture_wiki_screenshots.py
+++ b/tools/capture_wiki_screenshots.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Render fpdb's screens to PNG for the wiki, from the demo database.
+
+Screenshots taken with a screen-capture tool carry whatever else was on the
+desktop and have to be retaken by hand every release. Qt can draw a widget into
+an image directly, so this builds each view against the demo database and grabs
+it -- no window manager, no desktop chrome, no cursor, and the same result every
+run.
+
+    python tools/make_demo_db.py                     # once
+    python tools/capture_wiki_screenshots.py         # then this
+
+Output lands in ``--out`` (default ``wiki-images/``), one PNG per view, ready to
+drop into the wiki's ``Images/`` directory.
+
+Every player in these images is invented -- see ``tools/make_demo_db.py`` -- so
+nothing here needs redacting. That is the whole point of going through the demo
+database rather than the user's own.
+
+Views that cannot be built headlessly are skipped with a reason rather than
+failing the run: the useful output is the set that did render.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import traceback
+from pathlib import Path
+from time import monotonic, sleep
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+os.chdir(REPO)
+
+# Qt must render somewhere. "offscreen" keeps windows off the user's display
+# while still producing real pixels for grab().
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+DEFAULT_CONFIG = Path.home() / "fpdb-demo" / "HUD_config.xml"
+DEFAULT_OUT = REPO / "wiki-images"
+SIZE = (1400, 820)
+
+
+def theme_colors() -> dict[str, str]:
+    """The colour set the graph views expect, matching the application default."""
+    return {
+        "background": "#1E222A",
+        "foreground": "#C8CDD4",
+        "grid": "#3A4049",
+        "line_showdown": "#4ADE80",
+        "line_nonshowdown": "#FF6B6B",
+        "line_ev": "#4CC9F0",
+        "line_hands": "#F2C14E",
+        "line_up": "#4ADE80",
+        "line_down": "#FF6B6B",
+    }
+
+
+def make_stub_window(config, sql):
+    """A stand-in main window for views that call back into their parent.
+
+    It has to be a real ``QWidget``: the views subclass ``QSplitter`` and hand
+    this straight to Qt as their parent.
+    """
+    from PySide6.QtWidgets import QMainWindow
+
+    class StubMainWindow(QMainWindow):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = config
+            self.sql = sql
+            self.threads: list = []
+
+        def get_theme_colors(self) -> dict[str, str]:
+            return theme_colors()
+
+        def add_and_display_tab(self, *_args, **_kwargs) -> None:
+            pass
+
+        def release_global_lock(self, *_args, **_kwargs) -> None:
+            pass
+
+    return StubMainWindow()
+
+
+def grab(widget, path: Path, size: tuple[int, int] = SIZE) -> None:
+    """Lay the widget out at ``size`` and write its pixels to ``path``."""
+    from PySide6.QtWidgets import QApplication
+
+    widget.resize(*size)
+    widget.show()
+    # Two passes: the first lets deferred layout and any queued model refresh
+    # run, the second lets whatever that produced be laid out in turn.
+    for _ in range(2):
+        QApplication.processEvents()
+    widget.grab().save(str(path))
+    widget.hide()
+
+
+def build_views(config, sql, window):  # noqa: C901 - each small branch is one independent screenshot factory
+    """``(filename, factory)`` for every view worth a picture.
+
+    Factories are lazy so one view failing to import or build does not take the
+    rest of the run with it.
+    """
+    from fpdb_3_legacy import (
+        Database,
+        GuiAutoNotesWorkbench,
+        GuiGraphViewer,
+        GuiHandViewer,
+        GuiOpponentsReport,
+        GuiReplayer,
+        GuiSessionViewer,
+        GuiStatsInfo,
+    )
+    from fpdb_3_legacy.modern_hud_preferences import ModernHudPreferences
+    from fpdb_3_legacy.ring_stats import GuiRingPlayerStats
+
+    def ring_player_stats():
+        view = GuiRingPlayerStats(config, sql, window)
+        view.refreshStats()
+        return view
+
+    def graph_viewer():
+        view = GuiGraphViewer.GuiGraphViewer(sql, config, window, colors=theme_colors())
+        view.generateGraph(None)
+        return view
+
+    def session_viewer():
+        view = GuiSessionViewer.GuiSessionViewer(config, sql, window, window, colors=theme_colors())
+        view.refreshStats(None)
+        return view
+
+    def opponents_report():
+        view = GuiOpponentsReport.GuiOpponentsReport(config, sql, window)
+        view.refreshStats()
+        return view
+
+    def hand_viewer():
+        view = GuiHandViewer.GuiHandViewer(config, sql, window)
+        view.loadHands(None)
+        return view
+
+    def hand_replayer():
+        database = Database.Database(config, sql=sql)
+        database.cursor.execute(
+            """
+            SELECT ha.handId
+            FROM HandsActions ha
+            JOIN Players p ON p.id = ha.playerId
+            WHERE p.name = ?
+            GROUP BY ha.handId
+            ORDER BY MAX(ha.amount) DESC
+            LIMIT 1
+            """,
+            ("Hero",),
+        )
+        row = database.cursor.fetchone()
+        if row is None:
+            raise RuntimeError("the demo database has no replayable hero hand")
+
+        view = GuiReplayer.GuiReplayer(config, sql, window, [int(row[0])], db=database)
+        view.play_hand(0)
+
+        # Stop on a hero decision facing a bet so the decision card contains
+        # useful pot-odds/equity information instead of merely showing the deal.
+        target = 0
+        for index, state in enumerate(view.states):
+            frame = view._frame_from_state(state)
+            hero = next((player for player in frame.players if player.name == view.Heroes), None)
+            max_chips = max((player.chips for player in frame.players if player.action != "folds"), default=0)
+            if view._next_actor_name(index) == view.Heroes and hero is not None and max_chips > hero.chips:
+                target = index
+                break
+        view.stateSlider.setValue(target)
+        view.update()
+        return view
+
+    def hud_preferences():
+        return ModernHudPreferences(config, window)
+
+    def auto_notes():
+        from PySide6.QtWidgets import QApplication
+
+        view = GuiAutoNotesWorkbench.GuiAutoNotesWorkbench(config, window)
+        view.db_limit_spin.setValue(200)
+        view.run_database_dry_run()
+        deadline = monotonic() + 30
+        while view.worker_thread is not None and view.worker_thread.isRunning() and monotonic() < deadline:
+            QApplication.processEvents()
+            sleep(0.01)
+        QApplication.processEvents()
+        return view
+
+    return [
+        ("ring-player-stats.png", ring_player_stats),
+        ("graphs.png", graph_viewer),
+        ("session-stats.png", session_viewer),
+        ("opponents-report.png", opponents_report),
+        ("hand-viewer.png", hand_viewer),
+        ("hand-replayer.png", hand_replayer),
+        ("hud-preferences.png", hud_preferences),
+        ("auto-notes-workbench.png", auto_notes),
+        ("stats-guide.png", lambda: GuiStatsInfo.GuiStatsInfo(config, window)),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="demo HUD_config.xml")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="where to write the PNGs")
+    parser.add_argument("--only", help="substring: capture only views whose filename contains it")
+    parser.add_argument("--theme", default="dark_purple.xml", help="qt_material theme used for every capture")
+    args = parser.parse_args(argv)
+
+    if not args.config.is_file():
+        print(f"no demo configuration at {args.config}", file=sys.stderr)
+        print("run tools/make_demo_db.py first", file=sys.stderr)
+        return 1
+
+    out_dir = args.out.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    from PySide6.QtWidgets import QApplication
+
+    from fpdb_3_legacy import SQL
+    from fpdb_3_legacy.Configuration import Config
+    from fpdb_3_legacy.ThemeManager import ThemeManager
+
+    app = QApplication.instance() or QApplication([])
+    if not ThemeManager().set_qt_material_theme(args.theme, save=False, apply_to_ui=True):
+        print(f"unable to apply theme {args.theme}", file=sys.stderr)
+        return 1
+    config = Config(file=str(args.config))
+    params = config.get_db_parameters()
+    sql = SQL.Sql(db_server=params["db-server"])
+    window = make_stub_window(config, sql)
+
+    captured, skipped = 0, 0
+    for filename, factory in build_views(config, sql, window):
+        if args.only and args.only not in filename:
+            continue
+        try:
+            grab(factory(), out_dir / filename)
+        except Exception as exc:  # noqa: BLE001 - a view that will not build is data, not a crash
+            print(f"  skipped {filename}: {type(exc).__name__}: {exc}")
+            if os.environ.get("CAPTURE_DEBUG"):
+                traceback.print_exc()
+            skipped += 1
+            continue
+        size = (out_dir / filename).stat().st_size
+        print(f"  {filename}  ({size // 1024} KB)")
+        captured += 1
+
+    print(f"\n{captured} captured, {skipped} skipped -> {out_dir}")
+    app.quit()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/make_demo_db.py
+++ b/tools/make_demo_db.py
@@ -493,6 +493,8 @@ def write_config(out_dir: Path) -> Path:
     A copy, never the original: the reader's own configuration and their own
     database have to come out of this untouched.
     """
+    from xml.etree.ElementTree import SubElement
+
     from defusedxml import ElementTree as DefusedElementTree
 
     source = REPO / "HUD_config.xml"
@@ -506,6 +508,28 @@ def write_config(out_dir: Path) -> Path:
         if database.get("db_server") == "sqlite":
             database.set("db_name", "demo.db3")
             database.set("db_path", str(out_dir))
+    for site in tree.getroot().iter("site"):
+        is_demo_site = site.get("site_name") == "PokerStars.COM"
+        site.set("enabled", "True" if is_demo_site else "False")
+        if is_demo_site:
+            site.set("screen_name", HERO)
+            site.set("HH_path", str(out_dir / "hands"))
+            site.set("TS_path", "")
+
+    # The source profile may leave the Hold'em rule sets disabled. Enable a
+    # representative set in the disposable copy so the Auto Notes screenshot
+    # demonstrates real matches instead of an empty workbench.
+    root = tree.getroot()
+    autonotes = next(iter(root.iter("autonotes")), None)
+    if autonotes is None:
+        autonotes = SubElement(root, "autonotes")
+    enabled_rule_sets = {"holdem_cash_preflop", "flop_texture", "showdown_quality", "hero_relative"}
+    ruleset_nodes = {node.get("name"): node for node in autonotes.iter("ruleset")}
+    for rule_set_name in enabled_rule_sets:
+        node = ruleset_nodes.get(rule_set_name)
+        if node is None:
+            node = SubElement(autonotes, "ruleset", name=rule_set_name)
+        node.set("enabled", "True")
     tree.write(destination, encoding="utf-8", xml_declaration=True)
     return destination
 

--- a/tools/make_demo_db.py
+++ b/tools/make_demo_db.py
@@ -389,30 +389,37 @@ class HandWriter:
         awarded = round(self.pot - rake, 2)
 
         shown: dict[str, tuple[int, ...]] = {}
+        awards: dict[str, float] = {}
         if showdown and len(self.live) > 1:
             lines.append("*** SHOW DOWN ***")
             for player in self.live:
                 shown[player.name] = hand_rank(player.cards + self.board)
-            winner = max(self.live, key=lambda player: shown[player.name])
+            best_rank = max(shown.values())
+            winners = [player for player in self.live if shown[player.name] == best_rank]
             for player in self.live:
                 cards = " ".join(player.cards)
                 lines.append(f"{player.name}: shows [{cards}] ({describe(player.cards + self.board)})")
         else:
-            winner = self.live[0]
-        lines.append(f"{winner.name} collected {money(awarded)} from pot")
+            winners = [self.live[0]]
+
+        share_cents, remainder = divmod(round(awarded * 100), len(winners))
+        for index, winner in enumerate(winners):
+            awards[winner.name] = (share_cents + (index < remainder)) / 100
+            lines.append(f"{winner.name} collected {money(awards[winner.name])} from pot")
 
         lines.append("*** SUMMARY ***")
         lines.append(f"Total pot {money(self.pot)} | Rake {money(rake)}")
         if self.board:
             lines.append(f"Board [{' '.join(self.board)}]")
-        lines.extend(self._summary_line(player, winner, awarded, shown) for player in self.players)
+        winner_names = {winner.name for winner in winners}
+        lines.extend(self._summary_line(player, winner_names, awards, shown) for player in self.players)
         return lines
 
     def _summary_line(
         self,
         player: Player,
-        winner: Player,
-        awarded: float,
+        winner_names: set[str],
+        awards: dict[str, float],
         shown: dict[str, tuple[int, ...]],
     ) -> str:
         prefix = f"Seat {player.seat}: {player.name}"
@@ -426,11 +433,11 @@ class HandWriter:
         if player.name in shown:
             cards = " ".join(player.cards)
             category = describe(player.cards + self.board)
-            if player is winner:
-                return f"{prefix} showed [{cards}] and won ({money(awarded)}) with {category}"
+            if player.name in winner_names:
+                return f"{prefix} showed [{cards}] and won ({money(awards[player.name])}) with {category}"
             return f"{prefix} showed [{cards}] and lost with {category}"
-        if player is winner:
-            return f"{prefix} collected ({money(awarded)})"
+        if player.name in winner_names:
+            return f"{prefix} collected ({money(awards[player.name])})"
         if player.folded:
             where = ("before Flop", "on the Flop", "on the Turn", "on the River")[player.last_street_seen]
             suffix = " (didn't bet)" if player.last_street_seen == 0 and player.committed == 0 else ""
@@ -450,6 +457,8 @@ def generate(out_dir: Path, hand_count: int, seed: int) -> Path:
     """Write the invented hand histories, one file per simulated session."""
     rng = random.Random(seed)
     hands_dir = out_dir / "hands"
+    if hands_dir.exists():
+        shutil.rmtree(hands_dir)
     hands_dir.mkdir(parents=True, exist_ok=True)
 
     sessions = max(1, -(-hand_count // HANDS_PER_FILE))
@@ -505,11 +514,13 @@ def write_config(out_dir: Path) -> Path:
 
     tree = DefusedElementTree.parse(destination)
     for database in tree.getroot().iter("database"):
+        database.set("default", "False")
         if database.get("db_server") == "sqlite":
             database.set("db_name", "demo.db3")
             database.set("db_path", str(out_dir))
+            database.set("default", "True")
     for site in tree.getroot().iter("site"):
-        is_demo_site = site.get("site_name") == "PokerStars.COM"
+        is_demo_site = site.get("site_name") in {"PokerStars", "PokerStars.COM"}
         site.set("enabled", "True" if is_demo_site else "False")
         if is_demo_site:
             site.set("screen_name", HERO)

--- a/tools/make_demo_db.py
+++ b/tools/make_demo_db.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Build a throwaway database of invented hands, safe to screenshot.
+
+Every screenshot published to the wiki shows a database, and a real database
+shows the people the user played against. Neither the golden fixtures nor the
+regression corpus solve that -- both carry genuine screen names -- so this
+invents the hands instead: a fixed roster of obviously fictional players, dealt
+by a seeded generator, imported into a database of its own.
+
+    python tools/make_demo_db.py                    # ~/fpdb-demo, 2000 hands
+    python tools/make_demo_db.py --hands 5000 --out /tmp/shots
+
+It leaves a directory holding the generated hand histories, a SQLite database
+with them imported, and a configuration file pointing at that database. Launch
+fpdb against it and every screen -- reports, graphs, replayer, HUD popups --
+can be captured with no redaction at all:
+
+    python fpdb_3_legacy/fpdb.pyw -c ~/fpdb-demo/HUD_config.xml
+
+The real ``HUD_config.xml`` is copied, never written to: the copy is what gets
+repointed at the demo database, so the reader's own setup is untouched.
+
+What the generated hands are, and are not
+-----------------------------------------
+No-limit Hold'em 6-max cash, one stake, players with fixed and distinct styles
+so the statistics separate the way they do in life -- a nit next to a maniac,
+not fifteen players all at 24/18. The pot arithmetic is exact and the showdowns
+are adjudicated by a real evaluator, so the imported statistics are internally
+consistent.
+
+Deliberately not modelled: all-ins and side pots (stacks are deep and bet sizes
+clamped well below them), tournaments, and any game but Hold'em. They add engine
+complexity the screenshots do not need. Wanting a screenshot of a tournament
+report is a reason to extend this, not to fall back on real hands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import shutil
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+RANKS = "23456789TJQKA"
+SUITS = "shdc"
+RANK_VALUE = {rank: index for index, rank in enumerate(RANKS, start=2)}
+
+SMALL_BLIND = 0.05
+BIG_BLIND = 0.10
+STARTING_STACK = 20.00
+"""200 big blinds, reset every hand. Deep enough that clamped bet sizes never
+reach a stack, which is what keeps side pots out of the generator."""
+
+RAKE_RATE = 0.05
+RAKE_CAP = 0.50
+
+MAX_SEATS = 6
+HERO = "Hero"
+HERO_STYLE = (0.25, 0.20, 0.60)
+ROSTER = (
+    # (name, vpip, pfr, postflop aggression) -- invented players with invented
+    # tendencies, spread out so a HUD screenshot shows contrast rather than
+    # fifteen shades of the same regular.
+    ("NitPickerNed", 0.13, 0.11, 0.35),
+    ("CallingStation", 0.58, 0.04, 0.10),
+    ("MonsieurRegular", 0.24, 0.19, 0.55),
+    ("LoosePassivePat", 0.46, 0.09, 0.20),
+    ("TripleBarrelTom", 0.29, 0.25, 0.80),
+    ("ManiacMarcel", 0.67, 0.44, 0.72),
+    ("SolidSam", 0.21, 0.17, 0.50),
+    ("FishyFrancis", 0.52, 0.07, 0.15),
+    ("SqueezeQueen", 0.26, 0.22, 0.66),
+    ("RockRoland", 0.15, 0.12, 0.40),
+    ("SplashySteve", 0.61, 0.31, 0.58),
+    ("GrindGaston", 0.23, 0.18, 0.52),
+)
+TABLE_NAMES = ("Wezen", "Alderamin", "Bellatrix", "Cursa", "Denebola", "Elnath")
+
+HAND_CATEGORIES = (
+    "high card",
+    "a pair",
+    "two pair",
+    "three of a kind",
+    "a straight",
+    "a flush",
+    "a full house",
+    "four of a kind",
+    "a straight flush",
+)
+
+
+# --------------------------------------------------------------------------
+# cards
+# --------------------------------------------------------------------------
+
+
+def new_deck(rng: random.Random) -> list[str]:
+    """A shuffled 52-card deck as ``Rs`` strings (``Ah``, ``Ts``...)."""
+    deck = [rank + suit for rank in RANKS for suit in SUITS]
+    rng.shuffle(deck)
+    return deck
+
+
+def _straight_high(values: list[int]) -> int | None:
+    """Highest card of a straight inside ``values``, or None. Handles the wheel."""
+    unique = sorted(set(values), reverse=True)
+    if 14 in unique:
+        unique.append(1)  # the ace plays low for A-5
+    run = 1
+    for index in range(1, len(unique)):
+        if unique[index] == unique[index - 1] - 1:
+            run += 1
+            if run >= 5:
+                return unique[index] + 4
+        else:
+            run = 1
+    return None
+
+
+def hand_rank(cards: list[str]) -> tuple[int, ...]:
+    """Rank a 5-to-7-card hand; bigger tuples beat smaller ones.
+
+    Returns ``(category, tiebreakers...)`` with category 8 for a straight flush
+    down to 0 for a high card, so plain tuple comparison decides a showdown.
+    """
+    values = sorted((RANK_VALUE[card[0]] for card in cards), reverse=True)
+    suit_counts = Counter(card[1] for card in cards)
+
+    flush_suit = next((suit for suit, count in suit_counts.items() if count >= 5), None)
+    if flush_suit is not None:
+        flush_values = sorted((RANK_VALUE[c[0]] for c in cards if c[1] == flush_suit), reverse=True)
+        straight_flush = _straight_high(flush_values)
+        if straight_flush is not None:
+            return (8, straight_flush)
+        return (5, *flush_values[:5])
+
+    straight = _straight_high(values)
+    if straight is not None:
+        return (4, straight)
+
+    # Ranks grouped by how many of them there are, biggest group first.
+    counts = Counter(values)
+    groups = sorted(counts.items(), key=lambda item: (item[1], item[0]), reverse=True)
+    shape = [count for _, count in groups]
+    ordered = [value for value, _ in groups]
+
+    if shape[0] == 4:
+        return (7, ordered[0], max(ordered[1:]))
+    if shape[0] == 3 and len(shape) > 1 and shape[1] >= 2:
+        return (6, ordered[0], ordered[1])
+    if shape[0] == 3:
+        return (3, ordered[0], *sorted(ordered[1:], reverse=True)[:2])
+    if shape[0] == 2 and len(shape) > 1 and shape[1] == 2:
+        return (2, *sorted(ordered[:2], reverse=True), max(ordered[2:]))
+    if shape[0] == 2:
+        return (1, ordered[0], *sorted(ordered[1:], reverse=True)[:3])
+    return (0, *values[:5])
+
+
+def describe(cards: list[str]) -> str:
+    """The English name the client writes after a shown hand."""
+    return HAND_CATEGORIES[hand_rank(cards)[0]]
+
+
+def money(amount: float) -> str:
+    """Format like the client does: ``$0.05``, ``$1.20``, ``$10``."""
+    rounded = round(amount + 1e-9, 2)
+    if abs(rounded - round(rounded)) < 0.005:
+        return f"${int(round(rounded))}"
+    return f"${rounded:.2f}"
+
+
+# --------------------------------------------------------------------------
+# the hand
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Player:
+    """One seat for the duration of one hand."""
+
+    name: str
+    seat: int
+    vpip: float
+    pfr: float
+    aggression: float
+    stack: float = STARTING_STACK
+    cards: list[str] = field(default_factory=list)
+    street_bet: float = 0.0
+    committed: float = 0.0
+    folded: bool = False
+    last_street_seen: int = 0
+    """0 preflop, 1 flop, 2 turn, 3 river -- what the summary line reports."""
+
+
+class HandWriter:
+    """Plays one hand out and renders it as a PokerStars hand history."""
+
+    def __init__(self, rng: random.Random, players: list[Player], button: int, table: str) -> None:
+        self.rng = rng
+        self.players = players
+        self.button = button  # index into self.players
+        self.table = table
+        self.lines: list[str] = []
+        self.board: list[str] = []
+        self.pot = 0.0
+
+    # -- betting ---------------------------------------------------------
+
+    @property
+    def live(self) -> list[Player]:
+        return [player for player in self.players if not player.folded]
+
+    def _order(self, *, preflop: bool) -> list[Player]:
+        """Players in acting order: UTG first preflop, small blind first after."""
+        offset = 3 if preflop else 1
+        start = (self.button + offset) % len(self.players)
+        return [self.players[(start + step) % len(self.players)] for step in range(len(self.players))]
+
+    def _commit(self, player: Player, target: float) -> float:
+        """Move ``player``'s street total up to ``target``. Returns what was added."""
+        added = round(target - player.street_bet, 2)
+        player.street_bet = round(target, 2)
+        player.stack = round(player.stack - added, 2)
+        player.committed = round(player.committed + added, 2)
+        self.pot = round(self.pot + added, 2)
+        return added
+
+    def _run_street(self, current_bet: float, *, preflop: bool) -> bool:
+        """Run one betting round. Returns True when more than one player is left.
+
+        ``pending`` holds the indices, into the acting order, of players who
+        still owe an action. A bet or raise refills it with everyone else still
+        in the hand, which is exactly the rule that reopens the action.
+        """
+        order = self._order(preflop=preflop)
+        size = len(order)
+        raises = 1 if preflop else 0
+        pending = [index for index in range(size) if not order[index].folded]
+
+        while pending and len(self.live) > 1:
+            index = pending.pop(0)
+            player = order[index]
+            if player.folded:
+                continue
+
+            to_call = round(current_bet - player.street_bet, 2)
+            action, target = self._decide(player, to_call, raises, preflop=preflop)
+
+            if action == "fold":
+                player.folded = True
+                self.lines.append(f"{player.name}: folds")
+            elif action == "check":
+                self.lines.append(f"{player.name}: checks")
+            elif action == "call":
+                added = self._commit(player, current_bet)
+                self.lines.append(f"{player.name}: calls {money(added)}")
+            else:
+                verb_is_bet = current_bet <= 0
+                increment = round(target - current_bet, 2)
+                self._commit(player, target)
+                if verb_is_bet:
+                    self.lines.append(f"{player.name}: bets {money(target)}")
+                else:
+                    self.lines.append(f"{player.name}: raises {money(increment)} to {money(target)}")
+                current_bet = target
+                raises += 1
+                pending = [(index + step) % size for step in range(1, size) if not order[(index + step) % size].folded]
+
+        self._return_uncalled()
+        for player in self.players:
+            player.street_bet = 0.0
+        return len(self.live) > 1
+
+    def _return_uncalled(self) -> None:
+        """Hand back the part of the last bet nobody matched."""
+        bets = sorted((player.street_bet for player in self.players), reverse=True)
+        if len(bets) < 2 or bets[0] <= bets[1]:
+            return
+        excess = round(bets[0] - bets[1], 2)
+        top = max(self.players, key=lambda player: player.street_bet)
+        top.stack = round(top.stack + excess, 2)
+        top.committed = round(top.committed - excess, 2)
+        top.street_bet = round(top.street_bet - excess, 2)
+        self.pot = round(self.pot - excess, 2)
+        self.lines.append(f"Uncalled bet ({money(excess)}) returned to {top.name}")
+
+    def _decide(self, player: Player, to_call: float, raises: int, *, preflop: bool) -> tuple[str, float]:
+        """Pick an action from the player's style and the price of continuing."""
+        roll = self.rng.random()
+        if preflop:
+            return self._decide_preflop(player, to_call, raises, roll)
+        return self._decide_postflop(player, to_call, raises, roll)
+
+    def _decide_preflop(self, player: Player, to_call: float, raises: int, roll: float) -> tuple[str, float]:
+        """Open, three-bet, call or fold, on the player's VPIP and PFR."""
+        if roll > player.vpip:
+            return ("fold", 0.0) if to_call > 0 else ("check", 0.0)
+        if roll < player.pfr and raises < 3:
+            factor = 3.0 if raises == 1 else 2.6
+            current_bet = player.street_bet + to_call
+            target = self._legal_raise(player, current_bet * factor, current_bet)
+            if target is not None:
+                return "raise", target
+        return ("call", 0.0) if to_call > 0 else ("check", 0.0)
+
+    def _decide_postflop(self, player: Player, to_call: float, raises: int, roll: float) -> tuple[str, float]:
+        """Bet, raise, call or fold, on the player's aggression."""
+        if to_call <= 0:
+            if roll < player.aggression * 0.55 and raises < 2:
+                target = self._legal_raise(player, max(self.pot * 0.6, BIG_BLIND), 0.0)
+                if target is not None:
+                    return "raise", target
+            return "check", 0.0
+
+        current_bet = player.street_bet + to_call
+        if roll < player.aggression * 0.18 and raises < 3:
+            target = self._legal_raise(player, current_bet * 2.8, current_bet)
+            if target is not None:
+                return "raise", target
+        if roll < player.vpip * 0.8 + player.aggression * 0.2:
+            return "call", 0.0
+        return "fold", 0.0
+
+    def _legal_raise(self, player: Player, wanted: float, current_bet: float) -> float | None:
+        """``wanted`` clamped to a raise the player can make, or None if they can't.
+
+        The ceiling keeps every bet well short of the stack: the generator does
+        not model all-ins, so it must never produce one.
+        """
+        ceiling = round((player.stack + player.street_bet) * 0.4, 2)
+        target = round(min(wanted, ceiling), 2)
+        floor = round(current_bet + BIG_BLIND, 2)
+        return target if target >= floor else None
+
+    # -- rendering -------------------------------------------------------
+
+    def play(self, deck: list[str], hand_id: int, played_at: datetime) -> str:
+        """Deal, bet, award, and return the finished hand history text."""
+        self.lines.append(
+            f"PokerStars Hand #{hand_id}: Hold'em No Limit "
+            f"({money(SMALL_BLIND)}/{money(BIG_BLIND)} USD) - {played_at:%Y/%m/%d %H:%M:%S} CET "
+            f"[{played_at:%Y/%m/%d %H:%M:%S} ET]",
+        )
+        self.lines.append(f"Table '{self.table}' {MAX_SEATS}-max Seat #{self.players[self.button].seat} is the button")
+        for player in self.players:
+            self.lines.append(f"Seat {player.seat}: {player.name} ({money(player.stack)} in chips)")
+
+        small = self.players[(self.button + 1) % len(self.players)]
+        big = self.players[(self.button + 2) % len(self.players)]
+        self._commit(small, SMALL_BLIND)
+        self.lines.append(f"{small.name}: posts small blind {money(SMALL_BLIND)}")
+        self._commit(big, BIG_BLIND)
+        self.lines.append(f"{big.name}: posts big blind {money(BIG_BLIND)}")
+
+        for player in self.players:
+            player.cards = [deck.pop(), deck.pop()]
+        hero = next(player for player in self.players if player.name == HERO)
+        self.lines.append("*** HOLE CARDS ***")
+        self.lines.append(f"Dealt to {hero.name} [{hero.cards[0]} {hero.cards[1]}]")
+
+        alive = self._run_street(BIG_BLIND, preflop=True)
+        streets = (("FLOP", 3), ("TURN", 1), ("RIVER", 1))
+        for street_index, (label, count) in enumerate(streets, start=1):
+            if not alive:
+                break
+            self.board.extend(deck.pop() for _ in range(count))
+            for player in self.live:
+                player.last_street_seen = street_index
+            if label == "FLOP":
+                self.lines.append(f"*** FLOP *** [{' '.join(self.board)}]")
+            else:
+                self.lines.append(f"*** {label} *** [{' '.join(self.board[:-1])}] [{self.board[-1]}]")
+            alive = self._run_street(0.0, preflop=False)
+
+        return "\n".join(self.lines + self._conclude(showdown=alive)) + "\n"
+
+    def _conclude(self, *, showdown: bool) -> list[str]:
+        """Showdown or fold-out, then the summary block. No flop, no drop."""
+        lines: list[str] = []
+        rake = min(round(self.pot * RAKE_RATE, 2), RAKE_CAP) if self.board else 0.0
+        awarded = round(self.pot - rake, 2)
+
+        shown: dict[str, tuple[int, ...]] = {}
+        if showdown and len(self.live) > 1:
+            lines.append("*** SHOW DOWN ***")
+            for player in self.live:
+                shown[player.name] = hand_rank(player.cards + self.board)
+            winner = max(self.live, key=lambda player: shown[player.name])
+            for player in self.live:
+                cards = " ".join(player.cards)
+                lines.append(f"{player.name}: shows [{cards}] ({describe(player.cards + self.board)})")
+        else:
+            winner = self.live[0]
+        lines.append(f"{winner.name} collected {money(awarded)} from pot")
+
+        lines.append("*** SUMMARY ***")
+        lines.append(f"Total pot {money(self.pot)} | Rake {money(rake)}")
+        if self.board:
+            lines.append(f"Board [{' '.join(self.board)}]")
+        lines.extend(self._summary_line(player, winner, awarded, shown) for player in self.players)
+        return lines
+
+    def _summary_line(
+        self,
+        player: Player,
+        winner: Player,
+        awarded: float,
+        shown: dict[str, tuple[int, ...]],
+    ) -> str:
+        prefix = f"Seat {player.seat}: {player.name}"
+        if player is self.players[self.button]:
+            prefix += " (button)"
+        elif player is self.players[(self.button + 1) % len(self.players)]:
+            prefix += " (small blind)"
+        elif player is self.players[(self.button + 2) % len(self.players)]:
+            prefix += " (big blind)"
+
+        if player.name in shown:
+            cards = " ".join(player.cards)
+            category = describe(player.cards + self.board)
+            if player is winner:
+                return f"{prefix} showed [{cards}] and won ({money(awarded)}) with {category}"
+            return f"{prefix} showed [{cards}] and lost with {category}"
+        if player is winner:
+            return f"{prefix} collected ({money(awarded)})"
+        if player.folded:
+            where = ("before Flop", "on the Flop", "on the Turn", "on the River")[player.last_street_seen]
+            suffix = " (didn't bet)" if player.last_street_seen == 0 and player.committed == 0 else ""
+            return f"{prefix} folded {where}{suffix}"
+        return f"{prefix} mucked [{' '.join(player.cards)}]"
+
+
+# --------------------------------------------------------------------------
+# building the demo
+# --------------------------------------------------------------------------
+
+HANDS_PER_FILE = 120
+SPAN_DAYS = 120
+
+
+def generate(out_dir: Path, hand_count: int, seed: int) -> Path:
+    """Write the invented hand histories, one file per simulated session."""
+    rng = random.Random(seed)
+    hands_dir = out_dir / "hands"
+    hands_dir.mkdir(parents=True, exist_ok=True)
+
+    sessions = max(1, -(-hand_count // HANDS_PER_FILE))
+    first_day = datetime.now() - timedelta(days=SPAN_DAYS)
+    hand_id = 240_000_000_000
+    written = 0
+
+    for session in range(sessions):
+        # Sessions spread evenly across the span, so the graphs have a shape and
+        # the date filters have something to filter.
+        start = first_day + timedelta(
+            days=session * SPAN_DAYS / sessions,
+            hours=rng.randint(17, 22),
+            minutes=rng.randint(0, 59),
+        )
+        table = rng.choice(TABLE_NAMES)
+        opponents = rng.sample(ROSTER, MAX_SEATS - 1)
+        button = rng.randrange(MAX_SEATS)
+        chunk: list[str] = []
+
+        for offset in range(min(HANDS_PER_FILE, hand_count - written)):
+            hand_id += 1
+            seats = [Player(HERO, 1, *HERO_STYLE)]
+            seats += [
+                Player(name, index + 2, vpip, pfr, aggression)
+                for index, (name, vpip, pfr, aggression) in enumerate(opponents)
+            ]
+            writer = HandWriter(rng, seats, (button + offset) % MAX_SEATS, table)
+            chunk.append(writer.play(new_deck(rng), hand_id, start + timedelta(minutes=offset)))
+            written += 1
+
+        filename = f"HH{start:%Y%m%d}-{session:03d} {table} NLHE 6max.txt"
+        (hands_dir / filename).write_text("\n".join(chunk), encoding="utf-8")
+
+    return hands_dir
+
+
+def write_config(out_dir: Path) -> Path:
+    """Copy the real HUD_config.xml and repoint its SQLite database at the demo.
+
+    A copy, never the original: the reader's own configuration and their own
+    database have to come out of this untouched.
+    """
+    from defusedxml import ElementTree as DefusedElementTree
+
+    source = REPO / "HUD_config.xml"
+    if not source.is_file():
+        source = REPO / "HUD_config.xml.example"
+    destination = out_dir / "HUD_config.xml"
+    shutil.copy(source, destination)
+
+    tree = DefusedElementTree.parse(destination)
+    for database in tree.getroot().iter("database"):
+        if database.get("db_server") == "sqlite":
+            database.set("db_name", "demo.db3")
+            database.set("db_path", str(out_dir))
+    tree.write(destination, encoding="utf-8", xml_declaration=True)
+    return destination
+
+
+def import_hands(config_path: Path, hands_dir: Path) -> int:
+    """Create the demo database and bulk-import the generated hands into it."""
+    from fpdb_3_legacy.Configuration import Config
+    from fpdb_3_legacy.Database import Database
+    from fpdb_3_legacy.Importer import Importer
+
+    config = Config(file=str(config_path))
+    database = Database(config)
+    database.recreate_tables()
+
+    importer = Importer(None, {"threads": 1}, config, sql=database.sql)
+    importer.database = database
+    importer.setCallHud(False)
+    importer.setMode("bulk")
+    importer.addBulkImportImportFileOrDir(str(hands_dir), site="PokerStars")
+    importer.runImport()
+    database.connection.commit()
+
+    cursor = database.connection.cursor()
+    cursor.execute("SELECT COUNT(*) FROM Hands")
+    total = cursor.fetchone()[0]
+    database.disconnect()
+    del importer  # its __del__ disconnects importer.database, which is `database`
+    return total
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--hands", type=int, default=2000, help="how many hands to invent")
+    parser.add_argument("--out", type=Path, default=Path.home() / "fpdb-demo", help="where to build the demo")
+    parser.add_argument("--seed", type=int, default=20260808, help="generator seed; same seed, same hands")
+    parser.add_argument("--generate-only", action="store_true", help="write hand histories without importing them")
+    args = parser.parse_args(argv)
+
+    out_dir = args.out.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"inventing {args.hands} hands in {out_dir / 'hands'} ...")
+    hands_dir = generate(out_dir, args.hands, args.seed)
+    if args.generate_only:
+        print("done (not imported)")
+        return 0
+
+    config_path = write_config(out_dir)
+    print(f"importing into {out_dir / 'demo.db3'} ...")
+    total = import_hands(config_path, hands_dir)
+    print(f"\n{total} hands in the demo database.\n")
+    print("Launch fpdb against it -- nothing on screen will need redacting:")
+    print(f"    python fpdb_3_legacy/fpdb.pyw -c {config_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

A screenshot of fpdb shows a database, and a database shows the people the user played against. Publishing one to the wiki publishes their screen names.

Neither existing corpus solves this. `tests/fixtures/` and `regression-test-files/` both carry genuine screen names (`betsenvrac`, `1betUwill`, `39Harley`…) mixed in with the anonymised hands — they are test data, not demo data.

This came out of documenting release 3.6.0 in the wiki, where the [Screenshots and privacy](https://github.com/jejellyroll-fr/fpdb-3/wiki/Screenshots-and-privacy) page documents both tools.

## `tools/make_demo_db.py`

Invents the hands instead of borrowing them: a fixed roster of obviously fictional players, dealt by a seeded generator into a database of its own, with its own configuration. The real `HUD_config.xml` is **copied** and the copy repointed, so the user's setup is untouched.

```bash
python tools/make_demo_db.py
python fpdb_3_legacy/fpdb.pyw -c ~/fpdb-demo/HUD_config.xml
```

Everything on screen from that point on is invented, so any fpdb window can be captured with no redaction.

- Players have **distinct fixed styles**, so the statistics separate the way they do in life rather than clustering.
- **Pot arithmetic is exact** and showdowns are adjudicated by a real 7-card evaluator, so what a screenshot shows is internally consistent.
- Sessions spread over four months, so graphs and date filters have something to work with.
- **All-ins and side pots are deliberately not modelled** (stacks are deep, bet sizes clamped well below them), which is what keeps the engine to one file. Same for tournaments and non-Hold'em games — wanting a screenshot of a tournament report is a reason to extend this, not to fall back on real hands.

## `tools/capture_wiki_screenshots.py`

Renders nine real fpdb views directly through Qt, using the disposable demo database and fpdb's dark theme. Reports are refreshed before capture, the replayer stops on a hero decision, and Auto Notes runs a dry preview so every published image contains useful invented data.

```bash
python tools/make_demo_db.py --hands 4000
python tools/capture_wiki_screenshots.py
```

The generated PNGs land in `wiki-images/` (gitignored) and are ready to copy into the wiki's `Images/` directory.

## `tools/anonymize_screenshot.py`

Covers the case the demo database cannot: the HUD over a **real** table window, where the poker client draws the names.

```bash
python tools/anonymize_screenshot.py table.png -o table-wiki.png \
    --box 120,340,180,22 --box 410,190,180,22
```

**It deliberately offers no blur.** A Gaussian is a linear low-pass filter — it attenuates detail rather than discarding it, and a short screen name from a small alphabet in a known font is the easiest thing there is to recover by deconvolution. Fine-grained pixelation is the same argument with a box filter. So: `fill` (solid, default) or `pixelate` capped at four blocks per axis, meaning a requested `--block` can only ever be raised, never lowered.

It also strips EXIF, ICC and PNG text chunks, which carry the machine name and window title that were never visible in the picture that got reviewed.

## Verification

- 4,000 generated hands imported through the real `Importer` with **zero failures**.
- The full dark-theme screenshot run captured **9/9** populated views, including 4,000-hand reports and 168 Auto Notes from a 200-hand dry run.
- Derived stats separate as designed — `NitPickerNed` 10.6/8.8, `ManiacMarcel` 66.7/40.4, `CallingStation` 52.5/1.7 at 25% WTSD.
- Redaction tool exercised in both modes; the anti-fine-grid clamp fires as intended.
- `ruff check` and `ruff format --check` clean on all three tools.

## Notes for review

- The three tools are not imported by the application; they are standalone scripts under `tools/`, like the other maintenance scripts there.
- Pillow is not a declared dependency but ships transitively with matplotlib; the redaction tool fails with a clear message if it is absent.