### PR TITLE
chore(release): prepare 3.6.3

### DIFF
--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -13,4 +13,4 @@ import datetime
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.6.2"
+__version__ = "3.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.6.2"
+version = "3.6.3"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -261,7 +261,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.6.2"
+version = "3.6.3"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.6.2"
+version = "3.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump de version pour la release corrective 3.6.3. Aucun changement fonctionnel : uniquement les quatre marqueurs utilisés par Python, Briefcase et le lockfile.

| Fichier | Ligne |
| --- | --- |
| `pyproject.toml` | 7 (`[project]`), 264 (`[tool.briefcase]`) |
| `fpdb_3_legacy/__init__.py` | 16 (`__version__`) |
| `uv.lock` | 602 (paquet `fpdb-3`) |

## Contenu de la release

Correction de deux régressions macOS en mode packagé ([#220](https://github.com/jejellyroll-fr/fpdb-3/pull/220), fusionnée). **La 3.6.2 est inutilisable sur macOS** : le HUD PyInstaller y crashe au démarrage et le Fast HUD n'apparaît dans aucun des deux bundles.

- **Le HUD PyInstaller démarre à nouveau.** La 3.6.1 faisait passer le HUD macOS par `fpdb --hud` pour lui conserver l'identité de code de l'application. Mais l'exécutable `fpdb` est analysé à partir de `fpdb.pyw`, qui n'importe jamais le backend du HUD : aucune de ses dépendances n'est dans son archive, d'où `ModuleNotFoundError: No module named 'OSXTables'`, puis `fpdb.infrastructure`. PyInstaller repasse au binaire frère `HUD_main`, qui embarque sa propre archive complète. Seul PyOxidizer, dont le binaire unique héberge réellement les deux points d'entrée, conserve `--hud`.
- **Le Fast HUD retrouve les fenêtres de table.** La 3.6.1 conditionnait le scan AppleScript à la permission *Accessibility*. La prémisse est fausse : piloter System Events demande **Automation**. Accessibility est absente de tout build packagé — macOS ne la demande jamais — donc le scan était coupé précisément là où il est indispensable. Pour un client Electron comme Winamax, c'est le seul moyen de lire un titre de fenêtre, Quartz n'en exposant aucun.
- **Un scan bloqué ne gèle plus la détection.** Une invite Automation sans réponse bloque `osascript` au lieu de le faire échouer : `TimeoutExpired` était avalé par le gestionnaire large et laissait le scan actif. Pire, un résultat vide contournait le TTL — et « vide » est exactement ce que renvoie un scan refusé, donc le seul cas qui ne devait pas se répéter se répétait à chaque recherche de table.
- **Le refus est désormais visible.** Journalisé une fois en WARNING, avec la marche à suivre. Auparavant un scan refusé et « aucune table ouverte » produisaient des journaux identiques.
- **Durcissement.** `osascript` est appelé par chemin absolu, insensible au `PATH` hérité par l'application.

## Note pour les utilisateurs macOS

Le correctif rétablit le chemin, mais l'autorisation reste à accorder : *Réglages Système → Confidentialité et sécurité → Automatisation → FPDB → System Events*. Si FPDB n'y figure pas, un refus est enregistré ; `tccutil reset AppleEvents org.fpdb.fpdb3` fait réapparaître l'invite.

## Validation de #220

22/22 checks verts, Codacy à 0 problème, dont les six builds PyInstaller et PyOxidizer. Crash reproduit sur le binaire de la 3.6.2, puis binaire `HUD_main` reconstruit et démarré proprement.
