### PR TITLE
fix(macos): Fast HUD finds table windows without Accessibility

### DIFF
--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -466,6 +466,12 @@ class AuxSeats(AuxWindow):
         """
         super().__init__(hud, params, config)
         self.positions: dict[Any, tuple[int, int]] = {}
+        # Both are filled in by create(). Declared here so an aux that has not
+        # been created yet answers "nothing to place" rather than raising: a
+        # loading HUD deliberately skips create(), and the table watcher can
+        # report a move or a resize while it is still on screen.
+        self.adj: dict[int, int] = {}
+        self.m_windows: dict[Any, Any] = {}
         # but _not_ offset to the absolute screen position
         self.displayed = False  # the seat windows are displayed
         self.uses_timer = False  # the Aux_seats object uses a timer to control hiding
@@ -502,6 +508,8 @@ class AuxSeats(AuxWindow):
         Updates the internal map of window positions based on the latest table and layout dimensions,
         then moves all windows accordingly.
         """
+        if not self.m_windows:
+            return  # not created yet; create() will place everything itself
         log.debug("RESIZING HUD WINDOWS - Table dimensions: %dx%d", self.hud.table.width, self.hud.table.height)
         # Resize calculation has already happened in HUD_main&hud.py
         # refresh our internal map to reflect these changes
@@ -534,6 +542,8 @@ class AuxSeats(AuxWindow):
         Calculates the absolute positions for each window based on the table's current coordinates and layout,
         clamps them to the screen, and moves the windows accordingly.
         """
+        if not self.m_windows:
+            return  # not created yet; there is nothing on screen to move
         # Ensure table coordinates are valid (not negative or off-screen)
         table_x = max(0, self.hud.table.x) if self.hud.table.x is not None else 50
         table_y = max(0, self.hud.table.y) if self.hud.table.y is not None else 50

--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -470,7 +470,7 @@ class AuxSeats(AuxWindow):
         # been created yet answers "nothing to place" rather than raising: a
         # loading HUD deliberately skips create(), and the table watcher can
         # report a move or a resize while it is still on screen.
-        self.adj: dict[int, int] = {}
+        self.adj: list[int] = []
         self.m_windows: dict[Any, Any] = {}
         # but _not_ offset to the absolute screen position
         self.displayed = False  # the seat windows are displayed
@@ -598,7 +598,7 @@ class AuxSeats(AuxWindow):
         """
         log.debug("=== AUX_BASE CREATE() METHOD CALLED ===")
         self.adj = self.adj_seats()
-        self.m_windows: dict[Any, Any] = {}
+        self.m_windows = {}
         window_keys: list[int | str] = [*range(1, self.hud.max + 1), "common"]
         for i in window_keys:
             if i == "common":

--- a/fpdb_3_legacy/Aux_Hud.py
+++ b/fpdb_3_legacy/Aux_Hud.py
@@ -930,6 +930,8 @@ class SimpleHUD(Aux_Base.AuxSeats):
         if not self._uses_block_windows():
             super().resize_windows()
             return
+        if not self.m_windows:
+            return  # not created yet; create() will place every block itself
         for seat in range(1, self.hud.max + 1):
             self.positions[seat] = self.hud.layout.location[self.adj[seat]]
         self.positions["common"] = self.hud.layout.common

--- a/fpdb_3_legacy/Aux_Hud.py
+++ b/fpdb_3_legacy/Aux_Hud.py
@@ -839,7 +839,7 @@ class SimpleHUD(Aux_Base.AuxSeats):
         log.debug("=== SIMPLEHUD MULTI-BLOCK CREATE() METHOD CALLED ===")
         self.adj = self.adj_seats()
         self.hero_display_seat = self._hero_display_seat()
-        self.m_windows: dict[Any, Any] = {}
+        self.m_windows = {}
         self._keep_block_positions_for_this_table()
         self._claim_legacy_block_positions()
         # Unscaled reference seat anchors, captured once. Kept separate from the

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -784,18 +784,6 @@ class GuiAutoImport(QWidget):
             env = os.environ.copy()
             env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
 
-        # Source launches normally inherit macOS privacy grants from the user's
-        # terminal/Python. Packaged applications are separate TCC clients and
-        # start without those grants, so Fast HUD can tail Winamax's log but
-        # cannot inspect the table window. It then falls back to the delayed
-        # hand-history import, which looks like a slow trigger. Opt packaged
-        # macOS HUDs into the existing native permission preflight so the user
-        # is prompted instead of silently taking that slow path.
-        if getattr(sys, "frozen", False) and sys.platform == "darwin":
-            if env is None:
-                env = os.environ.copy()
-            env.setdefault("FPDB_REQUEST_MACOS_PERMISSIONS", "1")
-
         if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
             if env is None:
                 env = os.environ.copy()

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -784,6 +784,18 @@ class GuiAutoImport(QWidget):
             env = os.environ.copy()
             env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
 
+        # Source launches normally inherit macOS privacy grants from the user's
+        # terminal/Python. Packaged applications are separate TCC clients and
+        # start without those grants, so Fast HUD can tail Winamax's log but
+        # cannot inspect the table window. It then falls back to the delayed
+        # hand-history import, which looks like a slow trigger. Opt packaged
+        # macOS HUDs into the existing native permission preflight so the user
+        # is prompted instead of silently taking that slow path.
+        if getattr(sys, "frozen", False) and sys.platform == "darwin":
+            if env is None:
+                env = os.environ.copy()
+            env.setdefault("FPDB_REQUEST_MACOS_PERMISSIONS", "1")
+
         if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
             if env is None:
                 env = os.environ.copy()

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -541,6 +541,7 @@ class GuiAutoImport(QWidget):
         """Launch SwC native TLS capture and start live raw tailing thread."""
         try:
             from fpdb_3_legacy.swc_native_capture import DEFAULT_ARCHIVE, build_tap
+
             build_tap(check_executable=False)
             if self.swc_tailing_thread is None or not self.swc_tailing_thread.isRunning():
                 self.swc_tailing_thread = SwCNativeTailingThread(DEFAULT_ARCHIVE, parent=self)
@@ -718,11 +719,14 @@ class GuiAutoImport(QWidget):
         # 1) build command line
         # ------------------------------------------------------------------
         command: str | list[str]
-        if getattr(sys, "frozen", False) == "pyoxidizer":
+        frozen = getattr(sys, "frozen", False)
+        if frozen == "pyoxidizer" or (frozen and sys.platform == "darwin"):
+            # On macOS the HUD must retain fpdb.app's code identity so its
+            # Screen Recording and Accessibility grants remain valid.
             command = [sys.executable, "--hud", *self.settings["cl_options"].split()]
             bs = 1
 
