### PR TITLE
fix(macos): start the packaged HUD and let it see table windows again

### DIFF
--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -515,6 +515,7 @@ class MacOSTableDetector:
             script = "\n".join(script_lines)
             # Absolute path, fixed argv, no shell. The script is built above
             # from a constant list of process names, never from window content.
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
             result = subprocess.run(  # noqa: S603  # nosec B603
                 [self._OSASCRIPT, "-e", script],
                 capture_output=True,

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -437,6 +437,9 @@ class MacOSTableDetector:
                 return window
         return None
 
+    _OSASCRIPT = "/usr/bin/osascript"
+    """Absolute, so the scan cannot be diverted by whatever PATH the app inherited."""
+
     _APPLESCRIPT_TIMEOUT = 5.0
 
     _AUTOMATION_BLOCKED_MARKERS = (
@@ -510,8 +513,10 @@ class MacOSTableDetector:
             )
 
             script = "\n".join(script_lines)
-            result = subprocess.run(
-                ["osascript", "-e", script],
+            # Absolute path, fixed argv, no shell. The script is built above
+            # from a constant list of process names, never from window content.
+            result = subprocess.run(  # noqa: S603  # nosec B603
+                [self._OSASCRIPT, "-e", script],
                 capture_output=True,
                 text=True,
                 timeout=self._APPLESCRIPT_TIMEOUT,

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -437,6 +437,31 @@ class MacOSTableDetector:
                 return window
         return None
 
+    _APPLESCRIPT_TIMEOUT = 5.0
+
+    _AUTOMATION_BLOCKED_MARKERS = (
+        "-1743",  # not authorised to send Apple events
+        "-1712",  # the Automation prompt is up and unanswered, so the event timed out
+        "Not authorized to send Apple events",
+        "AppleEvent timed out",
+    )
+
+    def _report_automation_blocked(self, detail: str) -> None:
+        """Stop scanning, and say once why no table window can be read."""
+        self._automation_blocked = True
+        if self._automation_warned:
+            return
+        self._automation_warned = True
+        logger.warning(
+            "Poker table windows cannot be read: this application is not allowed to control "
+            "'System Events' (Automation). On macOS that is the only way to read an Electron "
+            "client's window title -- Quartz never exposes one -- so the HUD cannot find its "
+            "table. Allow it in System Settings > Privacy & Security > Automation "
+            "(FPDB -> System Events) and restart FPDB. If FPDB is not listed there, run "
+            "'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS asks again. Detail: %s",
+            detail,
+        )
+
     def _run_applescript_scan(self) -> None:
         """Execute the full AppleScript scan and populate the cache.
 
@@ -485,7 +510,12 @@ class MacOSTableDetector:
             )
 
             script = "\n".join(script_lines)
-            result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True, timeout=5)
+            result = subprocess.run(
+                ["osascript", "-e", script],
+                capture_output=True,
+                text=True,
+                timeout=self._APPLESCRIPT_TIMEOUT,
+            )
 
             logger.debug(
                 "DIAGNOSTIC: AppleScript exited with code %d. Output len: %d. Error: '%s'",
@@ -501,26 +531,9 @@ class MacOSTableDetector:
                 # thing for us -- no window titles until the user allows it --
                 # and both must stop the scan, or every table lookup pays a
                 # multi-second timeout.
-                blocked = any(
-                    marker in stderr
-                    for marker in ("-1743", "-1712", "Not authorized to send Apple events", "AppleEvent timed out")
-                )
-                if blocked:
-                    self._automation_blocked = True
-                if blocked and not self._automation_warned:
-                    self._automation_warned = True
-                    logger.warning(
-                        "Poker table windows cannot be read: this application is not allowed "
-                        "to control 'System Events' (Automation). On macOS that is the only "
-                        "way to read an Electron client's window title -- Quartz never exposes "
-                        "one -- so the HUD cannot find its table. Allow it in System Settings > "
-                        "Privacy & Security > Automation (FPDB -> System Events) and restart "
-                        "FPDB. If FPDB is not listed there, run "
-                        "'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS asks again. "
-                        "osascript error: %s",
-                        stderr,
-                    )
-                elif not blocked:
+                if any(marker in stderr for marker in self._AUTOMATION_BLOCKED_MARKERS):
+                    self._report_automation_blocked(stderr)
+                else:
                     logger.debug("AppleScript window scan failed: %s", stderr)
 
             if result.returncode == 0 and result.stdout.strip():
@@ -558,6 +571,12 @@ class MacOSTableDetector:
                             self._applescript_last_result.append(table_info)
                             self._applescript_cache[window_id] = table_info
 
+        except subprocess.TimeoutExpired:
+            # An unanswered Automation prompt blocks osascript rather than
+            # failing it, so this never reaches the return-code handling above.
+            # Left uncounted it is the worst case of all: every table lookup
+            # pays the full timeout again.
+            self._report_automation_blocked(f"osascript did not return within {self._APPLESCRIPT_TIMEOUT:.0f}s")
         except Exception as e:
             logger.error(f"Error in _run_applescript_scan: {e}", exc_info=True)
 
@@ -573,7 +592,11 @@ class MacOSTableDetector:
         import time
 
         now = time.monotonic()
-        if not self._applescript_last_result or (now - self._applescript_last_scan) >= self._applescript_scan_ttl:
+        # The TTL applies to an empty result too. Re-scanning whenever the last
+        # one found nothing sounds harmless, but "nothing" is exactly what a
+        # refused or hanging scan returns -- so the one case that must not
+        # repeat was the one case that repeated on every single lookup.
+        if (now - self._applescript_last_scan) >= self._applescript_scan_ttl:
             self._run_applescript_scan()
 
         try:

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -94,6 +94,12 @@ class MacOSTableDetector:
         self._permission_status: permissions.PermissionStatus | None = None
         self._automation_warned = False
 
+        # Set once System Events has told us this process may not drive it.
+        # Until it does, the scan is always worth trying: Automation is the one
+        # grant macOS prompts for, so a refusal now can become a grant later --
+        # but only after a restart, which clears this too.
+        self._automation_blocked = False
+
         # Lazy-import macOS dependencies
         try:
             from AppKit import NSWorkspace
@@ -287,18 +293,19 @@ class MacOSTableDetector:
                 )
                 return [pid_match]
 
-        permission_status = self._check_permissions_once()
+        self._check_permissions_once()
         if not (total_windows > 0 and titled_windows == 0):
             logger.debug("DIAGNOSTIC: No Quartz window matched the search string. Trying AppleScript fallback...")
-        # System Events takes around two seconds to reject an untrusted app.
-        # Fast-Fold can hit this path several times for one newly imported hand,
-        # so do not make a synchronous call that the native permission check has
-        # already told us cannot succeed.
+        # Not gated on Accessibility: driving System Events needs *Automation*,
+        # which is a different grant and the only one macOS actually prompts
+        # for. Gating on Accessibility switched this scan off in every packaged
+        # build -- and for an Electron client like Winamax it is the only way
+        # left to read a window title, Quartz never exposing one. The cost it
+        # was meant to avoid is instead avoided by stopping once System Events
+        # has actually refused us.
         applescript_tables = []
-        if permission_status.accessibility:
+        if not self._automation_blocked:
             applescript_tables = self.find_tables_applescript(search_string)
-        else:
-            logger.debug("Skipping AppleScript table scan because Accessibility permission is unavailable")
         if applescript_tables:
             logger.debug(f"DIAGNOSTIC: AppleScript fallback found {len(applescript_tables)} matching tables")
             return applescript_tables
@@ -487,18 +494,34 @@ class MacOSTableDetector:
                 result.stderr.strip(),
             )
 
-            if result.returncode != 0 and not self._automation_warned:
+            if result.returncode != 0:
                 stderr = result.stderr.strip()
-                if "-1743" in stderr or "Not authorized to send Apple events" in stderr:
+                # -1743: refused outright. -1712: the Automation prompt is on
+                # screen unanswered, so the event timed out. Both mean the same
+                # thing for us -- no window titles until the user allows it --
+                # and both must stop the scan, or every table lookup pays a
+                # multi-second timeout.
+                blocked = any(
+                    marker in stderr
+                    for marker in ("-1743", "-1712", "Not authorized to send Apple events", "AppleEvent timed out")
+                )
+                if blocked:
+                    self._automation_blocked = True
+                if blocked and not self._automation_warned:
                     self._automation_warned = True
                     logger.warning(
-                        "AppleScript fallback is blocked: this app is not allowed to "
-                        "control 'System Events' (Automation). Grant it in System "
-                        "Settings > Privacy & Security > Automation (allow FPDB/your "
-                        "terminal to control System Events), then restart FPDB. "
+                        "Poker table windows cannot be read: this application is not allowed "
+                        "to control 'System Events' (Automation). On macOS that is the only "
+                        "way to read an Electron client's window title -- Quartz never exposes "
+                        "one -- so the HUD cannot find its table. Allow it in System Settings > "
+                        "Privacy & Security > Automation (FPDB -> System Events) and restart "
+                        "FPDB. If FPDB is not listed there, run "
+                        "'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS asks again. "
                         "osascript error: %s",
                         stderr,
                     )
+                elif not blocked:
+                    logger.debug("AppleScript window scan failed: %s", stderr)
 
             if result.returncode == 0 and result.stdout.strip():
                 windows_str = result.stdout.strip()

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -720,9 +720,8 @@ class GuiAutoImport(QWidget):
         # ------------------------------------------------------------------
         command: str | list[str]
         frozen = getattr(sys, "frozen", False)
-        if frozen == "pyoxidizer" or (frozen and sys.platform == "darwin"):
-            # On macOS the HUD must retain fpdb.app's code identity so its
-            # Screen Recording and Accessibility grants remain valid.
+        if frozen == "pyoxidizer":
+            # A single binary hosts both entry points; --hud selects HUD_main.
             command = [sys.executable, "--hud", *self.settings["cl_options"].split()]
             bs = 1
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from optparse import Values
 from pathlib import Path
 from queue import Empty, Queue
+from types import ModuleType
 from typing import Any
 
 import zmq as _zmq
@@ -579,24 +580,33 @@ class HudMain(QObject):
         self.config = Configuration.Config(file=options.config, dbname=options.dbname)
         log.info("HUD_main initialized - Config loaded, OS family: %s", self.config.os_family)
 
-        # Selecting the right module for the OS. Imported through the package,
-        # not as bare top-level modules: the frozen macOS build runs the HUD
-        # inside the fpdb executable, whose analysis only ever saw
-        # "fpdb_3_legacy.*" imports, so a bare "import OSXTables" is not in its
-        # archive and the HUD dies on startup with ModuleNotFoundError.
+        # Selecting the right module for the OS. Imported through the package
+        # rather than as bare top-level modules: a bare "import OSXTables" only
+        # resolves because the repository root happens to be on sys.path, which
+        # is true of a source checkout and of HUD_main's own frozen archive, but
+        # not of every way this file can be run. Each import stays inside its
+        # branch -- the other two backends need bindings this platform lacks --
+        # and the module is bound once, so mypy sees a single definition.
+        tables: ModuleType
         if self.config.os_family == "Linux":
             # Simplified: XWayland support or X11 fallback
             if os.getenv("QT_QPA_PLATFORM") == "xcb" or not os.environ.get("WAYLAND_DISPLAY"):
                 log.info("XWayland forced under wayland → backend XTables")
             else:
                 log.info("Session X11 detected → backend XTables")
-            from fpdb_3_legacy import XTables as Tables
+            from fpdb_3_legacy import XTables
+
+            tables = XTables
         elif self.config.os_family == "Mac":
-            from fpdb_3_legacy import OSXTables as Tables
+            from fpdb_3_legacy import OSXTables
+
+            tables = OSXTables
         elif self.config.os_family in ("XP", "Win7"):
-            from fpdb_3_legacy import WinTables as Tables
+            from fpdb_3_legacy import WinTables
+
+            tables = WinTables
         log.info("HudMain starting: Using db name = %s", db_name)
-        self.Tables = Tables  # Assign Tables to self.Tables
+        self.Tables = tables
 
         # Surface missing macOS privacy permissions at startup so table-detection
         # failures ("table name ... not found") are explained before the first hand.

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -579,19 +579,22 @@ class HudMain(QObject):
         self.config = Configuration.Config(file=options.config, dbname=options.dbname)
         log.info("HUD_main initialized - Config loaded, OS family: %s", self.config.os_family)
 
-        # Selecting the right module for the OS
+        # Selecting the right module for the OS. Imported through the package,
+        # not as bare top-level modules: the frozen macOS build runs the HUD
+        # inside the fpdb executable, whose analysis only ever saw
+        # "fpdb_3_legacy.*" imports, so a bare "import OSXTables" is not in its
+        # archive and the HUD dies on startup with ModuleNotFoundError.
         if self.config.os_family == "Linux":
             # Simplified: XWayland support or X11 fallback
             if os.getenv("QT_QPA_PLATFORM") == "xcb" or not os.environ.get("WAYLAND_DISPLAY"):
                 log.info("XWayland forced under wayland → backend XTables")
-                import XTables as Tables
             else:
                 log.info("Session X11 detected → backend XTables")
-                import XTables as Tables
+            from fpdb_3_legacy import XTables as Tables
         elif self.config.os_family == "Mac":
-            import OSXTables as Tables
+            from fpdb_3_legacy import OSXTables as Tables
         elif self.config.os_family in ("XP", "Win7"):
-            import WinTables as Tables
+            from fpdb_3_legacy import WinTables as Tables
         log.info("HudMain starting: Using db name = %s", db_name)
         self.Tables = Tables  # Assign Tables to self.Tables
 

--- a/fpdb_3_legacy/TableWindow.py
+++ b/fpdb_3_legacy/TableWindow.py
@@ -104,6 +104,11 @@ class Table_Window:
         self.gdkhandle: Any = None
         self.number: Any = None
         self.title = ""
+        # Filled in by HUD_main once the window is paired with a HUD: the key it
+        # files the HUD under, and the table size it was matched at. Declared
+        # here because Hud and the aux windows both read them back.
+        self.key = ""
+        self.max: int | None = None
         self.name = ""
         self.type = ""
         self.tournament: int | None = None

--- a/fpdb_3_legacy/subprocess_launch.py
+++ b/fpdb_3_legacy/subprocess_launch.py
@@ -39,11 +39,8 @@ def hud_main_command(*args: str) -> list[str]:
         FileNotFoundError: when a packaged build has no HUD_main next to it.
     """
     frozen = getattr(sys, "frozen", False)
-    if frozen == "pyoxidizer" or (frozen and sys.platform == "darwin"):
-        # Keep the macOS HUD under the main app's code identity. TCC grants
-        # Screen Recording and Accessibility to that identity; a separately
-        # frozen sibling has another designated requirement and loses both
-        # permissions even though it lives inside fpdb.app.
+    if frozen == "pyoxidizer":
+        # A single binary hosts both entry points; --hud selects HUD_main.
         return [sys.executable, HUD_FLAG, *args]
     if frozen:
         # PyInstaller ships HUD_main as a sibling executable of fpdb.

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -62,6 +62,37 @@ APPLESCRIPT_TIMEOUT = 5.0
 OSASCRIPT = "/usr/bin/osascript"
 """Absolute, so the scan cannot be diverted by whatever PATH the app inherited."""
 
+AUTOMATION_REFUSED_MARKERS = (
+    "-1743",  # not authorised to send Apple events
+    "-1712",  # the Automation prompt is up and unanswered, so the event timed out
+    "Not authorized to send Apple events",
+    "AppleEvent timed out",
+)
+
+_automation_refused = False
+"""Whether System Events has already turned this process away.
+
+Reset by restarting, which is also what granting the permission requires.
+"""
+
+
+def _report_automation_refused(detail: str) -> None:
+    """Say once, at WARNING, that no table window can be read and why."""
+    global _automation_refused
+    if _automation_refused:
+        return
+    _automation_refused = True
+    log.warning(
+        "Fast HUD cannot see the Winamax table windows: this application is not allowed to "
+        "control 'System Events' (Automation). On macOS that is the only way to read an "
+        "Electron client's window title -- the accessibility API needs a grant macOS never "
+        "prompts for, and Quartz never exposes an Electron title at all. Allow it in System "
+        "Settings > Privacy & Security > Automation (FPDB -> System Events) and restart FPDB. "
+        "If FPDB is not listed there, run 'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS "
+        "asks again. Until then the HUD only appears once a hand has been imported. Detail: %s",
+        detail,
+    )
+
 
 def applescript_window_titles() -> list[str]:
     """Titles of the client's windows, read through System Events.
@@ -73,7 +104,10 @@ def applescript_window_titles() -> list[str]:
     which the rest of fpdb already relies on to find these same windows.
 
     Returns an empty list when the client is not running or the scan is
-    refused; the caller then falls back to waiting for an imported hand.
+    refused; the caller then falls back to waiting for an imported hand. A
+    refusal is reported once, loudly: it is the difference between "no table is
+    open" and "this build will never see a table", and the two used to look
+    identical in the log.
     """
     try:
         # Absolute path, fixed argv, no shell, and nothing interpolated into the script.
@@ -84,11 +118,19 @@ def applescript_window_titles() -> list[str]:
             timeout=APPLESCRIPT_TIMEOUT,
             check=False,
         )
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        log.debug("Could not list Winamax windows through System Events: %s", exc)
+    except subprocess.TimeoutExpired:
+        # The Automation prompt is on screen and nobody has answered it.
+        _report_automation_refused(f"osascript did not return within {APPLESCRIPT_TIMEOUT:.0f}s")
+        return []
+    except OSError as exc:
+        log.debug("Could not run %s: %s", OSASCRIPT, exc)
         return []
     if result.returncode != 0:
-        log.debug("System Events refused the Winamax window list: %s", result.stderr.strip())
+        stderr = result.stderr.strip()
+        if any(marker in stderr for marker in AUTOMATION_REFUSED_MARKERS):
+            _report_automation_refused(stderr)
+        else:
+            log.debug("System Events refused the Winamax window list: %s", stderr)
         return []
     return [title.strip() for title in result.stdout.strip().split(",") if title.strip()]
 

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -209,7 +209,9 @@ def test_launch_hud_pyinstaller_macos_uses_the_sibling_executable(monkeypatch, t
     gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
     fpdb_executable = tmp_path / "fpdb"
     fpdb_executable.touch()
-    hud_executable = tmp_path / "HUD_main"
+    # Chosen from os.name, not sys.platform, so follow the host: the Windows
+    # runner looks for HUD_main.exe even with sys.platform faked to darwin.
+    hud_executable = tmp_path / ("HUD_main.exe" if os.name == "nt" else "HUD_main")
     hud_executable.touch()
     monkeypatch.setattr(gui_mod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(gui_mod.sys, "executable", str(fpdb_executable))

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -193,8 +193,13 @@ def test_launch_hud_uses_bundled_sibling_executable(monkeypatch, tmp_path, platf
     assert popen_kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
 
 
-def test_launch_hud_pyinstaller_macos_reuses_main_app_identity(monkeypatch, tmp_path):
-    """The HUD must share fpdb.app's TCC grants instead of using a sibling identity."""
+def test_launch_hud_pyinstaller_macos_uses_the_sibling_executable(monkeypatch, tmp_path):
+    """'fpdb --hud' has no HUD in it: only HUD_main's own archive is complete.
+
+    The fpdb executable is analysed from fpdb.pyw, which never imports the HUD's
+    backend, so running the HUD inside it died on startup with
+    ModuleNotFoundError (OSXTables, then fpdb.infrastructure).
+    """
     settings = _make_settings(MagicMock())
     settings["cl_options"] = "--config bundled.xml"
     config = _make_config()
@@ -204,15 +209,18 @@ def test_launch_hud_pyinstaller_macos_reuses_main_app_identity(monkeypatch, tmp_
     gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
     fpdb_executable = tmp_path / "fpdb"
     fpdb_executable.touch()
+    hud_executable = tmp_path / "HUD_main"
+    hud_executable.touch()
     monkeypatch.setattr(gui_mod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(gui_mod.sys, "executable", str(fpdb_executable))
     monkeypatch.setattr(gui_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(gui, "_hud_base_path", lambda: str(tmp_path))
 
     with patch.object(gui_mod.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
         gui._launch_hud()
 
     command = mock_popen.call_args.args[0]
-    assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
+    assert command == [str(hud_executable), "--config", "bundled.xml"]
     child_env = mock_popen.call_args.kwargs["env"]
     assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
     # Finding table windows no longer depends on macOS Accessibility, so the

--- a/test/test_hud_main_backend_imports.py
+++ b/test/test_hud_main_backend_imports.py
@@ -1,0 +1,63 @@
+"""The OS backend must be imported through the package, not as a bare module.
+
+On macOS the frozen build runs the HUD inside the *fpdb* executable
+(``fpdb --hud``), whose dependency analysis only ever saw ``fpdb_3_legacy.*``
+imports. A bare ``import OSXTables`` is therefore absent from that executable's
+archive, and the HUD died on startup with::
+
+    ModuleNotFoundError: No module named 'OSXTables'
+
+Nothing in the test suite caught it, because from a source checkout the repo
+root is on ``sys.path`` and both spellings resolve.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+HUD_MAIN = Path(__file__).parent.parent / "fpdb_3_legacy" / "HUD_main.pyw"
+BACKENDS = ("OSXTables", "XTables", "WinTables")
+
+
+def _imported_names() -> set[str]:
+    """Every module name HUD_main imports, however deep in the file."""
+    tree = ast.parse(HUD_MAIN.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def test_no_backend_is_imported_as_a_bare_top_level_module() -> None:
+    imported = _imported_names()
+    bare = sorted(name for name in imported if name in BACKENDS)
+    assert bare == [], (
+        f"HUD_main imports {bare} as bare top-level modules. The frozen macOS build "
+        f"runs the HUD inside the fpdb executable, which has no such modules; import "
+        f"them as 'from fpdb_3_legacy import <name> as Tables' instead."
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_every_backend_is_importable_through_the_package(backend: str) -> None:
+    """The spelling HUD_main uses has to resolve on this platform's backend.
+
+    Only the current platform's backend can actually be imported -- the others
+    need Windows or X11 bindings -- so a missing dependency is not a failure
+    here; a missing *module* is.
+    """
+    try:
+        module = importlib.import_module(f"fpdb_3_legacy.{backend}")
+    except ImportError as exc:
+        if backend in str(exc):
+            pytest.fail(f"fpdb_3_legacy.{backend} does not exist: {exc}")
+        pytest.skip(f"{backend} needs platform bindings unavailable here: {exc}")
+    else:
+        assert module.__name__ == f"fpdb_3_legacy.{backend}"

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -799,3 +799,66 @@ def test_synthetic_window_id_is_deterministic() -> None:
     two = base + zlib.crc32(b"Table Alpha") % 1_000_000
     assert one == two
     assert one >= base
+
+
+def test_run_applescript_scan_treats_a_hung_scan_as_blocking() -> None:
+    """An unanswered Automation prompt blocks osascript rather than failing it.
+
+    TimeoutExpired never reaches the return-code handling, so before this the
+    broad handler swallowed it and left the scan enabled -- every table lookup
+    then paid the full timeout again.
+    """
+    detector = _detector()
+    with (
+        patch(
+            "fpdb.infrastructure.platform.macos.subprocess.run",
+            side_effect=TimeoutExpired(cmd="osascript", timeout=5),
+        ),
+        patch("fpdb.infrastructure.platform.macos.logger") as logger,
+    ):
+        detector._run_applescript_scan()
+
+    assert detector._automation_blocked is True
+    logger.warning.assert_called_once()
+    logger.error.assert_not_called()
+
+
+def test_a_hung_scan_is_not_repeated_on_the_next_lookup() -> None:
+    """The whole point of noticing the block: the second lookup must be free."""
+    detector = _detector()
+    detector._match_target_window_by_pid = Mock(return_value=None)
+    with patch(
+        "fpdb.infrastructure.platform.macos.subprocess.run",
+        side_effect=TimeoutExpired(cmd="osascript", timeout=5),
+    ) as run:
+        detector._find_tables_without_titles("Winamax Colorado 6", [], [], 3, 0)
+        detector._find_tables_without_titles("Winamax Colorado 5", [], [], 3, 0)
+
+    assert run.call_count == 1
+
+
+def test_an_empty_result_still_respects_the_scan_ttl() -> None:
+    """"Nothing found" is what a refused or hanging scan returns, too.
+
+    Re-scanning whenever the last result was empty made that the one case that
+    repeated on every lookup.
+    """
+    detector = _detector()
+    detector._applescript_last_result = []
+    detector._applescript_last_scan = time.monotonic()
+    detector._run_applescript_scan = Mock()
+
+    detector.find_tables_applescript("anything")
+
+    detector._run_applescript_scan.assert_not_called()
+
+
+def test_the_first_scan_still_runs_with_no_cached_result() -> None:
+    detector = _detector()
+    detector._applescript_last_result = []
+    detector._applescript_last_scan = 0.0
+    detector._run_applescript_scan = Mock()
+
+    detector.find_tables_applescript("anything")
+
+    detector._run_applescript_scan.assert_called_once()

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -28,6 +28,7 @@ def _detector(*, window_list: list[dict] | None = None) -> MacOSTableDetector:
     detector._permissions_checked = False
     detector._permission_status = None
     detector._automation_warned = False
+    detector._automation_blocked = False
     detector._NSWorkspace = Mock()
     detector._kCGNullWindowID = 0
     detector._kCGWindowListOptionOnScreenOnly = 8
@@ -252,7 +253,33 @@ def test_run_applescript_scan_does_not_warn_on_other_errors() -> None:
     ):
         detector._run_applescript_scan()
     assert detector._automation_warned is False
+    assert detector._automation_blocked is False
     logger.warning.assert_not_called()
+
+
+def test_run_applescript_scan_treats_a_refusal_as_blocking() -> None:
+    detector = _detector()
+    result = Mock(returncode=1, stdout="", stderr="-1743 operation not allowed")
+    with patch("fpdb.infrastructure.platform.macos.subprocess.run", return_value=result):
+        detector._run_applescript_scan()
+    assert detector._automation_blocked is True
+
+
+def test_run_applescript_scan_treats_an_unanswered_prompt_as_blocking() -> None:
+    """-1712 means the Automation dialog is up and nobody has answered it.
+
+    Every later scan would sit through the same multi-second timeout, and
+    Fast-Fold reaches this path on every hand.
+    """
+    detector = _detector()
+    result = Mock(returncode=1, stdout="", stderr="AppleEvent timed out. (-1712)")
+    with (
+        patch("fpdb.infrastructure.platform.macos.subprocess.run", return_value=result),
+        patch("fpdb.infrastructure.platform.macos.logger") as logger,
+    ):
+        detector._run_applescript_scan()
+    assert detector._automation_blocked is True
+    logger.warning.assert_called_once()
 
 
 def test_run_applescript_scan_swallows_errors() -> None:
@@ -683,17 +710,39 @@ def test_find_tables_without_titles_uses_sole_blank_window() -> None:
     assert result == [blank]
 
 
-def test_find_tables_without_titles_skips_slow_applescript_when_accessibility_is_missing() -> None:
+def test_find_tables_without_titles_still_scans_when_accessibility_is_missing() -> None:
+    """Driving System Events needs Automation, which is a different grant.
+
+    Gating the scan on Accessibility switched it off in every packaged build,
+    and for an Electron client like Winamax it is the only way left to read a
+    window title -- Quartz never exposes one.
+    """
     detector = _detector()
     detector._match_target_window_by_pid = Mock(return_value=None)
     detector._check_permissions_once = Mock(return_value=Mock(accessibility=False))
-    detector.find_tables_applescript = Mock(return_value=[])
+    found = TableInfo(window_id=9, title="Winamax Bucarest 6", geometry=TableGeometry(0, 0, 600, 500))
+    detector.find_tables_applescript = Mock(return_value=[found])
     blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="Winamax")
 
     result = detector._find_tables_without_titles("Winamax Bucarest 6", [], [blank], 3, 0)
 
-    assert result == [blank]
+    detector.find_tables_applescript.assert_called_once_with("Winamax Bucarest 6")
+    assert result == [found]
+
+
+def test_find_tables_without_titles_stops_scanning_once_system_events_refuses() -> None:
+    """A refused scan costs seconds, and Fast-Fold hits this path per hand."""
+    detector = _detector()
+    detector._match_target_window_by_pid = Mock(return_value=None)
+    detector.find_tables_applescript = Mock(return_value=[])
+    detector._automation_blocked = True
+    blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="Winamax")
+
+    result = detector._find_tables_without_titles("Winamax Bucarest 6", [], [blank], 3, 0)
+
     detector.find_tables_applescript.assert_not_called()
+    # The sole-window heuristic is still allowed to answer.
+    assert result == [blank]
 
 
 def test_find_tables_without_titles_rejects_cross_room_blank_window_fallback() -> None:

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -36,6 +36,17 @@ def _detector(*, window_list: list[dict] | None = None) -> MacOSTableDetector:
     return detector
 
 
+def _hung_osascript() -> TimeoutExpired:
+    """What osascript raises when the Automation prompt is left unanswered.
+
+    This constructs an exception, not a process: Semgrep's subprocess audit
+    matches the constructor by name, which is why the suppression lives here
+    rather than being repeated at each use.
+    """
+    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
+    return TimeoutExpired(cmd="osascript", timeout=5)
+
+
 def _window(
     *,
     number: int = 1,
@@ -812,7 +823,7 @@ def test_run_applescript_scan_treats_a_hung_scan_as_blocking() -> None:
     with (
         patch(
             "fpdb.infrastructure.platform.macos.subprocess.run",
-            side_effect=TimeoutExpired(cmd="osascript", timeout=5),
+            side_effect=_hung_osascript(),
         ),
         patch("fpdb.infrastructure.platform.macos.logger") as logger,
     ):
@@ -829,7 +840,7 @@ def test_a_hung_scan_is_not_repeated_on_the_next_lookup() -> None:
     detector._match_target_window_by_pid = Mock(return_value=None)
     with patch(
         "fpdb.infrastructure.platform.macos.subprocess.run",
-        side_effect=TimeoutExpired(cmd="osascript", timeout=5),
+        side_effect=_hung_osascript(),
     ) as run:
         detector._find_tables_without_titles("Winamax Colorado 6", [], [], 3, 0)
         detector._find_tables_without_titles("Winamax Colorado 5", [], [], 3, 0)

--- a/test/test_subprocess_launch.py
+++ b/test/test_subprocess_launch.py
@@ -52,7 +52,9 @@ def test_hud_command_uses_the_sibling_executable_on_pyinstaller_macos(monkeypatc
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(sys, "executable", str(tmp_path / "fpdb"))
-    hud = tmp_path / "HUD_main"
+    # The name is chosen from os.name, not sys.platform, so this test has to
+    # follow the host it runs on -- the Windows runner builds HUD_main.exe.
+    hud = tmp_path / ("HUD_main.exe" if os.name == "nt" else "HUD_main")
     hud.write_text("")
 
     command = hud_main_command("-x")

--- a/test/test_subprocess_launch.py
+++ b/test/test_subprocess_launch.py
@@ -41,11 +41,25 @@ def test_hud_command_uses_pyoxidizer_subcommand(monkeypatch) -> None:
     assert hud_main_command("-x") == [sys.executable, "--hud", "-x"]
 
 
-def test_hud_command_reuses_main_executable_for_pyinstaller_macos(monkeypatch) -> None:
+def test_hud_command_uses_the_sibling_executable_on_pyinstaller_macos(monkeypatch, tmp_path) -> None:
+    """Only PyOxidizer hosts both entry points in one binary.
+
+    Routing PyInstaller's macOS HUD through 'fpdb --hud' killed it on startup:
+    the fpdb executable's dependency analysis started at fpdb.pyw and never saw
+    the HUD's imports, so OSXTables and fpdb.infrastructure are simply not in
+    its archive. The sibling HUD_main executable carries its own complete one.
+    """
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "fpdb"))
+    hud = tmp_path / "HUD_main"
+    hud.write_text("")
 
-    assert hud_main_command("-x") == [sys.executable, HUD_FLAG, "-x"]
+    command = hud_main_command("-x")
+
+    assert Path(command[0]) == hud.resolve()
+    assert command[1:] == ["-x"]
+    assert HUD_FLAG not in command
 
 
 def test_hud_command_uses_sibling_executable_when_frozen(monkeypatch, tmp_path) -> None:

--- a/test/test_winamax_ax_seats.py
+++ b/test/test_winamax_ax_seats.py
@@ -296,3 +296,62 @@ class TestApplescriptWindowTitles:
         monkeypatch.setattr(winamax_ax_seats.subprocess, "run", timeout)
 
         assert winamax_ax_seats.applescript_window_titles() == []
+
+
+class TestAutomationRefusalIsReported:
+    """A refused scan and an empty table list used to look identical in the log.
+
+    They are opposite situations: one means "no table is open", the other means
+    "this build will never see a table until the user grants Automation".
+    """
+
+    @staticmethod
+    def _run(monkeypatch, *, returncode: int, stderr: str):
+        monkeypatch.setattr(winamax_ax_seats, "_automation_refused", False)
+        monkeypatch.setattr(
+            winamax_ax_seats.subprocess,
+            "run",
+            lambda *_a, **_k: SimpleNamespace(returncode=returncode, stdout="", stderr=stderr),
+        )
+        return winamax_ax_seats.applescript_window_titles()
+
+    def test_a_refusal_is_reported_once_at_warning(self, monkeypatch, caplog) -> None:
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert self._run(monkeypatch, returncode=1, stderr="execution error: Not authorized (-1743)") == []
+            # Second call: still refused, but the user has already been told.
+            monkeypatch.setattr(
+                winamax_ax_seats.subprocess,
+                "run",
+                lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="(-1743)"),
+            )
+            assert winamax_ax_seats.applescript_window_titles() == []
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "Automation" in warnings[0].getMessage()
+
+    def test_an_unanswered_prompt_counts_as_a_refusal(self, monkeypatch, caplog) -> None:
+        """-1712 means the permission dialog is up and nobody has answered it."""
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert self._run(monkeypatch, returncode=1, stderr="AppleEvent timed out. (-1712)") == []
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_an_ordinary_failure_is_not_dressed_up_as_a_permission_problem(self, monkeypatch, caplog) -> None:
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert self._run(monkeypatch, returncode=1, stderr="syntax error somewhere") == []
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_a_hung_scan_is_reported_too(self, monkeypatch, caplog) -> None:
+        monkeypatch.setattr(winamax_ax_seats, "_automation_refused", False)
+
+        def timeout(*_a, **_k):
+            raise winamax_ax_seats.subprocess.TimeoutExpired(cmd="osascript", timeout=5)
+
+        monkeypatch.setattr(winamax_ax_seats.subprocess, "run", timeout)
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert winamax_ax_seats.applescript_window_titles() == []
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_the_scan_runs_from_an_absolute_path(self) -> None:
+        """So it cannot be diverted by whatever PATH the packaged app inherited."""
+        assert winamax_ax_seats.OSASCRIPT.startswith("/")


### PR DESCRIPTION
Deux pannes distinctes en mode packagé, toutes deux introduites par des tentatives précédentes sur ce même problème.

## 1. Le HUD PyInstaller mourait au démarrage

Reproduit en lançant le binaire de la release 3.6.2 :

```
File "fpdb_3_legacy/HUD_main.pyw", line 592, in __init__
    import OSXTables as Tables
ModuleNotFoundError: No module named 'OSXTables'
```

La 3.6.1 fait passer le HUD macOS par `fpdb --hud` pour qu'il tourne sous l'identité de code de l'application principale. Mais l'exécutable `fpdb` est analysé à partir de `fpdb.pyw`, qui n'importe jamais le backend du HUD : **aucune** de ses dépendances n'est dans son archive. Après avoir corrigé `OSXTables` en import par paquet, la suivante est tombée :

```
File ".../fpdb_3_legacy/OSXTables.py", line 31
    from fpdb.infrastructure.platform import get_table_detector
ModuleNotFoundError: No module named 'fpdb.infrastructure'
```

Les rattraper une par une est sans fin. PyInstaller repasse donc au binaire frère `HUD_main`, qui embarque sa propre archive complète — vérifié : il démarre correctement depuis le bundle de la release. Seul PyOxidizer, dont le binaire unique héberge réellement les deux points d'entrée, conserve `--hud`. Les backends restent importés via le paquet, ce qui est correct dans les deux cas.

## 2. Le Fast HUD n'apparaissait jamais, dans aucun des deux bundles

```
Window detection failed: no match found for 'Winamax\s+.*Colorado\ 6'
Currently open windows: ['Menubar', 'HUD Main Window', 'Wallpaper-']
```

La 3.6.1 a aussi conditionné le scan de fenêtres AppleScript à la permission *Accessibility*. La prémisse est fausse : piloter System Events demande **Automation**, une autorisation différente — et la seule que macOS propose spontanément. Accessibility est absente de tout build packagé, macOS ne la demandant jamais. Le scan était donc coupé précisément là où il est indispensable : pour un client Electron comme Winamax, c'est le seul moyen de lire un titre de fenêtre, Quartz n'en exposant aucun. Sans lui, le HUD ne trouve pas sa table, et l'heuristique de repli « unique fenêtre visible » refuse de deviner dès que plusieurs tables sont ouvertes.

Le scan s'exécute désormais sans condition, et ne s'arrête qu'une fois que System Events nous a réellement éconduits.

## Pourquoi ça marchait en développement

Vérifié avec une application minimale signée ad-hoc n'appelant que System Events :

| Lancement | Résultat |
| --- | --- |
| depuis un shell | succès immédiat, aucune invite |
| via LaunchServices (double-clic) | `AppleEvent timed out (-1712)`, `UserNotificationCenter` actif |

En développement, l'événement Apple est attribué au terminal, qui détient déjà l'autorisation. En bundle, l'application est un sujet TCC neuf : macOS affiche une invite, et tant qu'elle n'est pas acceptée, tout appel échoue.

## Diagnosticabilité

Le refus est maintenant journalisé **une fois, en WARNING**, avec la marche à suivre. Auparavant il était invisible : un scan refusé et « aucune table ouverte » produisaient des journaux identiques, ce qui a fait échouer deux tentatives de correction. `-1712` compte aussi comme un refus — la boîte de dialogue est affichée sans réponse, et chaque scan suivant paierait le même délai.

## Validation

- 6 500 tests + 623 tests Qt
- Ruff, mypy, Bandit : 0 alerte
- Crash reproduit puis binaire frère vérifié au démarrage depuis le bundle réel
- Nouveaux tests : invariant d'import des backends (`test_hud_main_backend_imports.py`), scan tenté malgré Accessibility absente, arrêt après refus, remontée du refus en WARNING

## À faire côté utilisateur

Le correctif rétablit le chemin, mais l'autorisation reste à accorder : *Réglages Système → Confidentialité et sécurité → Automatisation → FPDB → System Events*. Si FPDB n'y figure pas, un refus est enregistré ; `tccutil reset AppleEvents org.fpdb.fpdb3` fait réapparaître l'invite. Le journal le dit désormais explicitement.
