### PR TITLE
chore(release): prepare 3.6.1

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.6.0"
+version = "3.6.1"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.6.0"
+version = "3.6.1"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.6.0"
+version = "3.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prépare la release **3.6.1**. Version bump uniquement — aucun changement de comportement supplémentaire.

## Pourquoi 3.6.1

Cette release corrective contient le correctif de démarrage fusionné dans #216 :

- ouverture d’Auto Import accélérée dans le bundle PyInstaller en différant les imports Matplotlib ;
- suppression des attentes AppleScript répétées du Fast HUD PyOxidizer lorsque la permission Accessibility manque.

Il s’agit d’un correctif patch SemVer.

## Bump

- `pyproject.toml` → `[project].version`
- `pyproject.toml` → `[tool.briefcase].version`
- `fpdb_3_legacy/__init__.py` → `__version__`
- `uv.lock`

## Vérifications locales

- `uv lock --check`
- `test/test_fpdb_version_resolution.py` — 6 tests réussis
- Ruff propre sur le fichier Python modifié
- `git diff --check`

## Après fusion

1. Avancer `main` sur le commit de release.
2. Créer le tag annoté `v3.6.1`.
3. Publier la GitHub Release.
4. Attendre le workflow `release: published` et vérifier les six archives.