-        elif getattr(sys, "frozen", False):
+        elif frozen:
             executable = "HUD_main.exe" if os.name == "nt" else "HUD_main"
             command = os.path.join(self._hud_base_path(), executable)
             if not os.path.isfile(command):

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1465,10 +1465,20 @@ class HudMain(QObject):
         """
         reader = getattr(self, "winamax_ax_seats", None)
         if reader is None:
+            self._ff_trace(
+                update.hand_id,
+                "create-deferred",
+                "macOS accessibility reader unavailable; waiting for an imported hand",
+            )
             return None
 
         window = reader.find_table_window(update.table_no)
         if window is None:
+            self._ff_trace(
+                update.hand_id,
+                "create-deferred",
+                f"Winamax [table] {update.table_no} is not accessible; waiting for an imported hand",
+            )
             return None
         temp_key = window.table_name
         if temp_key in self.hud_dict:
@@ -2067,8 +2077,7 @@ class HudMain(QObject):
         log.debug("got stats for hand %s", new_hand_id)
 
         if was_loading and not any(
-            values.get("screen_name") == self.hero.get(site_id)
-            for values in stat_dict.values()
+            values.get("screen_name") == self.hero.get(site_id) for values in stat_dict.values()
         ):
             if not self._hud_is_fast_fold(hud, temp_key):
                 log.warning(

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -686,10 +686,18 @@ class HudMain(QObject):
 
             from fpdb_3_legacy.winamax_ax_seats import WinamaxAXSeatReader, is_supported
             from fpdb_3_legacy.winamax_live_log_reader import WinamaxLiveLogReader
+            from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
 
             # Reads seats off the table window itself. The log can only say who
             # has acted, and never where they sit; this knows both, immediately.
             self.winamax_ax_seats = WinamaxAXSeatReader() if is_supported() else None
+
+            # The window says which game it deals only to a process holding
+            # macOS Accessibility, which packaged builds do not. Imported hands
+            # say it unconditionally, so what they prove is kept.
+            self.winamax_pool_games = WinamaxPoolGames(
+                Path(Configuration.CONFIG_PATH) / "winamax_pool_games.json" if Configuration.CONFIG_PATH else None,
+            )
 
             # Queued by Qt because the reader emits from its tailing thread.
             self.winamax_table_update.connect(self._on_winamax_table_update)
@@ -1425,6 +1433,10 @@ class HudMain(QObject):
             table_no,
             f"{info.table_name} {table_no}",
         )
+        # This hand settles what the pool deals, which is the one thing the log
+        # cannot say. Kept so later hands on this pool -- and later sessions --
+        # can build their HUD from the log alone.
+        self.winamax_pool_games.remember(info.table_name, info.poker_game)
         return info._replace(table_name=f"{info.table_name} {table_no}")
 
     def _hud_is_fast_fold(self, hud: Hud.Hud, temp_key: str = "") -> bool:
@@ -1477,19 +1489,23 @@ class HudMain(QObject):
             self._ff_trace(
                 update.hand_id,
                 "create-deferred",
-                f"Winamax [table] {update.table_no} is not accessible; waiting for an imported hand",
+                f"no open Winamax window is titled with the client index {update.table_no}; "
+                f"waiting for an imported hand",
             )
             return None
         temp_key = window.table_name
         if temp_key in self.hud_dict:
             return temp_key, self.hud_dict[temp_key]
 
-        poker_game = window.poker_game
+        # The window states the game only when the accessibility API answered.
+        # Otherwise fall back on what an imported hand from this pool proved.
+        poker_game = window.poker_game or self.winamax_pool_games.get(temp_key)
         if not poker_game:
             self._ff_trace(
                 update.hand_id,
                 "create-skipped",
-                f"{window.title!r} does not say what is being played: {window.description!r}",
+                f"{window.title!r} does not say what is being played ({window.description!r}) and "
+                f"no hand from this pool has been imported yet; the next one settles it",
             )
             return None
 

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -24,11 +24,13 @@ import sys
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-from fpdb_3_legacy.subprocess_launch import dispatch_run_module
+from fpdb_3_legacy.subprocess_launch import dispatch_hud_main, dispatch_run_module
 
 # Frozen builds have no "python -m": helper processes re-invoke this executable
 # with --run-module. Dispatch before pulling in the GUI stack below.
 if __name__ == "__main__" and dispatch_run_module():
+    sys.exit(0)
+if __name__ == "__main__" and dispatch_hud_main():
     sys.exit(0)
 
 import atexit

--- a/fpdb_3_legacy/subprocess_launch.py
+++ b/fpdb_3_legacy/subprocess_launch.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 RUN_MODULE_FLAG = "--run-module"
+HUD_FLAG = "--hud"
 
 
 def python_module_command(module: str, *args: str, unbuffered: bool = True) -> list[str]:
@@ -38,9 +39,12 @@ def hud_main_command(*args: str) -> list[str]:
         FileNotFoundError: when a packaged build has no HUD_main next to it.
     """
     frozen = getattr(sys, "frozen", False)
-    if frozen == "pyoxidizer":
-        # A single binary hosts both entry points; --hud selects HUD_main.
-        return [sys.executable, "--hud", *args]
+    if frozen == "pyoxidizer" or (frozen and sys.platform == "darwin"):
+        # Keep the macOS HUD under the main app's code identity. TCC grants
+        # Screen Recording and Accessibility to that identity; a separately
+        # frozen sibling has another designated requirement and loses both
+        # permissions even though it lives inside fpdb.app.
+        return [sys.executable, HUD_FLAG, *args]
     if frozen:
         # PyInstaller ships HUD_main as a sibling executable of fpdb.
         name = "HUD_main.exe" if os.name == "nt" else "HUD_main"
@@ -70,6 +74,26 @@ def dispatch_run_module(argv: list[str] | None = None) -> bool:
     sys.argv = [module, *argv[3:]]
     unbuffer_streams()
     runpy.run_module(module, run_name="__main__", alter_sys=True)
+    return True
+
+
+def dispatch_hud_main(argv: list[str] | None = None) -> bool:
+    """Run ``HUD_main.pyw`` through the current frozen launcher.
+
+    PyInstaller's macOS bundle must use the same executable for the GUI and HUD
+    so macOS applies the app's TCC permissions to both processes. The HUD script
+    is already shipped as package data beside this module.
+    """
+    argv = sys.argv if argv is None else argv
+    if len(argv) < 2 or argv[1] != HUD_FLAG:
+        return False
+    hud_main = Path(__file__).resolve().with_name("HUD_main.pyw")
+    if not hud_main.is_file():
+        msg = f"HUD_main not found at {hud_main}"
+        raise FileNotFoundError(msg)
+    sys.argv = [str(hud_main), *argv[2:]]
+    unbuffer_streams()
+    runpy.run_path(str(hud_main), run_name="__main__")
     return True
 
 

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -25,10 +25,69 @@ import logging
 import math
 import platform
 import re
