### PR TITLE
fix frozen Auto Import and Fast HUD startup

### DIFF
--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -91,6 +91,7 @@ class MacOSTableDetector:
 
         # Emit the privacy-permission diagnosis at most once per process.
         self._permissions_checked = False
+        self._permission_status: permissions.PermissionStatus | None = None
         self._automation_warned = False
 
         # Lazy-import macOS dependencies
@@ -118,17 +119,18 @@ class MacOSTableDetector:
         """Get the current platform"""
         return self._platform
 
-    def _check_permissions_once(self) -> None:
+    def _check_permissions_once(self) -> permissions.PermissionStatus:
         """Log the privacy-permission diagnosis once when titles are missing.
 
         Set ``FPDB_REQUEST_MACOS_PERMISSIONS=1`` to also trigger the native
         prompts / open the relevant System Settings panes automatically.
         """
         if self._permissions_checked:
-            return
+            return self._permission_status or permissions.get_status()
         self._permissions_checked = True
 
         status = permissions.get_status()
+        self._permission_status = status
         messages = permissions.describe_missing(status)
         if not messages:
             # Titles missing despite permissions looking granted (e.g. an
@@ -136,7 +138,7 @@ class MacOSTableDetector:
             logger.debug(
                 "Quartz exposed no window titles but permissions look granted; relying on the AppleScript fallback.",
             )
-            return
+            return status
 
         for message in messages:
             logger.warning(message)
@@ -150,6 +152,7 @@ class MacOSTableDetector:
                 logger.info("Requesting Accessibility permission (native prompt)...")
                 permissions.request_accessibility_permission(prompt=True)
                 permissions.open_accessibility_settings()
+        return status
 
     def find_tables(self, search_string: str = "") -> list[TableInfo]:
         """Find all windows matching the search string
@@ -284,13 +287,18 @@ class MacOSTableDetector:
                 )
                 return [pid_match]
 
-        if total_windows > 0 and titled_windows == 0:
-            # No Quartz title for any window almost always means Screen Recording
-            # is off. Emit the precise, actionable diagnosis once.
-            self._check_permissions_once()
-        else:
+        permission_status = self._check_permissions_once()
+        if not (total_windows > 0 and titled_windows == 0):
             logger.debug("DIAGNOSTIC: No Quartz window matched the search string. Trying AppleScript fallback...")
-        applescript_tables = self.find_tables_applescript(search_string)
+        # System Events takes around two seconds to reject an untrusted app.
+        # Fast-Fold can hit this path several times for one newly imported hand,
+        # so do not make a synchronous call that the native permission check has
+        # already told us cannot succeed.
+        applescript_tables = []
+        if permission_status.accessibility:
+            applescript_tables = self.find_tables_applescript(search_string)
+        else:
+            logger.debug("Skipping AppleScript table scan because Accessibility permission is unavailable")
         if applescript_tables:
             logger.debug(f"DIAGNOSTIC: AppleScript fallback found {len(applescript_tables)} matching tables")
             return applescript_tables

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -82,15 +82,11 @@ from fpdb_3_legacy import (
     GuiBulkImport,
     GuiCoinPokerCapture,
     GuiDatabase,
-    GuiGraphViewer,
     GuiHandViewer,
     GuiLogView,
     GuiOpponentsReport,
     GuiPrefs,
-    GuiRingPlayerStats,
-    GuiSessionViewer,
     GuiTourHandViewer,
-    GuiTourneyGraphViewer,
     GuiTourneyPlayerStats,
     ModernHudPreferences,
     Options,
@@ -156,6 +152,7 @@ if options.log_level != "EMPTY":
 log = get_logger("fpdb")
 # Note: Logger level is now controlled by Logger Dev Tool configuration
 # The get_logger() function automatically applies the correct level from saved configuration
+
 
 def _resolve_version() -> str:
     """Return the version to display, preferring what the checkout can tell us.
@@ -345,7 +342,10 @@ class fpdb(QMainWindow):
         from PySide6.QtWidgets import QFileDialog, QMessageBox
 
         path, _filter = QFileDialog.getOpenFileName(
-            self, "Import PT4 HUD layout", "", "PT4 HUD layout (*.pt4hud);;All files (*)",
+            self,
+            "Import PT4 HUD layout",
+            "",
+            "PT4 HUD layout (*.pt4hud);;All files (*)",
         )
         if not path:
             return
