### PR TITLE
chore(release): prepare 3.6.2

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.6.1"
+__version__ = "3.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.6.1"
+version = "3.6.2"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.6.1"
+version = "3.6.2"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.6.1"
+version = "3.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump de version pour la release corrective 3.6.2. Aucun changement fonctionnel : uniquement les quatre marqueurs utilisés par Python, Briefcase et le lockfile.

| Fichier | Ligne |
| --- | --- |
| `pyproject.toml` | 7 (`[project]`), 264 (`[tool.briefcase]`) |
| `fpdb_3_legacy/__init__.py` | 16 (`__version__`) |
| `uv.lock` | 602 (paquet `fpdb-3`) |

## Contenu de la release

Corrections du Fast HUD en mode packagé sur macOS ([#218](https://github.com/jejellyroll-fr/fpdb-3/pull/218), fusionnée) :

- **Le Fast HUD n'attend plus l'import de l'historique.** `find_table_window` n'utilisait que l'API d'accessibilité macOS, qui exige que le binaire appelant détienne *Accessibility* — permission que macOS ne demande jamais et qu'un build packagé, binaire neuf à un chemin neuf, n'a donc jamais. Chaque appel revenait vide et le HUD retombait sur l'historique de main : 5 à 54 s dans les traces, alors qu'un lancement depuis les sources hérite de la permission de son terminal et atteint `hud-created` en 145–623 ms. Le repli passe désormais par System Events, qui ne demande que *Automation* — celle-là, macOS la demande automatiquement, et c'est déjà ce dont le reste de fpdb dépend pour trouver ces mêmes fenêtres.
- **Le jeu d'un pool est mémorisé.** System Events donne le titre de la fenêtre mais pas l'en-tête du client, d'où vient le jeu. Ce que prouve une main importée est conservé dans `~/.fpdb/winamax_pool_games.json` : l'attente est payée une fois par pool, au lieu d'une fois par main.
- **Crash au redimensionnement corrigé.** `idle_create` saute volontairement `create()` pour un HUD de chargement, laissant ses fenêtres auxiliaires sans carte des sièges ; un déplacement ou redimensionnement de table levait alors `AttributeError: 'ClassicHud' object has no attribute 'adj'`. Une auxiliaire non créée n'a désormais rien à placer.
- **Retrait du forçage `FPDB_REQUEST_MACOS_PERMISSIONS=1`**, qui ouvrait les Réglages Système à chaque lancement du HUD packagé et n'a plus lieu d'être. La variable reste disponible en opt-in.
- **Durcissement.** Le scan System Events s'exécute depuis `/usr/bin/osascript`, chemin absolu, donc insensible au `PATH` hérité par l'application.

## Validation de #218

22/22 checks verts (Codacy compris, 0 problème), dont les six builds PyInstaller et PyOxidizer. Bundle PyInstaller macOS ARM64 reconstruit et testé localement : démarrage à froid 1,5 s, les trois correctifs présents dans le bundle.