+import subprocess
+import time
 from dataclasses import dataclass
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+# Lists the client's window titles through System Events. Used when the
+# accessibility API itself is closed to us -- see WINDOW_SCAN_TTL.
+_WINDOW_TITLES_SCRIPT = """
+tell application "System Events"
+    set windowList to {}
+    repeat with proc in (processes whose name contains "Winamax")
+        repeat with win in (every window of proc)
+            try
+                set end of windowList to name of win
+            end try
+        end repeat
+    end repeat
+    return windowList
+end tell
+"""
+
+WINDOW_SCAN_TTL = 1.0
+"""Seconds an AppleScript window list stays good for.
+
+Each scan is a synchronous ``osascript`` call costing a couple of hundred
+milliseconds, and a busy pool starts hands faster than that. One scan per
+second is far below the rate at which windows are opened or closed, and keeps
+the fallback off the critical path.
+"""
+
+APPLESCRIPT_TIMEOUT = 5.0
+
+
+def applescript_window_titles() -> list[str]:
+    """Titles of the client's windows, read through System Events.
+
+    The direct accessibility API needs this process to hold *Accessibility*,
+    which macOS never prompts for: a packaged build is a new TCC client and
+    starts without it, so every AX call comes back empty. Going through System
+    Events instead needs only *Automation*, which macOS does prompt for and
+    which the rest of fpdb already relies on to find these same windows.
+
+    Returns an empty list when the client is not running or the scan is
+    refused; the caller then falls back to waiting for an imported hand.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+            ["osascript", "-e", _WINDOW_TITLES_SCRIPT],  # noqa: S607 - resolved from PATH by design
+            capture_output=True,
+            text=True,
+            timeout=APPLESCRIPT_TIMEOUT,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        log.debug("Could not list Winamax windows through System Events: %s", exc)
+        return []
+    if result.returncode != 0:
+        log.debug("System Events refused the Winamax window list: %s", result.stderr.strip())
+        return []
+    return [title.strip() for title in result.stdout.strip().split(",") if title.strip()]
+
 
 # A player's stack, e.g. "552,5 BB" or "7,64 €". The client draws it directly
 # under the name, and that pairing is what identifies a seat -- far steadier than
@@ -112,7 +171,22 @@ def poker_game_from_description(description: str) -> str | None:
 
 
 def is_supported() -> bool:
-    """Whether this platform can read seats from the window."""
+    """Whether this platform can locate the client's table windows at all.
+
+    True on macOS regardless of the accessibility API: ``find_table_window``
+    falls back to System Events, which is enough to create a HUD. Reading
+    seats still needs the API -- see :func:`is_ax_available`.
+    """
+    return platform.system() == "Darwin"
+
+
+def is_ax_available() -> bool:
+    """Whether the accessibility API can be called from this process.
+
+    Only reports whether the bindings are importable. Whether macOS will
+    actually answer depends on this binary holding *Accessibility*, which is
+    not knowable without trying.
+    """
     if platform.system() != "Darwin":
         return False
     try:
@@ -209,6 +283,18 @@ class WinamaxAXSeatReader:
     def __init__(self) -> None:
         self._app: Any = None
         self._pid: int | None = None
+        self._titles: list[str] = []
+        self._titles_read_at = 0.0
+        self._fallback_announced = False
+
+    def _window_titles(self) -> list[str]:
+        """The client's window titles via System Events, at most once a second."""
+        now = time.monotonic()
+        if now - self._titles_read_at < WINDOW_SCAN_TTL:
+            return self._titles
+        self._titles = applescript_window_titles()
+        self._titles_read_at = now
+        return self._titles
 
     def _application(self) -> Any:
         """The AX handle for the running client, with its web tree switched on."""