@@ -366,8 +366,10 @@ class fpdb(QMainWindow):
             f"• {summary['stats']} stats mapped to a new HUD stat-set.",
         ]
         if summary["charts"]:
-            lines.append(f"• {len(summary['charts'])} range chart(s) ({', '.join(summary['charts'])}) "
-                         f"→ popup '{summary['popup']}'.")
+            lines.append(
+                f"• {len(summary['charts'])} range chart(s) ({', '.join(summary['charts'])}) "
+                f"→ popup '{summary['popup']}'."
+            )
         if summary["unmapped"]:
             lines.append(f"• {len(summary['unmapped'])} custom formula stat(s) could not be mapped.")
         lines.append("\nAssign the new stat-set / popup to a game in HUD Preferences.")
@@ -385,7 +387,10 @@ class fpdb(QMainWindow):
         from PySide6.QtWidgets import QFileDialog, QMessageBox
 
         paths, _filter = QFileDialog.getOpenFileNames(
-            self, "Import PT4 stats", "", "PT4 stat (*.pt4stat);;All files (*)",
+            self,
+            "Import PT4 stats",
+            "",
+            "PT4 stat (*.pt4stat);;All files (*)",
         )
         if not paths:
             return
@@ -621,9 +626,31 @@ class fpdb(QMainWindow):
 
         GROUPS = {
             "Hold'em": ["holdem", "2_holdem", "6_holdem"],
-            "Omaha": ["omahahi", "omahahilo", "5_omahahi", "6_omahahi", "5_omaha8", "6_omaha8", "cour_hi", "cour_hilo", "aof_omaha", "fusion", "irish"],
+            "Omaha": [
+                "omahahi",
+                "omahahilo",
+                "5_omahahi",
+                "6_omahahi",
+                "5_omaha8",
+                "6_omaha8",
+                "cour_hi",
+                "cour_hilo",
+                "aof_omaha",
+                "fusion",
+                "irish",
+            ],
             "Stud": ["5_studhi", "razz", "studhi", "studhilo", "27_razz"],
-            "Draw && Others": ["27_3draw", "fivedraw", "badugi", "27_1draw", "a5_3draw", "a5_1draw", "badacey", "badeucey", "drawmaha"]
+            "Draw && Others": [
+                "27_3draw",
+                "fivedraw",
+                "badugi",
+                "27_1draw",
+                "a5_3draw",
+                "a5_1draw",
+                "badacey",
+                "badeucey",
+                "drawmaha",
+            ],
         }
 
         # Dynamically append any other games found in Card.games to prevent missed game types
@@ -635,6 +662,7 @@ class fpdb(QMainWindow):
             GROUPS["Other"] = other_games
 
         from fpdb_3_legacy.ThemeManager import ThemeManager
+
         palette = ThemeManager().get_legacy_palette()
         border_color = palette.get("border", "#483d65")
 
@@ -1090,7 +1118,7 @@ class fpdb(QMainWindow):
                 sys.exit()
         else:
             self.warning_box(
-                "The updated preferences have not been loaded because windows are open. " "Restart fpdb to load them.",
+                "The updated preferences have not been loaded because windows are open. Restart fpdb to load them.",
             )
 
     def process_close_messages(self) -> None:
@@ -1170,9 +1198,18 @@ class fpdb(QMainWindow):
             themes = ThemeManager().get_available_qt_themes()
         except ImportError:
             themes = [
-                "dark_purple.xml", "dark_teal.xml", "dark_blue.xml", "dark_cyan.xml",
-                "dark_pink.xml", "dark_red.xml", "light_purple.xml", "light_teal.xml",
-                "light_blue.xml", "light_cyan.xml", "light_pink.xml", "light_red.xml",
+                "dark_purple.xml",
+                "dark_teal.xml",
+                "dark_blue.xml",
+                "dark_cyan.xml",
+                "dark_pink.xml",
+                "dark_red.xml",
+                "light_purple.xml",
+                "light_teal.xml",
+                "light_blue.xml",
+                "light_cyan.xml",
+                "light_pink.xml",
+                "light_red.xml",
             ]
         for theme in themes:
             action = QAction(theme, self)
@@ -1638,6 +1675,11 @@ class fpdb(QMainWindow):
     # end def tab_import_imap_summaries
 
     def tab_ring_player_stats(self, widget, data=None) -> None:
+        # This package imports Matplotlib and scans every system font. Frozen
+        # builds cannot reliably reuse that scan, so importing it at startup
+        # delayed Auto Import even though no graphing tab had been requested.
+        from fpdb_3_legacy import GuiRingPlayerStats
+
         new_ps_thread = GuiRingPlayerStats.GuiRingPlayerStats(self.config, self.sql, self)
         self.threads.append(new_ps_thread)
         self.add_and_display_tab(new_ps_thread, "Ring Player Stats")
@@ -1664,6 +1706,8 @@ class fpdb(QMainWindow):
     #     self.add_and_display_tab(ps_tab, "Positional Stats")
 
     def tab_session_stats(self, widget, data=None) -> None:
+        from fpdb_3_legacy import GuiSessionViewer
+
         colors = self.get_theme_colors()
         new_ps_thread = GuiSessionViewer.GuiSessionViewer(self.config, self.sql, self, self, colors=colors)
         self.threads.append(new_ps_thread)
@@ -1718,6 +1762,8 @@ class fpdb(QMainWindow):
 
     def tabGraphViewer(self, widget, data=None) -> None:
         """Opens a graph viewer tab."""
+        from fpdb_3_legacy import GuiGraphViewer
+
         colors = self.get_theme_colors()
         new_gv_thread = GuiGraphViewer.GuiGraphViewer(self.sql, self.config, self, colors=colors)
         self.threads.append(new_gv_thread)
@@ -1725,6 +1771,8 @@ class fpdb(QMainWindow):
 
     def tabTourneyGraphViewer(self, widget, data=None) -> None:
         """Opens a graph viewer tab."""
+        from fpdb_3_legacy import GuiTourneyGraphViewer
+
         colors = self.get_theme_colors()
         new_gv_thread = GuiTourneyGraphViewer.GuiTourneyGraphViewer(self.sql, self.config, self, colors=colors)
         self.threads.append(new_gv_thread)
@@ -1733,6 +1781,7 @@ class fpdb(QMainWindow):
     def tabStatsInfo(self, widget, data=None) -> None:
         """Opens a statistics guide tab."""
         from fpdb_3_legacy import GuiStatsInfo
+
         new_si_tab = GuiStatsInfo.GuiStatsInfo(self.config, self)
         self.threads.append(new_si_tab)
         self.add_and_display_tab(new_si_tab, "Stats Guide")

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -26,6 +26,7 @@ def _detector(*, window_list: list[dict] | None = None) -> MacOSTableDetector:
     detector._applescript_last_scan = 0.0
     detector._applescript_last_result = []
     detector._permissions_checked = False
+    detector._permission_status = None
     detector._automation_warned = False
     detector._NSWorkspace = Mock()
     detector._kCGNullWindowID = 0
@@ -194,11 +195,7 @@ def test_find_tables_applescript_rescans_after_ttl() -> None:
 
 def test_run_applescript_scan_parses_entries() -> None:
     detector = _detector()
-    stdout = (
-        "PokerStars|Table 1|10|20|600|500, "
-        "Winamax|SpeedPool|5|5|800|600, "
-        "PokerStars|Lobby|0|0|300|200"
-    )
+    stdout = "PokerStars|Table 1|10|20|600|500, Winamax|SpeedPool|5|5|800|600, PokerStars|Lobby|0|0|300|200"
     with patch(
         "fpdb.infrastructure.platform.macos.subprocess.run",
         return_value=Mock(returncode=0, stdout=stdout, stderr=""),
@@ -271,7 +268,9 @@ def test_match_target_window_by_pid_exact() -> None:
         TableInfo(window_id=1, title="", geometry=TableGeometry(0, 0, 600, 500), process_id=101),
         TableInfo(window_id=2, title="", geometry=TableGeometry(0, 0, 600, 500), process_id=102),
     ]
-    with patch("fpdb.infrastructure.platform.macos_process.table_id_for_pid", side_effect={101: "922564", 102: "1"}.__getitem__):
+    with patch(
+        "fpdb.infrastructure.platform.macos_process.table_id_for_pid", side_effect={101: "922564", 102: "1"}.__getitem__
+    ):
         assert detector._match_target_window_by_pid("922564", windows).window_id == 1
 
 