@@ -289,8 +375,23 @@ class WinamaxAXSeatReader:
         The client numbers its table windows in their titles ("Winamax Casablanca
         6"), which is the same index the log writes, so a pool can be tied to a
         window without waiting for any hand to be imported.
+
+        Tries the accessibility API first, because it also reads the header that
+        names the game. When that is closed to us -- the normal state of a
+        packaged build, which macOS treats as a new client with no
+        *Accessibility* grant -- the title alone is recovered through System
+        Events, and the game is left for the caller to supply.
         """
         if not is_supported():
+            return None
+        window = self._find_table_window_ax(table_no)
+        if window is not None:
+            return window
+        return self._find_table_window_applescript(table_no)
+
+    def _find_table_window_ax(self, table_no: str) -> AXTableWindow | None:
+        """The table window and its header, read through the accessibility API."""
+        if not is_ax_available():
             return None
         try:
             app = self._application()
@@ -298,8 +399,7 @@ class WinamaxAXSeatReader:
                 return None
             for window in self._attr(app, "AXWindows") or []:
                 title = self._attr(window, "AXTitle") or ""
-                m = re.search(r"(\d+)\s*$", title)
-                if not m or m.group(1) != str(table_no):
+                if not self._is_table_no(title, table_no):
                     continue
                 labels: list[AXSeat] = []
                 self._collect_text(window, labels)
@@ -308,6 +408,28 @@ class WinamaxAXSeatReader:
         except Exception:
             log.exception("Could not look up the Winamax window for table %s", table_no)
         return None
+
+    def _find_table_window_applescript(self, table_no: str) -> AXTableWindow | None:
+        """The table window by title only, read through System Events."""
+        for title in self._window_titles():
+            if not self._is_table_no(title, table_no):
+                continue
+            if not self._fallback_announced:
+                self._fallback_announced = True
+                log.info(
+                    "Reading Winamax table windows through System Events: the accessibility "
+                    "API returned nothing for this process. Table windows are still found, but "
+                    "seats come from the log rather than the window. Granting this application "
+                    "Accessibility in System Settings > Privacy & Security restores the direct read.",
+                )
+            return AXTableWindow(title=title, description="")
+        return None
+
+    @staticmethod
+    def _is_table_no(title: str, table_no: str) -> bool:
+        """Whether a window title carries the client index the log reported."""
+        m = re.search(r"(\d+)\s*$", title or "")
+        return m is not None and m.group(1) == str(table_no)
 
     def read_window(self, title: str, max_seats: int = 6) -> dict[int, str]:
         """Players at the window with this exact title, keyed by layout slot.
@@ -319,7 +441,7 @@ class WinamaxAXSeatReader:
         found, or accessibility is unavailable -- the caller then keeps whatever
         the log was able to work out.
         """
-        if not is_supported():
+        if not is_ax_available():
             return {}
         try:
             app = self._application()

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -25,7 +25,7 @@ import logging
 import math
 import platform
 import re
-import subprocess
+import subprocess  # nosec B404 - only ever runs the fixed osascript command below
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -59,6 +59,9 @@ the fallback off the critical path.
 
 APPLESCRIPT_TIMEOUT = 5.0
 
+OSASCRIPT = "/usr/bin/osascript"
+"""Absolute, so the scan cannot be diverted by whatever PATH the app inherited."""
+
 
 def applescript_window_titles() -> list[str]:
     """Titles of the client's windows, read through System Events.
@@ -73,8 +76,9 @@ def applescript_window_titles() -> list[str]:
     refused; the caller then falls back to waiting for an imported hand.
     """
     try:
-        result = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
-            ["osascript", "-e", _WINDOW_TITLES_SCRIPT],  # noqa: S607 - resolved from PATH by design
+        # Absolute path, fixed argv, no shell, and nothing interpolated into the script.
+        result = subprocess.run(  # noqa: S603  # nosec B603
+            [OSASCRIPT, "-e", _WINDOW_TITLES_SCRIPT],
             capture_output=True,
             text=True,
             timeout=APPLESCRIPT_TIMEOUT,

--- a/fpdb_3_legacy/winamax_pool_games.py
+++ b/fpdb_3_legacy/winamax_pool_games.py
@@ -1,0 +1,96 @@
+"""Remember which game a Winamax Fast-Fold pool deals.
+
+Why this exists
+---------------
+A Fast-Fold HUD is built from the client log the moment a hand starts, long
+before that hand is imported. Everything it needs comes from the log or the
+window title except one thing: the game. That is written only in the header the
+client draws inside the table, which can be read solely through the macOS
+accessibility API -- and a packaged build is a fresh TCC client that macOS never
+prompts for *Accessibility*, so in practice that header is unreadable.
+
+The game does arrive eventually, on the first hand of the pool that gets
+imported. Keeping it means the wait is paid once per pool rather than once per
+hand: every later hand, and every later session, can build the HUD straight from
+the log.
+
+Pools are keyed by their display name ("Colorado", "Casablanca"), which is what
+both the hand history and the window title carry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+MAX_POOLS = 200
+"""Cap on remembered pools, so a long-lived file cannot grow without bound."""
+
+
+def pool_name(table_name: str) -> str:
+    """The pool a table belongs to: its name without the client's window index.
+
+    ``"Colorado 4"`` and ``"Colorado"`` are both the Colorado pool; the trailing
+    number identifies which of its windows, not which game it deals. The client
+    always separates it from the name, so a name that simply ends in a digit
+    keeps it.
+    """
+    return re.sub(r"\s+\d+\s*$", "", table_name or "").strip()
+
+
+class WinamaxPoolGames:
+    """Pool display name -> fpdb game category, persisted between sessions."""
+
+    def __init__(self, path: Path | None) -> None:
+        self._path = path
+        self._games: dict[str, str] = {}
+        self._loaded = False
+
+    def _load(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        if self._path is None or not self._path.is_file():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            log.debug("Could not read remembered Winamax pool games from %s", self._path)
+            return
+        if isinstance(data, dict):
+            self._games = {str(k): str(v) for k, v in data.items() if k and v}
+
+    def get(self, table_name: str) -> str | None:
+        """The game last seen at this table's pool, if one was ever imported."""
+        self._load()
+        return self._games.get(pool_name(table_name))
+
+    def remember(self, table_name: str, poker_game: str) -> None:
+        """Record the game an imported hand proved this pool deals."""
+        name = pool_name(table_name)
+        if not name or not poker_game:
+            return
+        self._load()
+        if self._games.get(name) == poker_game:
+            return
+        self._games[name] = poker_game
+        # Oldest first: dict preserves insertion order, and a pool that is still
+        # being played is re-inserted only when its game changes, so trimming the
+        # front drops the pools longest untouched.
+        while len(self._games) > MAX_POOLS:
+            self._games.pop(next(iter(self._games)))
+        self._save()
+
+    def _save(self) -> None:
+        if self._path is None:
+            return
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(self._games, indent=2, sort_keys=True), encoding="utf-8")
+        except OSError:
+            # Losing the file only costs one hand's delay per pool next session.
+            log.debug("Could not save remembered Winamax pool games to %s", self._path)

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -2359,6 +2359,84 @@ def test_no_hud_is_created_when_the_window_does_not_say_what_is_played(hud_main)
     create.assert_not_called()
 
 
+def test_a_hud_is_created_from_the_title_alone_once_the_pool_game_is_known(hud_main) -> None:
+    """A packaged build reads no window header, so the game comes from an import.
+
+    Without this the Fast-Fold HUD waits for the hand history on every hand,
+    which is the multi-second delay seen in the PyInstaller and PyOxidizer
+    bundles but never in a source run.
+    """
+    from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
+
+    hud_main.winamax_pool_games = WinamaxPoolGames(None)
+    hud_main.winamax_pool_games.remember("Casablanca", "omahahi")
+    # System Events gives the title but cannot read the client's own header.
+    hud_main.winamax_ax_seats = SimpleNamespace(find_table_window=lambda table_no: _ax_window(description=""))
+    hud_main.hud_dict = {}
+    created = {}
+
+    def fake_create(hand_id, temp_key, info, site_id, num_seats, site, *, loading=False, stats=None):
+        created.update(info=info)
+        hud_main.hud_dict[temp_key] = SimpleNamespace(site="Winamax", table=SimpleNamespace(title=info.table_name))
+
+    try:
+        with patch.object(hud_main, "_create_new_hud", side_effect=fake_create):
+            found = hud_main._find_fast_fold_hud(_log_update(table_no="6"))
+
+        assert found is not None
+        assert found[0] == "Casablanca 6"
+        assert created["info"].poker_game == "omahahi"
+    finally:
+        hud_main.hud_dict = {}
+
+
+def test_the_window_header_wins_over_what_was_remembered(hud_main) -> None:
+    """A pool that changed game must not be built from a stale memory."""
+    from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
+
+    hud_main.winamax_pool_games = WinamaxPoolGames(None)
+    hud_main.winamax_pool_games.remember("Casablanca", "holdem")
+    hud_main.winamax_ax_seats = SimpleNamespace(find_table_window=lambda table_no: _ax_window())
+    hud_main.hud_dict = {}
+    created = {}
+
+    def fake_create(hand_id, temp_key, info, site_id, num_seats, site, *, loading=False, stats=None):
+        created.update(info=info)
+        hud_main.hud_dict[temp_key] = SimpleNamespace(site="Winamax", table=SimpleNamespace(title=info.table_name))
+
+    try:
+        with patch.object(hud_main, "_create_new_hud", side_effect=fake_create):
+            hud_main._find_fast_fold_hud(_log_update(table_no="6"))
+        assert created["info"].poker_game == "omahahi"
+    finally:
+        hud_main.hud_dict = {}
+
+
+def test_an_imported_hand_records_what_its_pool_deals(hud_main) -> None:
+    """That record is what lets every later hand skip the wait."""
+    from fpdb_3_legacy.table_info import TableInfo
+    from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
+
+    hud_main.winamax_pool_games = WinamaxPoolGames(None)
+    hud_main._prepared_hands = {"42": SimpleNamespace(site_hand_no="22753788-426918-1786200400")}
+    hud_main.winamax_log_reader = SimpleNamespace(table_no_for_hand=lambda _hand: "4", is_tailing=True)
+    info = TableInfo(
+        table_name="Colorado",
+        max_seats=6,
+        poker_game="omahahi",
+        game_type="ring",
+        fast=True,
+        site_id=15,
+        site_name="Winamax",
+        num_seats=6,
+    )
+
+    qualified = hud_main._qualify_fast_fold_table(info, "42")
+
+    assert qualified.table_name == "Colorado 4"
+    assert hud_main.winamax_pool_games.get("Colorado 2") == "omahahi"
+
+
 def test_no_hud_is_created_when_the_window_is_gone(hud_main) -> None:
     hud_main.winamax_ax_seats = SimpleNamespace(find_table_window=lambda table_no: None)
     hud_main.hud_dict = {}

--- a/test/test_aux_uncreated_windows.py
+++ b/test/test_aux_uncreated_windows.py
@@ -1,0 +1,87 @@
+"""An aux window that was never created must not crash when the table moves.
+
+A loading HUD is put on screen deliberately without creating its aux windows --
+``idle_create`` returns early for it, so the seat map and the window objects that
+``create()`` builds do not exist yet. The table watcher keeps reporting moves and
+resizes the whole time, and Fast-Fold puts a loading HUD up on every new table,
+which is how ``'ClassicHud' object has no attribute 'adj'`` reached the log.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.qt
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+sys.modules.setdefault("PySide6", Mock())
+sys.modules.setdefault("PySide6.QtWidgets", Mock())
+sys.modules.setdefault("PySide6.QtCore", Mock())
+sys.modules.setdefault("PySide6.QtGui", Mock())
+
+from fpdb_3_legacy import Aux_Base  # noqa: E402
+from fpdb_3_legacy.Aux_Base import AuxSeats  # noqa: E402
+
+
+def _hud() -> Mock:
+    hud = Mock()
+    hud.max = 6
+    hud.table.width, hud.table.height = 757, 592
+    hud.table.x, hud.table.y = 0, 33
+    # Empty on purpose: a HUD whose aux windows were never created has no seat
+    # map, so any lookup here would be the bug this guards against.
+    hud.layout.location = {}
+    hud.layout.common = (0, 0)
+    return hud
+
+
+@pytest.fixture
+def uncreated() -> AuxSeats:
+    """An aux exactly as it is between ``__init__`` and ``create()``."""
+    return AuxSeats(_hud(), Mock(), {})
+
+
+class TestBeforeCreate:
+    def test_the_seat_map_exists_and_is_empty(self, uncreated: AuxSeats) -> None:
+        assert uncreated.adj == {}
+        assert uncreated.m_windows == {}
+
+    def test_resizing_is_a_no_op(self, uncreated: AuxSeats) -> None:
+        uncreated.resize_windows()
+
+        assert uncreated.positions == {}
+
+    def test_moving_is_a_no_op(self, uncreated: AuxSeats) -> None:
+        uncreated.move_windows()
+
+    def test_updating_is_a_no_op(self, uncreated: AuxSeats) -> None:
+        uncreated.update_gui("some-hand")
+
+    def test_destroying_is_a_no_op(self, uncreated: AuxSeats) -> None:
+        uncreated.destroy()
+
+        assert uncreated.displayed is False
+
+
+class TestAfterCreate:
+    def test_resizing_still_places_every_seat(self, monkeypatch) -> None:
+        """The guard must not silence a resize for an aux that does exist."""
+        monkeypatch.setattr(Aux_Base, "clamp_to_screen", lambda x, y: (x, y))
+        hud = _hud()
+        hud.layout.location = {seat: (seat * 10, seat * 20) for seat in range(1, 7)}
+        hud.layout.common = (5, 6)
+        aux = AuxSeats(hud, Mock(), {})
+        aux.adj = dict.fromkeys(range(1, 7), 1) | {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6}
+        aux.m_windows = {seat: Mock() for seat in range(1, 7)} | {"common": Mock()}
+
+        aux.resize_windows()
+
+        assert aux.positions[1] == (10, 20)
+        assert aux.positions[6] == (60, 120)
+        assert aux.positions["common"] == (5, 6)
+        aux.m_windows[1].move.assert_called_once()

--- a/test/test_aux_uncreated_windows.py
+++ b/test/test_aux_uncreated_windows.py
@@ -48,7 +48,7 @@ def uncreated() -> AuxSeats:
 
 class TestBeforeCreate:
     def test_the_seat_map_exists_and_is_empty(self, uncreated: AuxSeats) -> None:
-        assert uncreated.adj == {}
+        assert uncreated.adj == []
         assert uncreated.m_windows == {}
 
     def test_resizing_is_a_no_op(self, uncreated: AuxSeats) -> None:
@@ -76,7 +76,7 @@ class TestAfterCreate:
         hud.layout.location = {seat: (seat * 10, seat * 20) for seat in range(1, 7)}
         hud.layout.common = (5, 6)
         aux = AuxSeats(hud, Mock(), {})
-        aux.adj = dict.fromkeys(range(1, 7), 1) | {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6}
+        aux.adj = list(range(7))  # identity: seat N sits at layout slot N
         aux.m_windows = {seat: Mock() for seat in range(1, 7)} | {"common": Mock()}
 
         aux.resize_windows()

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -160,7 +160,6 @@ def test_hud_base_path_is_module_dir_and_holds_hud_main():
 @pytest.mark.parametrize(
     ("platform_name", "os_name", "executable_name"),
     [
-        ("darwin", "posix", "HUD_main"),
         ("linux", "posix", "HUD_main"),
         ("win32", "nt", "HUD_main.exe"),
     ],
@@ -192,6 +191,29 @@ def test_launch_hud_uses_bundled_sibling_executable(monkeypatch, tmp_path, platf
     assert command == [str(hud_executable), "--config", "bundled.xml"]
     popen_kwargs = mock_popen.call_args.kwargs
     assert popen_kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+
+
+def test_launch_hud_pyinstaller_macos_reuses_main_app_identity(monkeypatch, tmp_path):
+    """The HUD must share fpdb.app's TCC grants instead of using a sibling identity."""
+    settings = _make_settings(MagicMock())
+    settings["cl_options"] = "--config bundled.xml"
+    config = _make_config()
+    config.install_method = "app"
+    gui = _make_gui(settings, config)
+
+    gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
+    fpdb_executable = tmp_path / "fpdb"
+    fpdb_executable.touch()
+    monkeypatch.setattr(gui_mod.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(gui_mod.sys, "executable", str(fpdb_executable))
+    monkeypatch.setattr(gui_mod.sys, "platform", "darwin")
+
+    with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        gui._launch_hud()
+
+    command = mock_popen.call_args.args[0]
+    assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
+    assert mock_popen.call_args.kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
 
 
 def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -213,7 +213,9 @@ def test_launch_hud_pyinstaller_macos_reuses_main_app_identity(monkeypatch, tmp_
 
     command = mock_popen.call_args.args[0]
     assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
-    assert mock_popen.call_args.kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    child_env = mock_popen.call_args.kwargs["env"]
+    assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert child_env["FPDB_REQUEST_MACOS_PERMISSIONS"] == "1"
 
 
 def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
@@ -232,7 +234,7 @@ def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
 
     command = mock_popen.call_args.args[0]
     assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
-    assert "env" not in mock_popen.call_args.kwargs
+    assert mock_popen.call_args.kwargs["env"]["FPDB_REQUEST_MACOS_PERMISSIONS"] == "1"
 
 
 def test_check_hud_process_started_clears_terminated_process():

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -228,6 +228,7 @@ def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
     fpdb_executable = tmp_path / "fpdb"
     monkeypatch.setattr(gui_mod.sys, "frozen", "pyoxidizer", raising=False)
     monkeypatch.setattr(gui_mod.sys, "executable", str(fpdb_executable))
+    monkeypatch.setattr(gui_mod.sys, "platform", "darwin")
 
     with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
         gui._launch_hud()
@@ -235,6 +236,22 @@ def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
     command = mock_popen.call_args.args[0]
     assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
     assert mock_popen.call_args.kwargs["env"]["FPDB_REQUEST_MACOS_PERMISSIONS"] == "1"
+
+
+def test_launch_hud_pyoxidizer_non_macos_does_not_request_macos_permissions(monkeypatch, tmp_path):
+    settings = _make_settings(MagicMock())
+    settings["cl_options"] = ""
+    gui = _make_gui(settings, _make_config())
+
+    gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
+    monkeypatch.setattr(gui_mod.sys, "frozen", "pyoxidizer", raising=False)
+    monkeypatch.setattr(gui_mod.sys, "executable", str(tmp_path / "fpdb"))
+    monkeypatch.setattr(gui_mod.sys, "platform", "linux")
+
+    with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        gui._launch_hud()
+
+    assert "env" not in mock_popen.call_args.kwargs
 
 
 def test_check_hud_process_started_clears_terminated_process():

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -215,7 +215,9 @@ def test_launch_hud_pyinstaller_macos_reuses_main_app_identity(monkeypatch, tmp_
     assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
     child_env = mock_popen.call_args.kwargs["env"]
     assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
-    assert child_env["FPDB_REQUEST_MACOS_PERMISSIONS"] == "1"
+    # Finding table windows no longer depends on macOS Accessibility, so the
+    # HUD must not push the user at System Settings on every launch.
+    assert "FPDB_REQUEST_MACOS_PERMISSIONS" not in child_env
 
 
 def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
@@ -235,7 +237,7 @@ def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):
 
     command = mock_popen.call_args.args[0]
     assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
-    assert mock_popen.call_args.kwargs["env"]["FPDB_REQUEST_MACOS_PERMISSIONS"] == "1"
+    assert "env" not in mock_popen.call_args.kwargs
 
 
 def test_launch_hud_pyoxidizer_non_macos_does_not_request_macos_permissions(monkeypatch, tmp_path):

--- a/test/test_subprocess_launch.py
+++ b/test/test_subprocess_launch.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import pytest
 
 from fpdb_3_legacy.subprocess_launch import (
+    HUD_FLAG,
     RUN_MODULE_FLAG,
+    dispatch_hud_main,
     dispatch_run_module,
     hud_main_command,
     python_module_command,
@@ -39,8 +41,16 @@ def test_hud_command_uses_pyoxidizer_subcommand(monkeypatch) -> None:
     assert hud_main_command("-x") == [sys.executable, "--hud", "-x"]
 
 
+def test_hud_command_reuses_main_executable_for_pyinstaller_macos(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    assert hud_main_command("-x") == [sys.executable, HUD_FLAG, "-x"]
+
+
 def test_hud_command_uses_sibling_executable_when_frozen(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "win32" if os.name == "nt" else "linux")
     monkeypatch.setattr(sys, "executable", str(tmp_path / "fpdb"))
     hud = tmp_path / ("HUD_main.exe" if os.name == "nt" else "HUD_main")
     hud.write_text("")
@@ -53,6 +63,7 @@ def test_hud_command_uses_sibling_executable_when_frozen(monkeypatch, tmp_path) 
 
 def test_hud_command_reports_missing_packaged_executable(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "win32" if os.name == "nt" else "linux")
     monkeypatch.setattr(sys, "executable", str(tmp_path / "fpdb"))
 
     with pytest.raises(FileNotFoundError):
@@ -98,8 +109,7 @@ def test_dispatch_runs_the_requested_module(monkeypatch, tmp_path) -> None:
     module_dir.mkdir()
     (module_dir / "__init__.py").write_text("")
     (module_dir / "mod.py").write_text(
-        "import sys, pathlib\n"
-        "pathlib.Path(sys.argv[1]).write_text(f'{__name__}|{sys.argv[2]}')\n",
+        "import sys, pathlib\npathlib.Path(sys.argv[1]).write_text(f'{__name__}|{sys.argv[2]}')\n",
     )
     monkeypatch.syspath_prepend(str(tmp_path))
     marker = tmp_path / "ran.txt"
@@ -107,3 +117,14 @@ def test_dispatch_runs_the_requested_module(monkeypatch, tmp_path) -> None:
 
     assert dispatch_run_module() is True
     assert marker.read_text() == "__main__|--live"
+
+
+def test_dispatch_hud_main_runs_packaged_script_with_forwarded_args(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["fpdb", HUD_FLAG, "--config", "bundled.xml"])
+
+    monkeypatch.setattr("fpdb_3_legacy.subprocess_launch.runpy.run_path", lambda *args, **kwargs: None)
+
+    assert dispatch_hud_main() is True
+
+    assert Path(sys.argv[0]).name == "HUD_main.pyw"
+    assert sys.argv[1:] == ["--config", "bundled.xml"]

--- a/test/test_winamax_ax_seats.py
+++ b/test/test_winamax_ax_seats.py
@@ -7,8 +7,13 @@ ordering them the way the client draws them.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from fpdb_3_legacy import winamax_ax_seats
 from fpdb_3_legacy.winamax_ax_seats import (
     AXSeat,
+    AXTableWindow,
+    WinamaxAXSeatReader,
     is_stack_label,
     seat_slots_from_positions,
     seats_from_labels,
@@ -178,3 +183,116 @@ def test_the_pot_label_does_not_take_a_seat() -> None:
     ]
 
     assert [s.login for s in seats_from_labels(labels)] == ["Hero", "Player08"]
+
+
+class TestFindTableWindowWithoutAccessibility:
+    """A packaged build holds no macOS Accessibility grant, so the API answers nothing.
+
+    Table windows must still be found -- otherwise the Fast-Fold HUD silently
+    waits for the hand history and appears seconds late.
+    """
+
+    @staticmethod
+    def _reader(monkeypatch, titles: list[str]) -> WinamaxAXSeatReader:
+        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
+        # The accessibility API is reachable but returns nothing, which is what
+        # macOS does for a process that was never granted Accessibility.
+        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: None)
+        monkeypatch.setattr(winamax_ax_seats, "applescript_window_titles", lambda: titles)
+        return WinamaxAXSeatReader()
+
+    def test_window_is_found_through_system_events(self, monkeypatch) -> None:
+        reader = self._reader(monkeypatch, ["Winamax", "Winamax Colorado 4"])
+
+        window = reader.find_table_window("4")
+
+        assert window is not None
+        assert window.title == "Winamax Colorado 4"
+        assert window.table_name == "Colorado 4"
+        # System Events cannot read the client's header, so the game is unknown
+        # and the caller supplies it from an imported hand.
+        assert window.poker_game is None
+
+    def test_only_the_window_carrying_the_client_index_matches(self, monkeypatch) -> None:
+        reader = self._reader(monkeypatch, ["Winamax Colorado 3", "Winamax Colorado 4"])
+
+        assert reader.find_table_window("3").title == "Winamax Colorado 3"
+        assert reader.find_table_window("9") is None
+
+    def test_lobby_alone_is_not_a_table(self, monkeypatch) -> None:
+        reader = self._reader(monkeypatch, ["Winamax"])
+
+        assert reader.find_table_window("1") is None
+
+    def test_the_scan_is_throttled(self, monkeypatch) -> None:
+        """Hands start faster than osascript returns, so it must not run per hand."""
+        calls = []
+        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: None)
+        monkeypatch.setattr(
+            winamax_ax_seats,
+            "applescript_window_titles",
+            lambda: (calls.append(1), ["Winamax Colorado 4"])[1],
+        )
+        reader = WinamaxAXSeatReader()
+
+        for _ in range(5):
+            assert reader.find_table_window("4") is not None
+
+        assert len(calls) == 1
+
+    def test_the_accessibility_answer_is_preferred(self, monkeypatch) -> None:
+        """It carries the header, which names the game; System Events cannot."""
+        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
+        from_ax = AXTableWindow(title="Winamax Colorado 4", description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha")
+        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: from_ax)
+
+        def unreachable() -> list[str]:
+            msg = "System Events must not be consulted when the API answered"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(winamax_ax_seats, "applescript_window_titles", unreachable)
+
+        assert WinamaxAXSeatReader().find_table_window("4").poker_game == "omahahi"
+
+    def test_nothing_is_attempted_off_macos(self, monkeypatch) -> None:
+        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Linux")
+
+        assert WinamaxAXSeatReader().find_table_window("4") is None
+
+
+class TestApplescriptWindowTitles:
+    def test_a_refused_scan_is_not_an_error(self, monkeypatch) -> None:
+        """Automation may be denied too; the caller then waits for an import."""
+        monkeypatch.setattr(
+            winamax_ax_seats.subprocess,
+            "run",
+            lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="not authorized"),
+        )
+
+        assert winamax_ax_seats.applescript_window_titles() == []
+
+    def test_titles_are_split_and_stripped(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            winamax_ax_seats.subprocess,
+            "run",
+            lambda *_a, **_k: SimpleNamespace(
+                returncode=0,
+                stdout="Winamax, Winamax Colorado 3, Winamax Colorado 4\n",
+                stderr="",
+            ),
+        )
+
+        assert winamax_ax_seats.applescript_window_titles() == [
+            "Winamax",
+            "Winamax Colorado 3",
+            "Winamax Colorado 4",
+        ]
+
+    def test_a_timeout_is_survivable(self, monkeypatch) -> None:
+        def timeout(*_a, **_k):
+            raise winamax_ax_seats.subprocess.TimeoutExpired(cmd="osascript", timeout=5)
+
+        monkeypatch.setattr(winamax_ax_seats.subprocess, "run", timeout)
+
+        assert winamax_ax_seats.applescript_window_titles() == []

--- a/test/test_winamax_pool_games.py
+++ b/test/test_winamax_pool_games.py
@@ -1,0 +1,115 @@
+"""Unit tests for remembering which game a Winamax Fast-Fold pool deals.
+
+The window states the game only to a process holding macOS Accessibility, which
+packaged builds do not hold. What an imported hand proved has to survive, or the
+Fast-Fold HUD pays a hand's delay on every pool, every session.
+"""
+
+from __future__ import annotations
+
+from fpdb_3_legacy.winamax_pool_games import MAX_POOLS, WinamaxPoolGames, pool_name
+
+
+class TestPoolName:
+    def test_the_client_window_index_is_not_part_of_the_pool(self) -> None:
+        assert pool_name("Colorado 4") == "Colorado"
+        assert pool_name("Colorado") == "Colorado"
+        assert pool_name("Casablanca 12") == "Casablanca"
+
+    def test_a_number_inside_the_name_is_kept(self) -> None:
+        assert pool_name("Colorado 2 Deluxe") == "Colorado 2 Deluxe"
+
+    def test_a_name_that_merely_ends_in_a_digit_is_kept(self) -> None:
+        """The client always puts a space before the window index."""
+        assert pool_name("Pool4") == "Pool4"
+
+    def test_nothing_is_not_a_pool(self) -> None:
+        assert pool_name("") == ""
+        assert pool_name(None) == ""
+
+
+class TestRecall:
+    def test_every_window_of_a_pool_shares_what_was_learned(self, tmp_path) -> None:
+        store = WinamaxPoolGames(tmp_path / "pools.json")
+
+        store.remember("Colorado", "omahahi")
+
+        assert store.get("Colorado 4") == "omahahi"
+        assert store.get("Colorado 1") == "omahahi"
+
+    def test_an_unknown_pool_is_not_guessed(self, tmp_path) -> None:
+        store = WinamaxPoolGames(tmp_path / "pools.json")
+
+        assert store.get("Casablanca 6") is None
+
+    def test_what_a_hand_proved_outlives_the_session(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        WinamaxPoolGames(path).remember("Colorado 4", "omahahi")
+
+        assert WinamaxPoolGames(path).get("Colorado 2") == "omahahi"
+
+    def test_a_pool_that_changes_game_is_re_learned(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        store = WinamaxPoolGames(path)
+
+        store.remember("Colorado", "holdem")
+        store.remember("Colorado", "omahahi")
+
+        assert WinamaxPoolGames(path).get("Colorado") == "omahahi"
+
+    def test_nothing_is_recorded_without_both_halves(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        store = WinamaxPoolGames(path)
+
+        store.remember("Colorado", "")
+        store.remember("", "omahahi")
+
+        assert not path.exists()
+
+    def test_the_file_cannot_grow_without_bound(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        store = WinamaxPoolGames(path)
+
+        for i in range(MAX_POOLS + 10):
+            store.remember(f"Pool{i}", "holdem")
+
+        reloaded = WinamaxPoolGames(path)
+        kept = [i for i in range(MAX_POOLS + 10) if reloaded.get(f"Pool{i}") is not None]
+        assert len(kept) == MAX_POOLS
+        # The most recent survive; the pools longest untouched are dropped.
+        assert kept[0] == 10
+        assert kept[-1] == MAX_POOLS + 9
+
+
+class TestDegradedStorage:
+    def test_a_corrupt_file_is_ignored_rather_than_fatal(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        store = WinamaxPoolGames(path)
+
+        assert store.get("Colorado") is None
+        store.remember("Colorado", "holdem")
+        assert store.get("Colorado") == "holdem"
+
+    def test_a_file_holding_something_else_is_ignored(self, tmp_path) -> None:
+        path = tmp_path / "pools.json"
+        path.write_text('["Colorado"]', encoding="utf-8")
+
+        assert WinamaxPoolGames(path).get("Colorado") is None
+
+    def test_no_config_directory_still_works_in_memory(self) -> None:
+        store = WinamaxPoolGames(None)
+
+        store.remember("Colorado", "omahahi")
+
+        assert store.get("Colorado 4") == "omahahi"
+
+    def test_an_unwritable_path_does_not_raise(self, tmp_path) -> None:
+        blocker = tmp_path / "blocker"
+        blocker.write_text("", encoding="utf-8")
+        store = WinamaxPoolGames(blocker / "sub" / "pools.json")
+
+        store.remember("Colorado", "omahahi")
+
+        assert store.get("Colorado") == "omahahi"


### PR DESCRIPTION
## Cause réelle

Ce n'est ni le coût de démarrage des exécutables (0,47 s / 0,49 s), ni un module absent des bundles : `ApplicationServices` et ses dépendances sont bien empaquetés dans les deux builds.

Le Fast HUD ne peut être construit qu'une fois la fenêtre nommée par `find_table_window`, et cette fonction n'utilisait **que l'API d'accessibilité macOS**, qui exige que le binaire appelant détienne l'autorisation **Accessibility**.

- Un lancement depuis les sources hérite de cette autorisation du terminal qui l'a démarré : le chemin rapide atteint `hud-created` en 145–623 ms.
- Chaque build packagé est un binaire neuf, à un chemin neuf : macOS le traite comme un nouveau client TCC. Or **macOS ne demande jamais Accessibility** — l'autorisation est donc simplement absente, chaque appel AX ne renvoie rien, `find_table_window` renvoie `None`, et le HUD retombe sur l'attente de l'historique de main : **5 à 54 s** dans les traces.

La preuve est dans un même processus, à 24 s d'intervalle :

```
16:46:16  _ensure_fast_fold_hud  create-deferred  ... is not accessible
16:46:40  HUD attach: table='Colorado 4' title='Winamax Colorado 4' geometry=(0,33 757x592)
```

L'attache réussit parce que le reste de fpdb passe par **System Events**, qui ne demande que l'autorisation **Automation** — celle-là, macOS la demande automatiquement. Quartz ne peut pas remplacer l'AX : Winamax est un client Electron et n'expose aucun titre de fenêtre par ce biais (vérifié en direct : `kCGWindowName` vide).

## Correctif

- `find_table_window` retombe sur System Events quand l'API d'accessibilité ne répond pas, avec throttling à un scan par seconde (chaque `osascript` coûte ~200 ms, les mains démarrent plus vite).
- System Events donne le titre mais pas l'en-tête du client, d'où vient le jeu. Le jeu qu'une main importée a prouvé est donc mémorisé par pool dans `~/.fpdb/winamax_pool_games.json` : l'attente est payée une fois par pool, au lieu d'une fois par main.
- L'API d'accessibilité reste prioritaire quand elle répond : elle seule donne l'en-tête.

## Crash corrigé

`idle_create` saute volontairement `create()` pour un HUD de chargement, ce qui laisse ses fenêtres auxiliaires sans carte des sièges. Un déplacement ou un redimensionnement de table levait alors :

```
AttributeError: 'ClassicHud' object has no attribute 'adj'
  Aux_Base.py:510 in resize_windows
```

Une auxiliaire non créée n'a désormais rien à placer plutôt que de lever.

## Retrait

Le forçage de `FPDB_REQUEST_MACOS_PERMISSIONS=1` ajouté à l'itération précédente est retiré : il ouvrait les panneaux des Réglages Système à chaque lancement du HUD packagé, et n'est plus nécessaire. La variable reste disponible en opt-in.

## Validation

- 6 488 tests + 623 tests Qt : OK
- Ruff `check` : OK ; `format` : propre sur les fichiers touchés
- mypy sur les modules nouveaux/modifiés : OK
- Repli System Events vérifié contre le client Winamax en cours d'exécution, throttling compris (20 recherches consécutives : 0 ms)