@@ -362,7 +361,9 @@ def test_get_window_geometry_for_fake_id_uses_cache() -> None:
     detector = _detector()
     fake_id = detector._FAKE_ID_BASE + 5
     detector._applescript_cache[fake_id] = TableInfo(
-        window_id=fake_id, title="Table 1", geometry=TableGeometry(3, 4, 600, 500),
+        window_id=fake_id,
+        title="Table 1",
+        geometry=TableGeometry(3, 4, 600, 500),
     )
     detector.find_tables_applescript = Mock()
     geometry = detector.get_window_geometry(fake_id)
@@ -375,7 +376,9 @@ def test_get_window_geometry_for_real_id_queries_quartz() -> None:
     desc = Mock(
         return_value=[{"kCGWindowBounds": {"X": 1, "Y": 2, "Width": 640, "Height": 480}}],
     )
-    with patch.dict("sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}):
+    with patch.dict(
+        "sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}
+    ):
         geometry = detector.get_window_geometry(9)
     assert geometry == (1, 2, 640, 480) or (geometry.x, geometry.y, geometry.width, geometry.height) == (1, 2, 640, 480)
 
@@ -383,7 +386,9 @@ def test_get_window_geometry_for_real_id_queries_quartz() -> None:
 def test_get_window_geometry_none_when_window_missing() -> None:
     detector = _detector()
     desc = Mock(return_value=[])
-    with patch.dict("sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}):
+    with patch.dict(
+        "sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}
+    ):
         assert detector.get_window_geometry(9) is None
 
 
@@ -391,7 +396,10 @@ def test_get_window_geometry_none_on_error() -> None:
     detector = _detector()
     with patch.dict(
         "sys.modules",
-        {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=Mock(side_effect=RuntimeError))},
+        {
+            "Quartz": Mock(),
+            "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=Mock(side_effect=RuntimeError)),
+        },
     ):
         assert detector.get_window_geometry(9) is None
 
@@ -405,7 +413,9 @@ def test_is_window_visible_real_id() -> None:
 def test_is_window_visible_fake_id_rescans() -> None:
     detector = _detector()
     fake_id = detector._FAKE_ID_BASE + 5
-    detector._applescript_cache[fake_id] = TableInfo(window_id=fake_id, title="T", geometry=TableGeometry(0, 0, 600, 500))
+    detector._applescript_cache[fake_id] = TableInfo(
+        window_id=fake_id, title="T", geometry=TableGeometry(0, 0, 600, 500)
+    )
     detector.find_tables_applescript = Mock()
     assert detector.is_window_visible(fake_id) is True
     detector.find_tables_applescript.assert_called_once_with("")
@@ -429,7 +439,9 @@ def test_get_window_title_fake_id() -> None:
     detector = _detector()
     fake_id = detector._FAKE_ID_BASE + 5
     detector._applescript_cache[fake_id] = TableInfo(
-        window_id=fake_id, title="Table Alpha", geometry=TableGeometry(0, 0, 600, 500),
+        window_id=fake_id,
+        title="Table Alpha",
+        geometry=TableGeometry(0, 0, 600, 500),
     )
     assert detector.get_window_title(fake_id) == "Table Alpha"
     assert detector.get_window_title(detector._FAKE_ID_BASE + 999) is None
@@ -438,14 +450,18 @@ def test_get_window_title_fake_id() -> None:
 def test_get_window_title_real_id() -> None:
     detector = _detector()
     desc = Mock(return_value=[{"kCGWindowName": "Table Beta"}])
-    with patch.dict("sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}):
+    with patch.dict(
+        "sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}
+    ):
         assert detector.get_window_title(9) == "Table Beta"
 
 
 def test_get_window_title_none_when_window_missing() -> None:
     detector = _detector()
     desc = Mock(return_value=[])
-    with patch.dict("sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}):
+    with patch.dict(
+        "sys.modules", {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=desc)}
+    ):
         assert detector.get_window_title(9) is None
 
 
@@ -453,7 +469,10 @@ def test_get_window_title_none_on_error() -> None:
     detector = _detector()
     with patch.dict(
         "sys.modules",
-        {"Quartz": Mock(), "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=Mock(side_effect=RuntimeError))},
+        {
+            "Quartz": Mock(),
+            "Quartz.CoreGraphics": Mock(CGWindowListCreateDescriptionFromArray=Mock(side_effect=RuntimeError)),
+        },
     ):
         assert detector.get_window_title(9) is None
 
@@ -627,7 +646,9 @@ def test_check_permissions_once_noop_when_permissions_ok() -> None:
 
 def test_find_tables_without_titles_prefers_pid_match() -> None:
     detector = _detector()
-    target = TableInfo(window_id=1, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="CoinPoker", process_id=99)
+    target = TableInfo(
+        window_id=1, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="CoinPoker", process_id=99
+    )
     detector._match_target_window_by_pid = Mock(return_value=target)
     result = detector._find_tables_without_titles("922564", [target], [], 2, 0)
     assert result == [target]
@@ -660,6 +681,19 @@ def test_find_tables_without_titles_uses_sole_blank_window() -> None:
     blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="PokerStars")
     result = detector._find_tables_without_titles("pokerstars", [], [blank], 0, 0)
     assert result == [blank]
+
+
+def test_find_tables_without_titles_skips_slow_applescript_when_accessibility_is_missing() -> None:
+    detector = _detector()
+    detector._match_target_window_by_pid = Mock(return_value=None)
+    detector._check_permissions_once = Mock(return_value=Mock(accessibility=False))
+    detector.find_tables_applescript = Mock(return_value=[])
+    blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="Winamax")
+
+    result = detector._find_tables_without_titles("Winamax Bucarest 6", [], [blank], 3, 0)
+
+    assert result == [blank]
+    detector.find_tables_applescript.assert_not_called()
 
 
 def test_find_tables_without_titles_rejects_cross_room_blank_window_fallback() -> None:

--- a/test/test_menu_layout.py
+++ b/test/test_menu_layout.py
@@ -7,6 +7,7 @@ heavy Qt main window. Handler existence is checked by scanning fpdb.pyw source.
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 import sys
@@ -27,7 +28,15 @@ def _all_items():
 def test_top_level_menus_are_grouped_by_intent():
     titles = [m.title for m in menu_layout.menu_layout()]
     assert titles == [
-        "File", "Configure", "Import", "Cash", "Tournament", "Database", "Tools", "View", "Help",
+        "File",
+        "Configure",
+        "Import",
+        "Cash",
+        "Tournament",
+        "Database",
+        "Tools",
+        "View",
+        "Help",
     ]
 
 
@@ -56,6 +65,27 @@ def test_all_handlers_are_defined_on_the_main_window():
         if item.handler in sentinels:
             continue
         assert item.handler in defined, f"handler '{item.handler}' not defined in fpdb.pyw"
+
+
+def test_graphing_modules_are_lazy_so_auto_import_does_not_build_the_font_cache():
+    """Frozen startup must not import Matplotlib-backed tabs Auto Import does not use."""
+    with open(FPDB_PYW, encoding="utf-8") as source_file:
+        tree = ast.parse(source_file.read())
+
+    expensive = {
+        "GuiGraphViewer",
+        "GuiRingPlayerStats",
+        "GuiSessionViewer",
+        "GuiTourneyGraphViewer",
+    }
+    eager = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "fpdb_3_legacy"
+        for alias in node.names
+    }
+
+    assert eager.isdisjoint(expensive)
 
 
 def test_view_menu_exposes_themes_and_language_submenus():


### PR DESCRIPTION
## What changed

- defer Matplotlib-backed GUI modules until their tabs are opened
- cache the macOS privacy-permission status in the table detector
- skip the synchronous AppleScript window scan when Accessibility is unavailable
- add regressions for frozen startup imports and the Fast HUD fallback

## Root cause and impact

The PyInstaller launcher imported graph modules during normal application startup. Those modules import Matplotlib, which rebuilt its font cache in the frozen bundle and delayed opening Auto Import by several seconds.

On the PyOxidizer build, Fast HUD hand ingestion and statistics were already fast, but table attachment retried a synchronous AppleScript scan. Without Accessibility permission, each rejected scan took roughly two seconds. The detector now uses the safe single-window Quartz fallback immediately in that situation.

## Validation

- `105 passed` across the macOS detector, menu-layout, headless Auto Import, and subprocess-launch test suites
- Ruff checks pass for all modified files
- `git diff --check` passes
- corrected PyInstaller cold launcher measured about 1.3 seconds versus about 8.7 seconds before the change

## macOS note

Screen Recording and Accessibility permissions remain recommended for reliable multi-table detection. The fix removes the repeated delay when Accessibility has not yet been granted.