### PR TITLE
fix(macos): stabilize frozen HUD identity and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,8 +775,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         env:
-          # The filesystem importer otherwise fills the unsigned smoke bundle
-          # with thousands of disposable .pyc files before its final seal.
+          # Defense in depth; pyoxidizer.bzl also sets dont_write_bytecode
+          # because the embedded interpreter may ignore this environment flag.
           PYTHONDONTWRITEBYTECODE: "1"
         run: |
           install_dir="build/${{ matrix.target }}/release/install"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,14 +774,19 @@ jobs:
       - name: Assemble PyOxidizer macOS application
         if: runner.os == 'macOS'
         shell: bash
+        env:
+          # The filesystem importer otherwise fills the unsigned smoke bundle
+          # with thousands of disposable .pyc files before its final seal.
+          PYTHONDONTWRITEBYTECODE: "1"
         run: |
           install_dir="build/${{ matrix.target }}/release/install"
           mkdir -p dist
-          python -m tools.package_pyoxidizer_macos "$install_dir" dist/fpdb.app --icon gfx/tribal.icns
-          codesign --verify --deep --strict dist/fpdb.app
+          python -m tools.package_pyoxidizer_macos "$install_dir" dist/fpdb.app --icon gfx/tribal.icns --defer-signing
           dist/fpdb.app/Contents/MacOS/fpdb --hud --help
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.OSXTables
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb.infrastructure.platform.macos
+          python -m tools.package_pyoxidizer_macos --sign-existing dist/fpdb.app
+          codesign --verify --deep --strict dist/fpdb.app
           if [[ "${{ github.event_name }}" == "release" ]]; then
             codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
             codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
@@ -812,6 +817,7 @@ jobs:
         run: |
           install_dir="build/${{ matrix.target }}/release/install"
           if [[ "${{ runner.os }}" == "macOS" ]]; then
+            codesign --verify --deep --strict dist/fpdb.app
             cp docs/macos-gatekeeper.md dist/READ-ME-FIRST-macos.md
             tar -czf "${{ matrix.artifact }}.tar.gz" -C dist fpdb.app READ-ME-FIRST-macos.md
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,47 +505,17 @@ jobs:
   build:
     name: Build with PyInstaller (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
-    env:
-      FPDB_MACOS_SIGNING_IDENTITY: ${{ github.event_name == 'release' && secrets.MACOS_SIGNING_IDENTITY || '-' }}
-      FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             label: Linux x64
             artifact: fpdb-pyinstaller-linux-x64
-          - os: macos-latest
-            label: macOS ARM64
-            artifact: fpdb-pyinstaller-macos-arm64
           - os: windows-latest
             label: Windows x64
             artifact: fpdb-pyinstaller-windows-x64
     steps:
       - uses: actions/checkout@v4
-      - name: Validate macOS release credentials
-        if: runner.os == 'macOS' && github.event_name == 'release'
-        shell: bash
-        env:
-          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
-          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-        run: |
-          missing=0
-          for name in FPDB_MACOS_SIGNING_IDENTITY MACOS_CERTIFICATE_P12_BASE64 MACOS_CERTIFICATE_PASSWORD MACOS_NOTARY_API_KEY_P8_BASE64 MACOS_NOTARY_KEY_ID MACOS_NOTARY_ISSUER_ID; do
-            if [[ -z "${!name}" || "${!name}" == "-" ]]; then
-              echo "::error::Missing required macOS release credential: $name"
-              missing=1
-            fi
-          done
-          exit "$missing"
-      - name: Import Developer ID certificate
-        if: runner.os == 'macOS' && github.event_name == 'release'
-        uses: apple-actions/import-codesign-certs@v7
-        with:
-          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
-          p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -578,62 +548,22 @@ jobs:
           fi
       - name: Bundle HUD inside fpdb
         run: python tools/bundle_pyinstaller_hud.py dist
-      - name: Verify assembled macOS application
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          codesign --verify --deep --strict dist/fpdb.app
-          dist/fpdb.app/Contents/MacOS/fpdb --hud --help
-          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.OSXTables
-          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb.infrastructure.platform.macos
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
-            codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
-            codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null
-            grep -Eq '^TeamIdentifier=[A-Z0-9]+$' "$RUNNER_TEMP/fpdb-signature.txt"
-            grep -q 'runtime' "$RUNNER_TEMP/fpdb-signature.txt"
-            if grep -q 'designated => cdhash' "$RUNNER_TEMP/fpdb-requirement.txt"; then
-              echo "::error::Release signature still has a version-specific cdhash requirement"
-              exit 1
-            fi
-            grep -q 'com.apple.security.automation.apple-events' "$RUNNER_TEMP/fpdb-entitlements.plist"
-          fi
-      - name: Notarize and staple PyInstaller macOS release
-        if: runner.os == 'macOS' && github.event_name == 'release'
-        shell: bash
-        env:
-          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-        run: |
-          python -c 'import base64, os, pathlib, sys; pathlib.Path(sys.argv[1]).write_bytes(base64.b64decode(os.environ["MACOS_NOTARY_API_KEY_P8_BASE64"]))' "$RUNNER_TEMP/fpdb-notary-key.p8"
-          ditto -c -k --keepParent dist/fpdb.app "$RUNNER_TEMP/fpdb-pyinstaller-notary.zip"
-          xcrun notarytool submit "$RUNNER_TEMP/fpdb-pyinstaller-notary.zip" --key "$RUNNER_TEMP/fpdb-notary-key.p8" --key-id "$MACOS_NOTARY_KEY_ID" --issuer "$MACOS_NOTARY_ISSUER_ID" --wait
-          xcrun stapler staple dist/fpdb.app
-          xcrun stapler validate dist/fpdb.app
       - name: Package build artifact
         shell: bash
         env:
           ARTIFACT: ${{ matrix.artifact }}
-        run: |
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            cp docs/macos-gatekeeper.md dist/READ-ME-FIRST-macos.md
-            tar -czf "$ARTIFACT.tar.gz" -C dist fpdb.app READ-ME-FIRST-macos.md
-          else
-            tar -czf "$ARTIFACT.tar.gz" -C dist fpdb
-          fi
+        run: tar -czf "$ARTIFACT.tar.gz" -C dist fpdb
       - name: Upload Build Artifacts
+        if: runner.os != 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.tar.gz
           compression-level: 0
-      # Shipped alongside the PyOxidizer tarballs rather than instead of them:
-      # the PyOxidizer Windows build does not run, so on that platform this is
-      # the only working download, and offering the same pair everywhere keeps
-      # the release predictable.
+      # macOS is distributed only by build-pyoxidizer. Keep the runner guard as
+      # defense in depth if a macOS entry is ever accidentally reintroduced.
       - name: Attach PyInstaller build to the release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && runner.os != 'macOS'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -652,6 +582,8 @@ jobs:
     # emitted by `cargo init` since Rust 1.85.
     env:
       RUSTUP_TOOLCHAIN: "1.83.0"
+      # release/published covers both final releases and published prereleases
+      # (including RCs), so neither may fall back to an ad-hoc identity.
       FPDB_MACOS_SIGNING_IDENTITY: ${{ github.event_name == 'release' && secrets.MACOS_SIGNING_IDENTITY || '-' }}
       FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}
     strategy:
@@ -701,6 +633,11 @@ jobs:
               missing=1
             fi
           done
+          if [[ "$FPDB_MACOS_SIGNING_IDENTITY" != "Developer ID Application: "* ]] ||
+             [[ ! "$FPDB_MACOS_SIGNING_IDENTITY" =~ \([A-Z0-9]{10}\)$ ]]; then
+            echo "::error::MACOS_SIGNING_IDENTITY must be a Developer ID Application identity ending in a 10-character Team ID"
+            missing=1
+          fi
           exit "$missing"
       - name: Import Developer ID certificate
         if: runner.os == 'macOS' && github.event_name == 'release'
@@ -794,8 +731,18 @@ jobs:
             codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
             codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
             codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null
-            grep -Eq '^TeamIdentifier=[A-Z0-9]+$' "$RUNNER_TEMP/fpdb-signature.txt"
-            grep -q 'runtime' "$RUNNER_TEMP/fpdb-signature.txt"
+            if [[ "$FPDB_MACOS_SIGNING_IDENTITY" =~ \(([A-Z0-9]{10})\)$ ]]; then
+              expected_team_id="${BASH_REMATCH[1]}"
+            else
+              echo "::error::Could not extract Team ID from Developer ID identity"
+              exit 1
+            fi
+            grep -Fqx "Authority=$FPDB_MACOS_SIGNING_IDENTITY" "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -Fqx "TeamIdentifier=$expected_team_id" "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -Fxq 'Identifier=org.fpdb.fpdb3' "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -Eq '^CodeDirectory .*flags=.*\(runtime\)' "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -Fq 'identifier "org.fpdb.fpdb3"' "$RUNNER_TEMP/fpdb-requirement.txt"
+            grep -Fq 'anchor apple generic' "$RUNNER_TEMP/fpdb-requirement.txt"
             if grep -q 'designated => cdhash' "$RUNNER_TEMP/fpdb-requirement.txt"; then
               echo "::error::Release signature still has a version-specific cdhash requirement"
               exit 1
@@ -815,6 +762,8 @@ jobs:
           xcrun notarytool submit "$RUNNER_TEMP/fpdb-pyoxidizer-notary.zip" --key "$RUNNER_TEMP/fpdb-notary-key.p8" --key-id "$MACOS_NOTARY_KEY_ID" --issuer "$MACOS_NOTARY_ISSUER_ID" --wait
           xcrun stapler staple dist/fpdb.app
           xcrun stapler validate dist/fpdb.app
+          codesign --verify --deep --strict --verbose=2 dist/fpdb.app
+          spctl --assess --type execute --verbose=4 dist/fpdb.app
       - name: Package PyOxidizer artifact
         shell: bash
         run: |
@@ -823,6 +772,13 @@ jobs:
             codesign --verify --deep --strict dist/fpdb.app
             cp docs/macos-gatekeeper.md dist/READ-ME-FIRST-macos.md
             tar -czf "${{ matrix.artifact }}.tar.gz" -C dist fpdb.app READ-ME-FIRST-macos.md
+            verify_dir="$(mktemp -d "$RUNNER_TEMP/fpdb-pyoxidizer-artifact.XXXXXX")"
+            tar -xzf "${{ matrix.artifact }}.tar.gz" -C "$verify_dir"
+            codesign --verify --deep --strict --verbose=2 "$verify_dir/fpdb.app"
+            if [[ "${{ github.event_name }}" == "release" ]]; then
+              xcrun stapler validate "$verify_dir/fpdb.app"
+              spctl --assess --type execute --verbose=4 "$verify_dir/fpdb.app"
+            fi
           else
             tar -czf "${{ matrix.artifact }}.tar.gz" -C "$install_dir" .
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,11 +399,13 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
-          native_tests="test/test_equity.py"
+          native_tests=(test/test_equity.py)
           for f in test/test_aof_equity.py test/test_aof_ranges.py; do
-            [ -f "$f" ] && native_tests="$native_tests $f"
+            if [[ -f "$f" ]]; then
+              native_tests+=("$f")
+            fi
           done
-          python -m pytest $native_tests -x -v --tb=short
+          python -m pytest "${native_tests[@]}" -x -v --tb=short
 
   coverage:
     runs-on: ubuntu-latest
@@ -503,6 +505,9 @@ jobs:
   build:
     name: Build with PyInstaller (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
+    env:
+      FPDB_MACOS_SIGNING_IDENTITY: ${{ github.event_name == 'release' && secrets.MACOS_SIGNING_IDENTITY || '-' }}
+      FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}
     strategy:
       matrix:
         include:
@@ -517,6 +522,30 @@ jobs:
             artifact: fpdb-pyinstaller-windows-x64
     steps:
       - uses: actions/checkout@v4
+      - name: Validate macOS release credentials
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        shell: bash
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          missing=0
+          for name in FPDB_MACOS_SIGNING_IDENTITY MACOS_CERTIFICATE_P12_BASE64 MACOS_CERTIFICATE_PASSWORD MACOS_NOTARY_API_KEY_P8_BASE64 MACOS_NOTARY_KEY_ID MACOS_NOTARY_ISSUER_ID; do
+            if [[ -z "${!name}" || "${!name}" == "-" ]]; then
+              echo "::error::Missing required macOS release credential: $name"
+              missing=1
+            fi
+          done
+          exit "$missing"
+      - name: Import Developer ID certificate
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        uses: apple-actions/import-codesign-certs@v7
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -541,17 +570,47 @@ jobs:
           # distribution still exposes numpy's compiled sub-packages, and
           # "import numpy" then yields an empty namespace package.
           if [ "${{ runner.os }}" = "Windows" ]; then
-            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy;fpdb_3_legacy" --add-data "gfx;gfx" --add-data "icons;icons" --add-data "fonts;fonts" --add-data "locale;locale" --add-data "HUD_config.xml;." "fpdb_3_legacy/fpdb.pyw"
-            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy;fpdb_3_legacy" --add-data "gfx;gfx" --add-data "icons;icons" --add-data "fonts;fonts" --add-data "locale;locale" --add-data "HUD_config.xml;." "fpdb_3_legacy/HUD_main.pyw"
+            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy;fpdb_3_legacy" --add-data "gfx;gfx" --add-data "icons;icons" --add-data "fonts;fonts" --add-data "locale;locale" --add-data "HUD_config.xml;." "fpdb_3_legacy/fpdb.pyw"
+            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy;fpdb_3_legacy" --add-data "gfx;gfx" --add-data "icons;icons" --add-data "fonts;fonts" --add-data "locale;locale" --add-data "HUD_config.xml;." "fpdb_3_legacy/HUD_main.pyw"
           else
-            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy:fpdb_3_legacy" --add-data "gfx:gfx" --add-data "icons:icons" --add-data "fonts:fonts" --add-data "locale:locale" --add-data "HUD_config.xml:." "fpdb_3_legacy/fpdb.pyw"
-            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy:fpdb_3_legacy" --add-data "gfx:gfx" --add-data "icons:icons" --add-data "fonts:fonts" --add-data "locale:locale" --add-data "HUD_config.xml:." "fpdb_3_legacy/HUD_main.pyw"
+            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy:fpdb_3_legacy" --add-data "gfx:gfx" --add-data "icons:icons" --add-data "fonts:fonts" --add-data "locale:locale" --add-data "HUD_config.xml:." "fpdb_3_legacy/fpdb.pyw"
+            python -m PyInstaller --noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import numpy --hidden-import fpdb_3_legacy.coinpoker_live_capture --hidden-import fpdb_3_legacy.Aux_Hud --hidden-import fpdb_3_legacy.Aux_Classic_Hud --hidden-import fpdb_3_legacy.Mucked --icon="gfx/tribal.jpg" --add-data "fpdb_3_legacy:fpdb_3_legacy" --add-data "gfx:gfx" --add-data "icons:icons" --add-data "fonts:fonts" --add-data "locale:locale" --add-data "HUD_config.xml:." "fpdb_3_legacy/HUD_main.pyw"
           fi
       - name: Bundle HUD inside fpdb
         run: python tools/bundle_pyinstaller_hud.py dist
-      - name: Re-sign assembled macOS application
+      - name: Verify assembled macOS application
         if: runner.os == 'macOS'
-        run: codesign --force --deep --sign - dist/fpdb.app
+        shell: bash
+        run: |
+          codesign --verify --deep --strict dist/fpdb.app
+          dist/fpdb.app/Contents/MacOS/fpdb --hud --help
+          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.OSXTables
+          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb.infrastructure.platform.macos
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
+            codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
+            codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null
+            grep -Eq '^TeamIdentifier=[A-Z0-9]+$' "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -q 'runtime' "$RUNNER_TEMP/fpdb-signature.txt"
+            if grep -q 'designated => cdhash' "$RUNNER_TEMP/fpdb-requirement.txt"; then
+              echo "::error::Release signature still has a version-specific cdhash requirement"
+              exit 1
+            fi
+            grep -q 'com.apple.security.automation.apple-events' "$RUNNER_TEMP/fpdb-entitlements.plist"
+          fi
+      - name: Notarize and staple PyInstaller macOS release
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        shell: bash
+        env:
+          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          python -c 'import base64, os, pathlib, sys; pathlib.Path(sys.argv[1]).write_bytes(base64.b64decode(os.environ["MACOS_NOTARY_API_KEY_P8_BASE64"]))' "$RUNNER_TEMP/fpdb-notary-key.p8"
+          ditto -c -k --keepParent dist/fpdb.app "$RUNNER_TEMP/fpdb-pyinstaller-notary.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/fpdb-pyinstaller-notary.zip" --key "$RUNNER_TEMP/fpdb-notary-key.p8" --key-id "$MACOS_NOTARY_KEY_ID" --issuer "$MACOS_NOTARY_ISSUER_ID" --wait
+          xcrun stapler staple dist/fpdb.app
+          xcrun stapler validate dist/fpdb.app
       - name: Package build artifact
         shell: bash
         env:
@@ -593,6 +652,8 @@ jobs:
     # emitted by `cargo init` since Rust 1.85.
     env:
       RUSTUP_TOOLCHAIN: "1.83.0"
+      FPDB_MACOS_SIGNING_IDENTITY: ${{ github.event_name == 'release' && secrets.MACOS_SIGNING_IDENTITY || '-' }}
+      FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}
     strategy:
       fail-fast: false
       matrix:
@@ -623,6 +684,30 @@ jobs:
             artifact: fpdb-pyoxidizer-windows-x64
     steps:
       - uses: actions/checkout@v4
+      - name: Validate macOS release credentials
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        shell: bash
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          missing=0
+          for name in FPDB_MACOS_SIGNING_IDENTITY MACOS_CERTIFICATE_P12_BASE64 MACOS_CERTIFICATE_PASSWORD MACOS_NOTARY_API_KEY_P8_BASE64 MACOS_NOTARY_KEY_ID MACOS_NOTARY_ISSUER_ID; do
+            if [[ -z "${!name}" || "${!name}" == "-" ]]; then
+              echo "::error::Missing required macOS release credential: $name"
+              missing=1
+            fi
+          done
+          exit "$missing"
+      - name: Import Developer ID certificate
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        uses: apple-actions/import-codesign-certs@v7
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -686,18 +771,47 @@ jobs:
           # The launcher is the interpreter of every helper process, so a
           # broken payload layout or search path must fail the build here.
           "$install_dir/${{ matrix.executable }}" --run-module fpdb_3_legacy.subprocess_launch
+      - name: Assemble PyOxidizer macOS application
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          install_dir="build/${{ matrix.target }}/release/install"
+          mkdir -p dist
+          python -m tools.package_pyoxidizer_macos "$install_dir" dist/fpdb.app --icon gfx/tribal.icns
+          codesign --verify --deep --strict dist/fpdb.app
+          dist/fpdb.app/Contents/MacOS/fpdb --hud --help
+          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.OSXTables
+          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb.infrastructure.platform.macos
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
+            codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
+            codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null
+            grep -Eq '^TeamIdentifier=[A-Z0-9]+$' "$RUNNER_TEMP/fpdb-signature.txt"
+            grep -q 'runtime' "$RUNNER_TEMP/fpdb-signature.txt"
+            if grep -q 'designated => cdhash' "$RUNNER_TEMP/fpdb-requirement.txt"; then
+              echo "::error::Release signature still has a version-specific cdhash requirement"
+              exit 1
+            fi
+            grep -q 'com.apple.security.automation.apple-events' "$RUNNER_TEMP/fpdb-entitlements.plist"
+          fi
+      - name: Notarize and staple PyOxidizer macOS release
+        if: runner.os == 'macOS' && github.event_name == 'release'
+        shell: bash
+        env:
+          MACOS_NOTARY_API_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_API_KEY_P8_BASE64 }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          python -c 'import base64, os, pathlib, sys; pathlib.Path(sys.argv[1]).write_bytes(base64.b64decode(os.environ["MACOS_NOTARY_API_KEY_P8_BASE64"]))' "$RUNNER_TEMP/fpdb-notary-key.p8"
+          ditto -c -k --keepParent dist/fpdb.app "$RUNNER_TEMP/fpdb-pyoxidizer-notary.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/fpdb-pyoxidizer-notary.zip" --key "$RUNNER_TEMP/fpdb-notary-key.p8" --key-id "$MACOS_NOTARY_KEY_ID" --issuer "$MACOS_NOTARY_ISSUER_ID" --wait
+          xcrun stapler staple dist/fpdb.app
+          xcrun stapler validate dist/fpdb.app
       - name: Package PyOxidizer artifact
         shell: bash
         run: |
           install_dir="build/${{ matrix.target }}/release/install"
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            # A loose directory means one quarantined download per dylib, and
-            # Gatekeeper prompts for each of them. Ship a signed bundle: it is
-            # assessed as a unit, so the user approves the app once.
-            mkdir -p dist
-            python -m tools.package_pyoxidizer_macos "$install_dir" dist/fpdb.app --icon gfx/tribal.icns
-            codesign --verify --deep --strict dist/fpdb.app
-            dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.subprocess_launch
             cp docs/macos-gatekeeper.md dist/READ-ME-FIRST-macos.md
             tar -czf "${{ matrix.artifact }}.tar.gz" -C dist fpdb.app READ-ME-FIRST-macos.md
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,6 +786,9 @@ jobs:
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.OSXTables
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb.infrastructure.platform.macos
           python -m tools.package_pyoxidizer_macos --sign-existing dist/fpdb.app
+          # Prove that a fresh filesystem import cannot mutate the sealed app.
+          # This module is intentionally absent from the pre-sign smoke list.
+          dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.winamax_ax_seats
           codesign --verify --deep --strict dist/fpdb.app
           if [[ "${{ github.event_name }}" == "release" ]]; then
             codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ Standalone builds for macOS (Apple Silicon), Windows x64 and Linux x64 are attac
 [release](https://github.com/jejellyroll-fr/fpdb-3/releases/latest). They bundle their own Python
 runtime — no install step. On macOS, read [docs/macos-gatekeeper.md](docs/macos-gatekeeper.md) first.
 
-Each platform ships two builds:
+The available packagers depend on the platform:
 
-- `fpdb-pyoxidizer-*` — a single embedded interpreter, the smaller download.
-- `fpdb-pyinstaller-*` — a directory distribution.
-
-**On Windows, take the PyInstaller build**: the PyOxidizer one does not currently run.
+- macOS ships only `fpdb-pyoxidizer-macos-arm64`. Keeping a single signed app
+  identity is required for reliable Screen Recording and Accessibility grants.
+- Linux ships both the PyOxidizer single-interpreter build and the PyInstaller
+  directory distribution.
+- Windows currently requires the PyInstaller directory distribution; its
+  PyOxidizer build does not currently run.
 
 ## 🔧 Requirements
 

--- a/build_fpdb-osx.sh
+++ b/build_fpdb-osx.sh
@@ -36,7 +36,7 @@ SECOND_SCRIPT="$LEGACY_PACKAGE_DIR/HUD_main.pyw"
 # Options of pyinstaller
 # numpy is only imported through import_module() in Database.py; PyInstaller
 # cannot follow that, and the HUD build would otherwise ship without it.
-PYINSTALLER_OPTIONS="--noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import=numpy --hidden-import=fpdb_3_legacy.coinpoker_live_capture --hidden-import=fpdb_3_legacy.Aux_Hud --hidden-import=fpdb_3_legacy.Aux_Classic_Hud --hidden-import=fpdb_3_legacy.Mucked"
+PYINSTALLER_OPTIONS="--noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import=numpy --hidden-import=fpdb_3_legacy.coinpoker_live_capture --hidden-import=fpdb_3_legacy.Aux_Hud --hidden-import=fpdb_3_legacy.Aux_Classic_Hud --hidden-import=fpdb_3_legacy.Mucked"
 
 # List of all files for fpdb
 FILES=(

--- a/build_fpdb.sh
+++ b/build_fpdb.sh
@@ -36,7 +36,7 @@ SECOND_SCRIPT="$LEGACY_PACKAGE_DIR/HUD_main.pyw"
 # Options of pyinstaller
 # numpy is only imported through import_module() in Database.py; PyInstaller
 # cannot follow that, and the HUD build would otherwise ship without it.
-PYINSTALLER_OPTIONS="--noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --hidden-import=numpy --hidden-import=fpdb_3_legacy.coinpoker_live_capture --hidden-import=fpdb_3_legacy.Aux_Hud --hidden-import=fpdb_3_legacy.Aux_Classic_Hud --hidden-import=fpdb_3_legacy.Mucked"
+PYINSTALLER_OPTIONS="--noconfirm --onedir --windowed --log-level=DEBUG --paths=fpdb_3_legacy --paths=. --additional-hooks-dir=tools/pyinstaller_hooks --hidden-import=numpy --hidden-import=fpdb_3_legacy.coinpoker_live_capture --hidden-import=fpdb_3_legacy.Aux_Hud --hidden-import=fpdb_3_legacy.Aux_Classic_Hud --hidden-import=fpdb_3_legacy.Mucked"
 
 # List of all files
 FILES=(

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -123,23 +123,25 @@ pas la vitesse.
 
 ---
 
-## 5. Les binaires macOS ne sont ni signés ni notarisés
+## 5. Provisionner les secrets de signature/notarisation macOS
 
-**Problème.** Les artefacts CI sont signés ad-hoc. macOS pose donc
-`com.apple.quarantine` sur tout ce qui vient d'un navigateur, Gatekeeper refuse
-de charger les bibliothèques Qt non signées, et le bundle tourne depuis un
-montage App Translocation en lecture seule.
+**État.** Le workflow sait signer les releases avec Developer ID, hardened
+runtime et entitlement Apple Events, puis notariser/stapler les deux variantes.
+Il refuse désormais une release ad-hoc ou sans Team ID. Les builds ordinaires de
+PR restent volontairement ad-hoc, les secrets n'étant pas exposés au code non
+fiable.
 
 **Effet mesuré.** Les traces de profilage d'une session 3.4.1 montrent les
 chemins `/private/var/…/AppTranslocation/…` : chaque première ouverture d'une
 fenêtre paie la validation Gatekeeper des ressources qu'elle charge.
 
-**Contournement documenté.** `docs/macos-gatekeeper.md` — déplacer le bundle
-hors de `~/Downloads` puis `xattr -dr com.apple.quarantine`.
+**À provisionner.** Les six secrets décrits dans `docs/macos-gatekeeper.md`, en
+utilisant le même certificat Developer ID Application pour PyInstaller,
+PyOxidizer et toutes les releases suivantes.
 
-**À faire.** `codesign --options runtime` + `xcrun notarytool submit` en CI.
-Demande un compte Apple Developer et des secrets CI, que le dépôt n'a pas.
-Tâche d'infrastructure, pas de développement.
+**Pourquoi.** Une signature ad-hoc a une designated requirement liée au CDHash
+du build. Même avec un `CFBundleIdentifier` stable, TCC ne peut donc pas
+réutiliser les autorisations Screen Recording/Accessibility entre versions.
 
 ---
 

--- a/docs/macos-gatekeeper.md
+++ b/docs/macos-gatekeeper.md
@@ -1,9 +1,24 @@
 # Running the prebuilt macOS builds
 
-The CI artifacts are **not** signed with a Developer ID and are **not** notarized.
-macOS therefore attaches the `com.apple.quarantine` attribute to everything that
-comes out of a browser download, and Gatekeeper refuses to load the unsigned Qt
-libraries the builds ship:
+Published GitHub Release builds are required by CI to be signed with one stable
+Developer ID Application identity, hardened, notarized, and stapled. The
+release job fails instead of uploading a macOS archive if the signature is ad
+hoc, has no Team ID, uses a designated requirement based on a `cdhash`, lacks
+the Apple Events entitlement, or cannot be notarized.
+
+Move `fpdb.app` to `/Applications` before the first launch. macOS can then keep
+the app at a stable location and attribute Screen Recording, Accessibility, and
+Automation consent to its stable code-signing identity.
+
+## Pull-request and ordinary CI artifacts
+
+Non-release Actions artifacts remain ad-hoc signed because untrusted workflows
+do not receive the Apple certificate secrets. They are suitable for testing one
+exact build, but their code hash changes on every rebuild; macOS privacy grants
+therefore do **not** persist between those artifacts.
+
+A browser also attaches the `com.apple.quarantine` attribute to a downloaded
+non-notarized artifact, and Gatekeeper can refuse to load its Qt libraries:
 
 ```
 Library not loaded: @rpath/libshiboken6.abi3.6.11.dylib
@@ -17,17 +32,16 @@ writes next to the executable.
 
 ## Fix: clear the quarantine attribute
 
-Both artifacts (`fpdb-pyoxidizer-macos-arm64` and `fpdb-build-macos-latest`) ship
-an ad-hoc signed `fpdb.app`. Gatekeeper assesses a bundle as a unit, so the app
-is approved once instead of once per bundled library:
+For an ad-hoc CI build only, move it and clear quarantine:
 
 ```bash
 mv ~/Downloads/fpdb.app /Applications/
 xattr -dr com.apple.quarantine /Applications/fpdb.app
 ```
 
-Moving the bundle out of `~/Downloads` and clearing the attribute both stop App
-Translocation, so the app runs from its real path again.
+Do not re-sign a published release ad hoc: doing so discards its Developer ID
+identity and invalidates the stable privacy grants this packaging is designed to
+preserve.
 
 ## Avoiding the problem: extract from the terminal
 
@@ -41,9 +55,15 @@ unzip fpdb-pyoxidizer-macos-arm64.zip
 tar -xzf fpdb-pyoxidizer-macos-arm64.tar.gz -C fpdb-pyoxidizer-macos-arm64
 ```
 
-## Permanent fix
+## Release credential setup
 
-Signing with a Developer ID certificate and notarizing the artifacts
-(`codesign --options runtime` + `xcrun notarytool submit`) removes the need for
-any of the above. That requires an Apple Developer account and CI secrets, which
-this repository does not currently have.
+The release workflow expects these repository secrets:
+
+- `MACOS_SIGNING_IDENTITY`: the full Developer ID Application identity;
+- `MACOS_CERTIFICATE_P12_BASE64` and `MACOS_CERTIFICATE_PASSWORD`;
+- `MACOS_NOTARY_API_KEY_P8_BASE64`, `MACOS_NOTARY_KEY_ID`, and
+  `MACOS_NOTARY_ISSUER_ID`.
+
+The same certificate must be used for both the PyInstaller and PyOxidizer
+variants and for every subsequent release. Replacing it changes the designated
+requirement and may require users to grant the privacy permissions again.

--- a/docs/macos-gatekeeper.md
+++ b/docs/macos-gatekeeper.md
@@ -1,14 +1,42 @@
-# Running the prebuilt macOS builds
+# Running the prebuilt macOS build
 
-Published GitHub Release builds are required by CI to be signed with one stable
-Developer ID Application identity, hardened, notarized, and stapled. The
-release job fails instead of uploading a macOS archive if the signature is ad
-hoc, has no Team ID, uses a designated requirement based on a `cdhash`, lacks
-the Apple Events entitlement, or cannot be notarized.
+PyOxidizer is the only published macOS build. Published GitHub Release builds
+are required by CI to be signed with one stable Developer ID Application
+identity, hardened, notarized, and stapled. The release job fails instead of
+uploading a macOS archive if the signature is ad hoc, has no Team ID, uses a
+designated requirement based on a `cdhash`, lacks the Apple Events entitlement,
+or cannot be notarized.
 
 Move `fpdb.app` to `/Applications` before the first launch. macOS can then keep
 the app at a stable location and attribute Screen Recording, Accessibility, and
 Automation consent to its stable code-signing identity.
+
+Do not keep a PyInstaller build or another CI copy named `fpdb.app` alongside
+the installed application. Multiple ad-hoc copies with the same bundle
+identifier have different code hashes, so System Settings can update the wrong
+copy's privacy record while another copy is running.
+
+macOS groups Screen Recording and system-audio capture in one Settings panel;
+FPDB needs the screen permission to read poker-table window metadata and does
+not request microphone access or record audio. The separate “data from other
+apps” prompt covers configured hand-history and client-log files. FPDB waits
+until auto-import is started before touching those protected paths.
+
+## One-time migration from older ad-hoc builds
+
+Before testing the first signed release, quit FPDB, delete every older
+`fpdb.app` copy from Downloads or elsewhere, and install the signed PyOxidizer
+application in `/Applications`. Clear the stale FPDB-only privacy records once:
+
+```bash
+tccutil reset All org.fpdb.fpdb3
+open /Applications/fpdb.app
+```
+
+Start the HUD and use its **macOS Permissions…** button to request only the
+missing permissions. Do not repeat this reset for normal upgrades: subsequent
+releases retain the same Developer ID identity specifically so that macOS can
+preserve those grants.
 
 ## Pull-request and ordinary CI artifacts
 
@@ -16,6 +44,10 @@ Non-release Actions artifacts remain ad-hoc signed because untrusted workflows
 do not receive the Apple certificate secrets. They are suitable for testing one
 exact build, but their code hash changes on every rebuild; macOS privacy grants
 therefore do **not** persist between those artifacts.
+
+Use a signed pre-release or release build for acceptance testing of Screen
+Recording and Accessibility. A pull-request artifact can exercise the feature
+within one run, but it cannot validate that permissions survive an upgrade.
 
 A browser also attaches the `com.apple.quarantine` attribute to a downloaded
 non-notarized artifact, and Gatekeeper can refuse to load its Qt libraries:
@@ -64,6 +96,6 @@ The release workflow expects these repository secrets:
 - `MACOS_NOTARY_API_KEY_P8_BASE64`, `MACOS_NOTARY_KEY_ID`, and
   `MACOS_NOTARY_ISSUER_ID`.
 
-The same certificate must be used for both the PyInstaller and PyOxidizer
-variants and for every subsequent release. Replacing it changes the designated
-requirement and may require users to grant the privacy permissions again.
+The same certificate must be used for every subsequent PyOxidizer release.
+Replacing it changes the designated requirement and may require users to grant
+the privacy permissions again.

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -7,9 +7,7 @@ Events GUI-scripting fallback when Quartz titles are unavailable.
 from __future__ import annotations
 
 import logging
-import os
 import subprocess
-import sys
 
 from . import permissions
 from .protocol import Platform, TableGeometry, TableInfo
@@ -127,8 +125,9 @@ class MacOSTableDetector:
     def _check_permissions_once(self) -> permissions.PermissionStatus:
         """Log the privacy-permission diagnosis once when titles are missing.
 
-        Frozen apps trigger the native prompts automatically. Source installs
-        can opt in with ``FPDB_REQUEST_MACOS_PERMISSIONS=1``.
+        This detector is deliberately diagnostic-only. ``HudMain`` owns the
+        native prompts so one missing title cannot reopen System Settings or
+        duplicate a request already made at HUD startup.
         """
         if self._permissions_checked:
             return self._permission_status or permissions.get_status()
@@ -147,23 +146,16 @@ class MacOSTableDetector:
 
         for message in messages:
             logger.warning(message)
-
-        if getattr(sys, "frozen", False) or os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
-            if not status.screen_recording:
-                logger.info("Requesting Screen Recording permission (native prompt)...")
-                permissions.request_screen_recording_permission()
-                permissions.open_screen_recording_settings()
-            if not status.accessibility:
-                logger.info("Requesting Accessibility permission (native prompt)...")
-                permissions.request_accessibility_permission(prompt=True)
-                permissions.open_accessibility_settings()
         return status
 
-    def find_tables(self, search_string: str = "") -> list[TableInfo]:
+    def find_tables(self, search_string: str = "", *, allow_fallback: bool = True) -> list[TableInfo]:
         """Find all windows matching the search string
 
         Args:
             search_string: String to search for in window titles
+            allow_fallback: Whether argv/System Events may be used when Quartz
+                exposes no matching title. Fast Fold disables this for its
+                first pass so Accessibility can answer before any Apple Event.
 
         Returns:
             List of TableInfo for matching windows
@@ -248,7 +240,7 @@ class MacOSTableDetector:
         # either no window matched, or none exposed a title at all (most often
         # missing Screen Recording permission).
         has_only_empty_titles = len(tables) > 0 and all(t.title == "" for t in tables)
-        if len(tables) == 0 or has_only_empty_titles:
+        if allow_fallback and (len(tables) == 0 or has_only_empty_titles):
             fallback = self._find_tables_without_titles(
                 search_string,
                 target_table_windows,

--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -1,8 +1,7 @@
 """macOS table detector implementation
 
-Uses AppKit/Quartz frameworks for window detection on macOS.
-Also uses AppleScript as fallback for apps like Winamax (Electron)
-that don't expose window titles through Quartz.
+Uses AppKit/Quartz frameworks for window detection on macOS, with a System
+Events GUI-scripting fallback when Quartz titles are unavailable.
 """
 
 from __future__ import annotations
@@ -10,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
 
 from . import permissions
 from .protocol import Platform, TableGeometry, TableInfo
@@ -92,13 +92,12 @@ class MacOSTableDetector:
         # Emit the privacy-permission diagnosis at most once per process.
         self._permissions_checked = False
         self._permission_status: permissions.PermissionStatus | None = None
-        self._automation_warned = False
+        self._system_events_warned = False
 
-        # Set once System Events has told us this process may not drive it.
-        # Until it does, the scan is always worth trying: Automation is the one
-        # grant macOS prompts for, so a refusal now can become a grant later --
-        # but only after a restart, which clears this too.
-        self._automation_blocked = False
+        # Set once System Events has refused GUI scripting or stopped answering.
+        # A restart is required after changing either Automation or
+        # Accessibility, and also clears this circuit breaker.
+        self._system_events_blocked = False
 
         # Lazy-import macOS dependencies
         try:
@@ -128,8 +127,8 @@ class MacOSTableDetector:
     def _check_permissions_once(self) -> permissions.PermissionStatus:
         """Log the privacy-permission diagnosis once when titles are missing.
 
-        Set ``FPDB_REQUEST_MACOS_PERMISSIONS=1`` to also trigger the native
-        prompts / open the relevant System Settings panes automatically.
+        Frozen apps trigger the native prompts automatically. Source installs
+        can opt in with ``FPDB_REQUEST_MACOS_PERMISSIONS=1``.
         """
         if self._permissions_checked:
             return self._permission_status or permissions.get_status()
@@ -149,7 +148,7 @@ class MacOSTableDetector:
         for message in messages:
             logger.warning(message)
 
-        if os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
+        if getattr(sys, "frozen", False) or os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
             if not status.screen_recording:
                 logger.info("Requesting Screen Recording permission (native prompt)...")
                 permissions.request_screen_recording_permission()
@@ -233,10 +232,10 @@ class MacOSTableDetector:
         except Exception as e:
             logger.error(f"Error finding tables via Quartz: {e}", exc_info=True)
 
-        # Quartz only exposes window titles when Screen Recording permission is
-        # granted; without it kCGWindowName is empty for every window. Electron
-        # clients (e.g. Winamax) also never expose titles through Quartz. Detect
-        # both cases so we can tell a permission problem apart from a regex miss.
+        # Quartz only exposes other applications' window titles when Screen
+        # Recording is granted; without it kCGWindowName is empty. A granted
+        # build does expose Winamax titles, so an empty title is a permission or
+        # lookup signal, not an Electron limitation.
         logger.debug(
             "DIAGNOSTIC: Quartz saw %d on-screen windows, %d with titles; %d matched search '%s'",
             total_windows,
@@ -246,8 +245,8 @@ class MacOSTableDetector:
         )
 
         # Fallback to AppleScript / argv when Quartz produced no usable match:
-        # either no window matched, or none exposed a title at all (missing Screen
-        # Recording permission / Electron client).
+        # either no window matched, or none exposed a title at all (most often
+        # missing Screen Recording permission).
         has_only_empty_titles = len(tables) > 0 and all(t.title == "" for t in tables)
         if len(tables) == 0 or has_only_empty_titles:
             fallback = self._find_tables_without_titles(
@@ -296,15 +295,12 @@ class MacOSTableDetector:
         self._check_permissions_once()
         if not (total_windows > 0 and titled_windows == 0):
             logger.debug("DIAGNOSTIC: No Quartz window matched the search string. Trying AppleScript fallback...")
-        # Not gated on Accessibility: driving System Events needs *Automation*,
-        # which is a different grant and the only one macOS actually prompts
-        # for. Gating on Accessibility switched this scan off in every packaged
-        # build -- and for an Electron client like Winamax it is the only way
-        # left to read a window title, Quartz never exposing one. The cost it
-        # was meant to avoid is instead avoided by stopping once System Events
-        # has actually refused us.
+        # System Events GUI scripting needs both Automation (to send it Apple
+        # Events) and Accessibility (to inspect processes/windows). Try once so
+        # macOS can surface the Automation request, then stop after an explicit
+        # refusal or timeout instead of blocking every table lookup.
         applescript_tables = []
-        if not self._automation_blocked:
+        if not self._system_events_blocked:
             applescript_tables = self.find_tables_applescript(search_string)
         if applescript_tables:
             logger.debug(f"DIAGNOSTIC: AppleScript fallback found {len(applescript_tables)} matching tables")
@@ -444,26 +440,42 @@ class MacOSTableDetector:
 
     _AUTOMATION_BLOCKED_MARKERS = (
         "-1743",  # not authorised to send Apple events
-        "-1712",  # the Automation prompt is up and unanswered, so the event timed out
         "Not authorized to send Apple events",
-        "AppleEvent timed out",
     )
 
-    def _report_automation_blocked(self, detail: str) -> None:
+    _ACCESSIBILITY_BLOCKED_MARKERS = (
+        # Often accompanied by -1719, but that number alone also means an
+        # invalid index. Match the diagnostic text, never the bare number.
+        "not allowed assistive access",
+        "does not have access to assistive devices",
+    )
+
+    _SYSTEM_EVENTS_TIMEOUT_MARKERS = ("-1712", "AppleEvent timed out")
+
+    def _report_system_events_blocked(self, detail: str, reason: str) -> None:
         """Stop scanning, and say once why no table window can be read."""
-        self._automation_blocked = True
-        if self._automation_warned:
+        self._system_events_blocked = True
+        if self._system_events_warned:
             return
-        self._automation_warned = True
-        logger.warning(
-            "Poker table windows cannot be read: this application is not allowed to control "
-            "'System Events' (Automation). On macOS that is the only way to read an Electron "
-            "client's window title -- Quartz never exposes one -- so the HUD cannot find its "
-            "table. Allow it in System Settings > Privacy & Security > Automation "
-            "(FPDB -> System Events) and restart FPDB. If FPDB is not listed there, run "
-            "'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS asks again. Detail: %s",
-            detail,
-        )
+        self._system_events_warned = True
+        if reason == "automation":
+            action = "Allow FPDB -> System Events in Privacy & Security > Automation"
+        elif reason == "accessibility":
+            action = "Allow FPDB in Privacy & Security > Accessibility"
+        else:
+            action = "Check for a pending permission prompt and that System Events is responsive"
+        logger.warning("Poker table windows cannot be read through System Events (%s). %s, then restart FPDB. Detail: %s", reason, action, detail)
+
+    def _handle_system_events_failure(self, stderr: str) -> None:
+        """Classify a failed System Events scan without conflating TCC services."""
+        if any(marker in stderr for marker in self._AUTOMATION_BLOCKED_MARKERS):
+            self._report_system_events_blocked(stderr, "automation")
+        elif any(marker in stderr for marker in self._ACCESSIBILITY_BLOCKED_MARKERS):
+            self._report_system_events_blocked(stderr, "accessibility")
+        elif any(marker in stderr for marker in self._SYSTEM_EVENTS_TIMEOUT_MARKERS):
+            self._report_system_events_blocked(stderr, "timeout")
+        else:
+            logger.debug("AppleScript window scan failed: %s", stderr)
 
     def _run_applescript_scan(self) -> None:
         """Execute the full AppleScript scan and populate the cache.
@@ -532,15 +544,7 @@ class MacOSTableDetector:
 
             if result.returncode != 0:
                 stderr = result.stderr.strip()
-                # -1743: refused outright. -1712: the Automation prompt is on
-                # screen unanswered, so the event timed out. Both mean the same
-                # thing for us -- no window titles until the user allows it --
-                # and both must stop the scan, or every table lookup pays a
-                # multi-second timeout.
-                if any(marker in stderr for marker in self._AUTOMATION_BLOCKED_MARKERS):
-                    self._report_automation_blocked(stderr)
-                else:
-                    logger.debug("AppleScript window scan failed: %s", stderr)
+                self._handle_system_events_failure(stderr)
 
             if result.returncode == 0 and result.stdout.strip():
                 windows_str = result.stdout.strip()
@@ -578,11 +582,12 @@ class MacOSTableDetector:
                             self._applescript_cache[window_id] = table_info
 
         except subprocess.TimeoutExpired:
-            # An unanswered Automation prompt blocks osascript rather than
-            # failing it, so this never reaches the return-code handling above.
-            # Left uncounted it is the worst case of all: every table lookup
-            # pays the full timeout again.
-            self._report_automation_blocked(f"osascript did not return within {self._APPLESCRIPT_TIMEOUT:.0f}s")
+            # A pending prompt or an unresponsive System Events process can
+            # block osascript. Do not make every table lookup pay the timeout.
+            self._report_system_events_blocked(
+                f"osascript did not return within {self._APPLESCRIPT_TIMEOUT:.0f}s",
+                "timeout",
+            )
         except Exception as e:
             logger.error(f"Error in _run_applescript_scan: {e}", exc_info=True)
 
@@ -591,8 +596,8 @@ class MacOSTableDetector:
     def find_tables_applescript(self, search_string: str = "") -> list[TableInfo]:
         """Find tables using AppleScript for all active poker processes.
 
-        This serves as a robust fallback on macOS 10.15+ when Screen Recording
-        permissions are missing or when Electron apps do not expose titles via Quartz.
+        This serves as a fallback when Screen Recording is missing or Quartz
+        otherwise produced no usable title.
         """
         import re
         import time

--- a/fpdb/infrastructure/platform/permissions.py
+++ b/fpdb/infrastructure/platform/permissions.py
@@ -9,6 +9,10 @@ found"):
   so title-based matching fails. Geometry/IDs are still available.
 * **Accessibility** – required for the Winamax seat reader and for System
   Events GUI scripting of processes/windows.
+* **App Data** – macOS may require consent when FPDB reads Winamax logs or hand
+  histories owned by another application. There is no side-effect-free public
+  preflight for this consent; its status is therefore informational until the
+  first real file access, whose system prompt uses ``NSAppDataUsageDescription``.
 * **Automation** – separately requested by macOS when FPDB sends an Apple Event
   to System Events. There is no side-effect-free preflight for that consent, so
   it is diagnosed from the first real scan rather than stored in this snapshot.
@@ -39,9 +43,15 @@ class PermissionStatus:
 
     screen_recording: bool
     accessibility: bool
+    # macOS exposes no public, side-effect-free App Data preflight. ``None`` is
+    # deliberately distinct from granted: the UI can explain that the status
+    # is managed by macOS without pretending that access was verified.
+    app_data: bool | None = None
 
     @property
     def all_granted(self) -> bool:
+        # App Data is informational and must never gate table detection or HUD
+        # startup: unlike the two checks above, it cannot be preflighted safely.
         return self.screen_recording and self.accessibility
 
 
@@ -128,6 +138,7 @@ def get_status() -> PermissionStatus:
     return PermissionStatus(
         screen_recording=has_screen_recording_permission(),
         accessibility=has_accessibility_permission(),
+        app_data=None,
     )
 
 
@@ -143,14 +154,22 @@ def describe_missing(status: PermissionStatus | None = None) -> list[str]:
         messages.append(
             "Screen Recording permission is missing: Quartz cannot read window "
             "titles, so poker tables won't be detected by title. Grant it in "
-            "System Settings > Privacy & Security > Screen Recording (then "
-            "restart FPDB).",
+            "System Settings > Privacy & Security > Screen & System Audio "
+            "Recording. Return to FPDB and use Recheck; quit and reopen FPDB "
+            "manually only if table titles remain unavailable.",
         )
     if not status.accessibility:
         messages.append(
             "Accessibility permission is missing: FPDB cannot inspect poker "
             "windows or read Winamax seats through Accessibility/System Events. "
             "Grant it in System Settings > Privacy & Security > Accessibility "
-            "(then restart FPDB).",
+            "and then return to FPDB and use Recheck.",
+        )
+    if status.app_data is False:
+        messages.append(
+            "App Data access is missing: FPDB may be unable to read Winamax "
+            "logs or hand histories. macOS owns this consent and provides no "
+            "safe preflight, request API, or dedicated Settings pane; FPDB "
+            "therefore waits for the prompt from the first real file access.",
         )
     return messages

--- a/fpdb/infrastructure/platform/permissions.py
+++ b/fpdb/infrastructure/platform/permissions.py
@@ -1,15 +1,17 @@
 """macOS privacy-permission preflight for HUD table detection.
 
-Table detection on macOS depends on two *separate* privacy permissions, and a
+Table detection on macOS depends on separate privacy permissions, and a
 missing one is the usual reason a HUD never appears ("table name ... not
 found"):
 
 * **Screen Recording** – required for Quartz (``CGWindowListCopyWindowInfo``) to
   expose window *titles* (``kCGWindowName``). Without it every title is empty,
   so title-based matching fails. Geometry/IDs are still available.
-* **Accessibility / Automation** – required for the AppleScript (``System
-  Events``) fallback used for Electron clients such as Winamax, which never
-  expose titles through Quartz. Without it ``osascript`` returns nothing.
+* **Accessibility** – required for the Winamax seat reader and for System
+  Events GUI scripting of processes/windows.
+* **Automation** – separately requested by macOS when FPDB sends an Apple Event
+  to System Events. There is no side-effect-free preflight for that consent, so
+  it is diagnosed from the first real scan rather than stored in this snapshot.
 
 This module checks, requests, and explains those permissions. Everything is a
 safe no-op (returning ``True``) on non-macOS so callers need no platform guard.
@@ -146,9 +148,9 @@ def describe_missing(status: PermissionStatus | None = None) -> list[str]:
         )
     if not status.accessibility:
         messages.append(
-            "Accessibility/Automation permission is missing: the AppleScript "
-            "fallback used for Electron clients (e.g. Winamax) cannot list "
-            "windows. Grant it in System Settings > Privacy & Security > "
-            "Accessibility (then restart FPDB).",
+            "Accessibility permission is missing: FPDB cannot inspect poker "
+            "windows or read Winamax seats through Accessibility/System Events. "
+            "Grant it in System Settings > Privacy & Security > Accessibility "
+            "(then restart FPDB).",
         )
     return messages

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -37,6 +37,7 @@ from PySide6.QtWidgets import (
 from fpdb_3_legacy import Configuration, Importer
 from fpdb_3_legacy.i18n import gettext as _
 from fpdb_3_legacy.loggingFpdb import get_logger
+from fpdb_3_legacy.subprocess_launch import hud_main_command
 
 # Import for dynamic reloading configuration
 try:
@@ -720,19 +721,9 @@ class GuiAutoImport(QWidget):
         # ------------------------------------------------------------------
         command: str | list[str]
         frozen = getattr(sys, "frozen", False)
-        if frozen == "pyoxidizer":
-            # A single binary hosts both entry points; --hud selects HUD_main.
-            command = [sys.executable, "--hud", *self.settings["cl_options"].split()]
-            bs = 1
-
-        elif frozen:
-            executable = "HUD_main.exe" if os.name == "nt" else "HUD_main"
-            command = os.path.join(self._hud_base_path(), executable)
-            if not os.path.isfile(command):
-                msg = f"HUD_main not found at {command}"
-                raise FileNotFoundError(msg)
-            command = [command, *self.settings["cl_options"].split()]
-            bs = 0 if os.name == "nt" else 1
+        if frozen:
+            command = hud_main_command(*self.settings["cl_options"].split())
+            bs = 0 if os.name == "nt" and frozen != "pyoxidizer" else 1
 
         elif self.config.install_method == "exe":
             command = "HUD_main.exe"

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -925,7 +925,13 @@ class GuiAutoImport(QWidget):
         super().closeEvent(event)
 
     def _configured_import_directories(self) -> dict[tuple[str, str], str]:
-        """Return existing import directories from the current enabled sites."""
+        """Resolve import paths for the current enabled sites.
+
+        This helper is reached only from an active ``updatePaths()`` call.
+        Keeping ``get_default_paths(site)`` here preserves room-specific path
+        recovery (for example after an OS/account migration) without probing
+        any site while Auto Import is stopped.
+        """
         directories: dict[tuple[str, str], str] = {}
         for site in self.config.get_supported_sites():
             # A site can be enabled under <supported_sites> without a matching
@@ -937,7 +943,7 @@ class GuiAutoImport(QWidget):
             except KeyError as e:
                 log.warning("Skipping auto-import for misconfigured site %s (missing config: %s)", site, e)
                 continue
-            if not params["enabled"]:
+            if not params.get("enabled", False):
                 continue
 
             try:
@@ -945,6 +951,7 @@ class GuiAutoImport(QWidget):
             except KeyError as e:
                 log.warning("Skipping auto-import paths for misconfigured site %s (missing config: %s)", site, e)
                 continue
+
             hh_path = paths.get("hud-defaultPath")
             if hh_path and os.path.isdir(hh_path):
                 directories[(site, "hh")] = hh_path
@@ -961,6 +968,13 @@ class GuiAutoImport(QWidget):
 
     def updatePaths(self) -> None:
         """Reload config paths and resynchronise the importer's watched dirs."""
+        if not self.doAutoImportBool:
+            # Configuration observers also run while the tab is merely open.
+            # Defer all reload/path work until Start Auto Import (or the
+            # headless equivalent) has explicitly made the importer active.
+            log.debug("Deferring auto-import path update while Auto Import is stopped")
+            return
+
         log.debug("Updating auto-import paths from configuration")
 
         if hasattr(self.config, "reload"):
@@ -1010,7 +1024,10 @@ def main(argv=None):
 
     settings.update(config.get_db_parameters())
     settings.update(config.get_import_parameters())
-    settings.update(config.get_default_paths())
+    # Path discovery belongs to an active Auto Import session. In particular,
+    # get_default_paths() probes fallback locations when the configured default
+    # is missing, which is inappropriate while merely constructing this entry
+    # point.
     settings["global_lock"] = interlocks.InterProcessLock(name="fpdb_global_lock")
     settings["cl_options"] = ".".join(argv)
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -40,7 +40,7 @@ zmq: Any = _zmq
 from cachetools import TTLCache
 from PySide6.QtCore import QCoreApplication, QEvent, QObject, Qt, QThread, QTimer, Signal
 from PySide6.QtGui import QCloseEvent, QIcon
-from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QApplication, QDialog, QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 from qt_material import apply_stylesheet
 
 from fpdb_3_legacy import Aux_Base, Configuration, Database, Deck, Hud, Options, db_profile
@@ -404,6 +404,143 @@ class HudMainWindow(QWidget):
         self._on_close(event)
 
 
+class MacOSPermissionsDialog(QDialog):
+    """Explicit, non-modal onboarding for the HUD's macOS permissions.
+
+    Constructing or refreshing this dialog only runs side-effect-free
+    preflights. Native prompts and System Settings are reached exclusively from
+    the corresponding user-operated buttons.
+    """
+
+    status_changed = Signal(object)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Build the permission status and action rows."""
+        super().__init__(parent)
+        self.setWindowTitle("FPDB macOS Permissions")
+        self.setModal(False)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, False)
+
+        layout = QVBoxLayout(self)
+        intro = QLabel(
+            "FPDB checks these permissions without requesting them. "
+            "Use the buttons below only when you want macOS to prompt or open System Settings.",
+        )
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+        screen_note = QLabel(
+            "macOS groups this under Screen & System Audio Recording. "
+            "FPDB reads window metadata only and does not request microphone access.",
+        )
+        screen_note.setWordWrap(True)
+        layout.addWidget(screen_note)
+
+        grid = QGridLayout()
+        grid.addWidget(QLabel("Permission"), 0, 0)
+        grid.addWidget(QLabel("Status"), 0, 1)
+        grid.addWidget(QLabel("Actions"), 0, 2, 1, 2)
+
+        self.screen_status_label = QLabel()
+        self.screen_request_button = QPushButton("Request Screen Recording")
+        self.screen_settings_button = QPushButton("Open Screen Recording Settings")
+        grid.addWidget(QLabel("Screen Recording"), 1, 0)
+        grid.addWidget(self.screen_status_label, 1, 1)
+        grid.addWidget(self.screen_request_button, 1, 2)
+        grid.addWidget(self.screen_settings_button, 1, 3)
+
+        self.accessibility_status_label = QLabel()
+        self.accessibility_request_button = QPushButton("Request Accessibility")
+        self.accessibility_settings_button = QPushButton("Open Accessibility Settings")
+        grid.addWidget(QLabel("Accessibility"), 2, 0)
+        grid.addWidget(self.accessibility_status_label, 2, 1)
+        grid.addWidget(self.accessibility_request_button, 2, 2)
+        grid.addWidget(self.accessibility_settings_button, 2, 3)
+
+        self.app_data_status_label = QLabel()
+        self.app_data_info_label = QLabel(
+            "Informational only: macOS prompts on the first protected Winamax file access, "
+            "using the bundle's NSAppDataUsageDescription.",
+        )
+        self.app_data_info_label.setWordWrap(True)
+        grid.addWidget(QLabel("App Data"), 3, 0)
+        grid.addWidget(self.app_data_status_label, 3, 1)
+        grid.addWidget(self.app_data_info_label, 3, 2, 1, 2)
+        grid.setColumnStretch(2, 1)
+        layout.addLayout(grid)
+
+        restart_note = QLabel(
+            "After changing Screen Recording, quit and reopen FPDB yourself if table titles remain unavailable. "
+            "FPDB never restarts automatically.",
+        )
+        restart_note.setWordWrap(True)
+        layout.addWidget(restart_note)
+
+        button_row = QHBoxLayout()
+        self.recheck_button = QPushButton("Recheck")
+        self.close_button = QPushButton("Close")
+        button_row.addWidget(self.recheck_button)
+        button_row.addStretch(1)
+        button_row.addWidget(self.close_button)
+        layout.addLayout(button_row)
+
+        self.screen_request_button.clicked.connect(self._request_screen_recording)
+        self.screen_settings_button.clicked.connect(self._open_screen_recording_settings)
+        self.accessibility_request_button.clicked.connect(self._request_accessibility)
+        self.accessibility_settings_button.clicked.connect(self._open_accessibility_settings)
+        self.recheck_button.clicked.connect(self.refresh_status)
+        self.close_button.clicked.connect(self.hide)
+
+    @staticmethod
+    def _binary_status(granted: bool) -> str:
+        return "Granted" if granted else "Missing"
+
+    def set_status(self, status: Any) -> None:
+        """Render an already-computed permission snapshot without side effects."""
+        self.screen_status_label.setText(self._binary_status(status.screen_recording))
+        self.accessibility_status_label.setText(self._binary_status(status.accessibility))
+        if status.app_data is None:
+            self.app_data_status_label.setText("Not preflightable")
+        else:
+            self.app_data_status_label.setText(self._binary_status(status.app_data))
+        self.screen_request_button.setEnabled(not status.screen_recording)
+        self.accessibility_request_button.setEnabled(not status.accessibility)
+
+    def refresh_status(self) -> Any:
+        """Run diagnostic-only preflights and update the three status rows."""
+        from fpdb.infrastructure.platform import permissions
+
+        status = permissions.get_status()
+        self.set_status(status)
+        self.status_changed.emit(status)
+        return status
+
+    def _request_screen_recording(self) -> None:
+        """Request Screen Recording after an explicit button click."""
+        from fpdb.infrastructure.platform import permissions
+
+        permissions.request_screen_recording_permission()
+        self.refresh_status()
+
+    def _request_accessibility(self) -> None:
+        """Request Accessibility after an explicit button click."""
+        from fpdb.infrastructure.platform import permissions
+
+        permissions.request_accessibility_permission(prompt=True)
+        self.refresh_status()
+
+    @staticmethod
+    def _open_screen_recording_settings() -> None:
+        from fpdb.infrastructure.platform import permissions
+
+        permissions.open_screen_recording_settings()
+
+    @staticmethod
+    def _open_accessibility_settings() -> None:
+        from fpdb.infrastructure.platform import permissions
+
+        permissions.open_accessibility_settings()
+
+
 class HudMain(QObject):
     """A main() object to own both the socket thread and the gui."""
 
@@ -697,27 +834,7 @@ class HudMain(QObject):
                 height=self.hud_params["card_ht"],
             )
 
-            from fpdb_3_legacy.winamax_ax_seats import WinamaxAXSeatReader, is_supported
-            from fpdb_3_legacy.winamax_live_log_reader import WinamaxLiveLogReader
-            from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
-
-            # Reads seats off the table window itself. The log can only say who
-            # has acted, and never where they sit; this knows both, immediately.
-            self.winamax_ax_seats = WinamaxAXSeatReader() if is_supported() else None
-
-            # The window says which game it deals only to a process holding
-            # macOS Accessibility, which packaged builds do not. Imported hands
-            # say it unconditionally, so what they prove is kept.
-            self.winamax_pool_games = WinamaxPoolGames(
-                Path(Configuration.CONFIG_PATH) / "winamax_pool_games.json" if Configuration.CONFIG_PATH else None,
-            )
-
-            # Queued by Qt because the reader emits from its tailing thread.
-            self.winamax_table_update.connect(self._on_winamax_table_update)
-            self.winamax_log_reader = WinamaxLiveLogReader(
-                on_table_update=self.winamax_table_update.emit,
-            )
-            self.winamax_log_reader.start()
+            self._initialize_winamax_live_sources()
 
             # Cache initialization
             self.cache: TTLCache = TTLCache(maxsize=1000, ttl=300)  # Cache of 1000 elements with a TTL of 5 minutes
@@ -771,44 +888,93 @@ class HudMain(QObject):
             raise
 
     def _check_macos_permissions(self) -> None:
-        """Diagnose macOS privacy permissions required for table detection.
+        """Diagnose macOS privacy permissions without prompting or opening Settings.
 
-        Screen Recording is needed for Quartz to expose window titles;
-        Accessibility is needed for Winamax seats and System Events GUI
-        scripting; Automation is a separate consent requested by the first
-        Apple Event. Frozen builds trigger the native Screen Recording and
-        Accessibility prompts automatically. Source installs can opt in with
-        ``FPDB_REQUEST_MACOS_PERMISSIONS=1``.
+        This startup path is deliberately identical for source and frozen
+        builds. Permission requests belong only to the explicit onboarding
+        buttons in :class:`MacOSPermissionsDialog`.
         """
         try:
             from fpdb.infrastructure.platform import permissions
         except Exception:
             log.debug("macOS permissions preflight unavailable", exc_info=True)
+            self._macos_permission_status = None
             return
 
         status = permissions.get_status()
+        self._macos_permission_status = status
         if status.all_granted:
             log.info("macOS permissions OK (Screen Recording + Accessibility granted)")
-            return
-
         for message in permissions.describe_missing(status):
             log.warning(message)
+        if status.app_data is None:
+            log.info("macOS App Data permission is managed by macOS and cannot be preflighted safely")
 
-        if getattr(sys, "frozen", False) or os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
-            if not status.screen_recording:
-                log.info("Requesting Screen Recording permission (native prompt)...")
-                permissions.request_screen_recording_permission()
-                permissions.open_screen_recording_settings()
-                log.warning(
-                    "After granting Screen Recording permission, restart FPDB for it to take effect.",
-                )
-            elif not status.accessibility:
-                log.info("Requesting Accessibility permission (native prompt)...")
-                permissions.request_accessibility_permission(prompt=True)
-                permissions.open_accessibility_settings()
-                log.warning(
-                    "After granting Accessibility permission, restart FPDB for it to take effect.",
-                )
+    @staticmethod
+    def _site_enabled_in_config(config: Any, site_name: str) -> bool:
+        """Read an enabled-site flag from the loaded config without resolving paths."""
+        try:
+            enabled_sites = config.get_supported_sites()
+            wanted = site_name.casefold()
+            return any(str(site).casefold() == wanted for site in enabled_sites)
+        except Exception:
+            log.warning("Could not read enabled sites while initializing %s live sources", site_name, exc_info=True)
+            return False
+
+    def _initialize_winamax_live_sources(self) -> None:
+        """Start Winamax-only helpers when Winamax is enabled in the loaded config."""
+        self.winamax_ax_seats = None
+        self.winamax_pool_games = None
+        self.winamax_log_reader = None
+        if not self._site_enabled_in_config(self.config, "Winamax"):
+            log.info("Winamax is disabled; live log and Accessibility helpers will not be initialized")
+            return
+
+        from fpdb_3_legacy.winamax_ax_seats import WinamaxAXSeatReader, is_supported
+        from fpdb_3_legacy.winamax_live_log_reader import WinamaxLiveLogReader
+        from fpdb_3_legacy.winamax_pool_games import WinamaxPoolGames
+
+        # Reads seats off the table window itself. The log can only say who has
+        # acted, and never where they sit; this knows both, immediately.
+        self.winamax_ax_seats = WinamaxAXSeatReader() if is_supported() else None
+
+        # The window says which game it deals only to a process holding macOS
+        # Accessibility. Imported hands say it unconditionally, so keep what
+        # they prove for later live hands.
+        self.winamax_pool_games = WinamaxPoolGames(
+            Path(Configuration.CONFIG_PATH) / "winamax_pool_games.json" if Configuration.CONFIG_PATH else None,
+        )
+
+        # Queued by Qt because the reader emits from its tailing thread.
+        self.winamax_table_update.connect(self._on_winamax_table_update)
+        self.winamax_log_reader = WinamaxLiveLogReader(
+            on_table_update=self.winamax_table_update.emit,
+        )
+        self.winamax_log_reader.start()
+
+    def show_macos_permissions(self) -> None:
+        """Show the explicit macOS permission onboarding window."""
+        dialog = getattr(self, "_macos_permissions_dialog", None)
+        if dialog is None:
+            dialog = MacOSPermissionsDialog(self.main_window)
+            dialog.status_changed.connect(self._remember_macos_permission_status)
+            self._macos_permissions_dialog = dialog
+        dialog.refresh_status()
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _remember_macos_permission_status(self, status: Any) -> None:
+        """Keep the latest UI preflight snapshot for diagnostics."""
+        self._macos_permission_status = status
+
+    def _on_application_state_changed(self, state: Any) -> None:
+        """Recheck an open onboarding window after returning from Settings."""
+        if state != Qt.ApplicationState.ApplicationActive:
+            return
+        dialog = getattr(self, "_macos_permissions_dialog", None)
+        if dialog is not None and dialog.isVisible():
+            dialog.refresh_status()
 
     def handle_worker_error(self, error_message: str) -> None:
         """Handle errors from the ZMQ worker."""
@@ -1097,6 +1263,14 @@ class HudMain(QObject):
         self.main_window.setLayout(self.vb)
         self.label = QLabel("Closing this window will exit from the HUD.")
         self.vb.addWidget(self.label)
+        if self.config.os_family == "Mac":
+            self._macos_permissions_dialog: MacOSPermissionsDialog | None = None
+            self.macos_permissions_button = QPushButton("macOS Permissions…")
+            self.macos_permissions_button.clicked.connect(self.show_macos_permissions)
+            self.vb.addWidget(self.macos_permissions_button)
+            app = QApplication.instance()
+            if app is not None:
+                app.applicationStateChanged.connect(self._on_application_state_changed)
         self.main_window.setWindowTitle("HUD Main Window")
         cards_path = Path(self.config.graphics_path) / "tribal.jpg"
         if cards_path.exists():
@@ -1431,7 +1605,8 @@ class HudMain(QObject):
         site_hand_no = getattr(prepared, "site_hand_no", None) or getattr(
             getattr(prepared, "hand_instance", None), "handid", None
         )
-        table_no = self.winamax_log_reader.table_no_for_hand(site_hand_no) if site_hand_no else None
+        log_reader = getattr(self, "winamax_log_reader", None)
+        table_no = log_reader.table_no_for_hand(site_hand_no) if log_reader is not None and site_hand_no else None
         if not table_no:
             # WARNING because this is what delays a table's HUD by a hand or two
             # at startup, and the delay is otherwise invisible.
@@ -1455,7 +1630,9 @@ class HudMain(QObject):
         # This hand settles what the pool deals, which is the one thing the log
         # cannot say. Kept so later hands on this pool -- and later sessions --
         # can build their HUD from the log alone.
-        self.winamax_pool_games.remember(info.table_name, info.poker_game)
+        pool_games = getattr(self, "winamax_pool_games", None)
+        if pool_games is not None:
+            pool_games.remember(info.table_name, info.poker_game)
         return info._replace(table_name=f"{info.table_name} {table_no}")
 
     def _hud_is_fast_fold(self, hud: Hud.Hud, temp_key: str = "") -> bool:
@@ -1518,7 +1695,8 @@ class HudMain(QObject):
 
         # The window states the game only when the accessibility API answered.
         # Otherwise fall back on what an imported hand from this pool proved.
-        poker_game = window.poker_game or self.winamax_pool_games.get(temp_key)
+        pool_games = getattr(self, "winamax_pool_games", None)
+        poker_game = window.poker_game or (pool_games.get(temp_key) if pool_games is not None else None)
         if not poker_game:
             self._ff_trace(
                 update.hand_id,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -799,11 +799,16 @@ class HudMain(QObject):
                 log.info("Requesting Screen Recording permission (native prompt)...")
                 permissions.request_screen_recording_permission()
                 permissions.open_screen_recording_settings()
-            if not status.accessibility:
+                log.warning(
+                    "After granting Screen Recording permission, restart FPDB for it to take effect.",
+                )
+            elif not status.accessibility:
                 log.info("Requesting Accessibility permission (native prompt)...")
                 permissions.request_accessibility_permission(prompt=True)
                 permissions.open_accessibility_settings()
-            log.warning("After granting permissions, restart FPDB for them to take effect.")
+                log.warning(
+                    "After granting Accessibility permission, restart FPDB for it to take effect.",
+                )
 
     def handle_worker_error(self, error_message: str) -> None:
         """Handle errors from the ZMQ worker."""
@@ -1543,6 +1548,9 @@ class HudMain(QObject):
         # A full HUD, not the loading placeholder: that one has no aux windows,
         # so it can only ever show "Loading HUD..." until an import replaces it.
         # The seats arrive from the window moments later.
+        create_kwargs: dict[str, Any] = {"stats": {}}
+        if window.window_id is not None:
+            create_kwargs["resolved_window"] = window
         self._create_new_hud(
             synthetic_hand,
             temp_key,
@@ -1550,7 +1558,7 @@ class HudMain(QObject):
             self._winamax_site_id,
             self.FAST_FOLD_MAX_SEATS,
             "Winamax",
-            stats={},
+            **create_kwargs,
         )
         hud = self.hud_dict.get(temp_key)
         if hud is None:
@@ -2545,6 +2553,7 @@ class HudMain(QObject):
         *,
         loading: bool = False,
         stats: dict | None = None,
+        resolved_window: Any | None = None,
     ) -> None:
         """Create a new HUD for a table.
 
@@ -2556,6 +2565,10 @@ class HudMain(QObject):
         the database, which is what lets a table be created from the client log
         with no hand behind it -- a full HUD, aux windows and all, on a thread
         that has no database connection.
+
+        ``resolved_window`` is a macOS Fast-Fold window already found at hand
+        start. Passing it through prevents OSXTables from performing a second
+        window scan that can disagree with the first one while TCC is changing.
         """
         info = TableInfo.coerce(table_info)
         table_name = info.table_name
@@ -2627,6 +2640,8 @@ class HudMain(QObject):
             "table_number": tab_number,
             "tourney_name": tourney_name,
         }
+        if resolved_window is not None:
+            table_kwargs["resolved_window"] = resolved_window
         tablewindow = self.Tables.Table(self.config, hud_site_name, **table_kwargs)
 
         if tablewindow.number is None:

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -770,6 +770,7 @@ class HudMain(QObject):
         try:
             # HUD dictionary and parameters
             self.hud_dict: dict[str, Hud.Hud] = {}
+            self._macos_permissions_dialog: MacOSPermissionsDialog | None = None
             # Session-only profile choices made from an individual table menu.
             # Values include game identity so a recycled table key cannot leak a
             # Hold'em/PLO choice into another game.
@@ -1264,7 +1265,7 @@ class HudMain(QObject):
         self.label = QLabel("Closing this window will exit from the HUD.")
         self.vb.addWidget(self.label)
         if self.config.os_family == "Mac":
-            self._macos_permissions_dialog: MacOSPermissionsDialog | None = None
+            self._macos_permissions_dialog = None
             self.macos_permissions_button = QPushButton("macOS Permissions…")
             self.macos_permissions_button.clicked.connect(self.show_macos_permissions)
             self.vb.addWidget(self.macos_permissions_button)

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -774,10 +774,11 @@ class HudMain(QObject):
         """Diagnose macOS privacy permissions required for table detection.
 
         Screen Recording is needed for Quartz to expose window titles;
-        Accessibility/Automation is needed for the AppleScript fallback used by
-        Electron clients (e.g. Winamax). Logs a clear, actionable message for any
-        missing permission. Set ``FPDB_REQUEST_MACOS_PERMISSIONS=1`` to also
-        trigger the native prompts and open the relevant System Settings panes.
+        Accessibility is needed for Winamax seats and System Events GUI
+        scripting; Automation is a separate consent requested by the first
+        Apple Event. Frozen builds trigger the native Screen Recording and
+        Accessibility prompts automatically. Source installs can opt in with
+        ``FPDB_REQUEST_MACOS_PERMISSIONS=1``.
         """
         try:
             from fpdb.infrastructure.platform import permissions
@@ -793,7 +794,7 @@ class HudMain(QObject):
         for message in permissions.describe_missing(status):
             log.warning(message)
 
-        if os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
+        if getattr(sys, "frozen", False) or os.getenv("FPDB_REQUEST_MACOS_PERMISSIONS") == "1":
             if not status.screen_recording:
                 log.info("Requesting Screen Recording permission (native prompt)...")
                 permissions.request_screen_recording_permission()

--- a/fpdb_3_legacy/OSXTables.py
+++ b/fpdb_3_legacy/OSXTables.py
@@ -45,6 +45,10 @@ class Table(Table_Window):
 
     def __init__(self, *args, **kwargs):
         """Initialize table with platform detector."""
+        # Fast Fold resolves the indexed Winamax window at hand-start. Reusing
+        # that answer avoids a second, potentially different Quartz/System
+        # Events scan during HUD construction.
+        self._resolved_window = kwargs.pop("resolved_window", None)
         self._detector = get_table_detector()
         super().__init__(*args, **kwargs)
 
@@ -60,6 +64,23 @@ class Table(Table_Window):
         """
         self.number = None
         log.debug("DIAGNOSTIC: Starting window detection for search string: '%s'", self.search_string)
+
+        if self._resolved_window is not None:
+            try:
+                number = int(self._resolved_window.window_id)
+                title = str(self._resolved_window.title)
+            except (AttributeError, TypeError, ValueError):
+                log.warning("Ignoring invalid pre-resolved macOS window: %r", self._resolved_window)
+            else:
+                if number > 0 and title and not self.check_bad_words(title):
+                    self.number = number
+                    self.title = title
+                    log.debug(
+                        "DIAGNOSTIC: Reusing pre-resolved table window ID: %s, title: '%s'",
+                        self.number,
+                        self.title,
+                    )
+                    return self.title
 
         # Use platform abstraction layer to find tables
         tables = self._detector.find_tables(self.search_string)

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1404,7 +1404,9 @@ class fpdb(QMainWindow):
         self.settings.update({"cl_options": cl_options})
         self.settings.update(self.config.get_db_parameters())
         self.settings.update(self.config.get_import_parameters())
-        self.settings.update(self.config.get_default_paths())
+        # Default-path resolution may inspect fallback locations when a saved
+        # room path is stale. Keep profile loading passive; import entry points
+        # resolve paths only when the user actually opens/starts that workflow.
 
         # Set up SQL and connect to the database
         self.sql = SQL.Sql(db_server=self.settings["db-server"])
@@ -1646,6 +1648,10 @@ class fpdb(QMainWindow):
 
     def tab_bulk_import(self, widget, data=None) -> None:
         """Opens a tab for bulk importing."""
+        # Bulk Import still gets its detected/custom default, but resolving it
+        # here avoids probing protected folders during ordinary application
+        # startup and profile refreshes.
+        self.settings.update(self.config.get_default_paths())
         new_import_thread = GuiBulkImport.GuiBulkImport(self.settings, self.config, self.sql, self)
         self.threads.append(new_import_thread)
         self.add_and_display_tab(new_import_thread, "Bulk Import")

--- a/fpdb_3_legacy/subprocess_launch.py
+++ b/fpdb_3_legacy/subprocess_launch.py
@@ -39,17 +39,20 @@ def hud_main_command(*args: str) -> list[str]:
         FileNotFoundError: when a packaged build has no HUD_main next to it.
     """
     frozen = getattr(sys, "frozen", False)
-    if frozen == "pyoxidizer":
-        # A single binary hosts both entry points; --hud selects HUD_main.
+    if frozen == "pyoxidizer" or (frozen and sys.platform == "darwin"):
+        # macOS must keep the GUI and HUD under one code identity so TCC grants
+        # (Screen Recording and Accessibility) apply to both processes.
+        # PyOxidizer always uses one launcher; the PyInstaller main executable
+        # embeds the same --hud dispatcher on macOS.
         return [sys.executable, HUD_FLAG, *args]
     if frozen:
         # PyInstaller ships HUD_main as a sibling executable of fpdb.
         name = "HUD_main.exe" if os.name == "nt" else "HUD_main"
-        executable = Path(sys.executable).resolve().parent / name
-        if not executable.is_file():
+        executable = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), name)
+        if not os.path.isfile(executable):
             msg = f"HUD_main not found at {executable}"
             raise FileNotFoundError(msg)
-        return [str(executable), *args]
+        return [executable, *args]
     hud_main = Path(__file__).resolve().parent / "HUD_main.pyw"
     if not hud_main.is_file():
         msg = f"HUD_main not found at {hud_main}"
@@ -103,7 +106,7 @@ def unbuffer_streams() -> None:
     """
     for stream in (sys.stdout, sys.stderr):
         try:
-            stream.reconfigure(line_buffering=True)
+            stream.reconfigure(line_buffering=True)  # type: ignore[union-attr]
         except (AttributeError, ValueError):
             # No console at all (windowed build), or an already-closed stream.
             continue

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -64,32 +64,42 @@ OSASCRIPT = "/usr/bin/osascript"
 
 AUTOMATION_REFUSED_MARKERS = (
     "-1743",  # not authorised to send Apple events
-    "-1712",  # the Automation prompt is up and unanswered, so the event timed out
     "Not authorized to send Apple events",
-    "AppleEvent timed out",
 )
 
-_automation_refused = False
-"""Whether System Events has already turned this process away.
+ACCESSIBILITY_REFUSED_MARKERS = (
+    # Do not match bare -1719: Apple also uses it for an invalid list index.
+    "not allowed assistive access",
+    "does not have access to assistive devices",
+)
+
+SYSTEM_EVENTS_TIMEOUT_MARKERS = ("-1712", "AppleEvent timed out")
+
+_system_events_blocked = False
+"""Whether System Events has already refused or timed out for this process.
 
 Reset by restarting, which is also what granting the permission requires.
 """
 
 
-def _report_automation_refused(detail: str) -> None:
+def _report_system_events_blocked(detail: str, reason: str) -> None:
     """Say once, at WARNING, that no table window can be read and why."""
-    global _automation_refused
-    if _automation_refused:
+    global _system_events_blocked
+    if _system_events_blocked:
         return
-    _automation_refused = True
+    _system_events_blocked = True
+    if reason == "Automation":
+        action = "Allow FPDB -> System Events in Privacy & Security > Automation"
+    elif reason == "Accessibility":
+        action = "Allow FPDB in Privacy & Security > Accessibility"
+    else:
+        action = "Check for a pending permission prompt and that System Events is responsive"
     log.warning(
-        "Fast HUD cannot see the Winamax table windows: this application is not allowed to "
-        "control 'System Events' (Automation). On macOS that is the only way to read an "
-        "Electron client's window title -- the accessibility API needs a grant macOS never "
-        "prompts for, and Quartz never exposes an Electron title at all. Allow it in System "
-        "Settings > Privacy & Security > Automation (FPDB -> System Events) and restart FPDB. "
-        "If FPDB is not listed there, run 'tccutil reset AppleEvents org.fpdb.fpdb3' so macOS "
-        "asks again. Until then the HUD only appears once a hand has been imported. Detail: %s",
+        "Fast HUD cannot see the Winamax table windows through System Events (%s). "
+        "%s, then restart FPDB. Screen Recording is the preferred path for window "
+        "titles; Accessibility is also required to read seats. Detail: %s",
+        reason,
+        action,
         detail,
     )
 
@@ -97,11 +107,9 @@ def _report_automation_refused(detail: str) -> None:
 def applescript_window_titles() -> list[str]:
     """Titles of the client's windows, read through System Events.
 
-    The direct accessibility API needs this process to hold *Accessibility*,
-    which macOS never prompts for: a packaged build is a new TCC client and
-    starts without it, so every AX call comes back empty. Going through System
-    Events instead needs only *Automation*, which macOS does prompt for and
-    which the rest of fpdb already relies on to find these same windows.
+    This is GUI scripting: FPDB needs Automation to control System Events and
+    Accessibility to inspect its process/window tree. Quartz is preferred when
+    Screen Recording exposes the real title and CGWindowID.
 
     Returns an empty list when the client is not running or the scan is
     refused; the caller then falls back to waiting for an imported hand. A
@@ -109,6 +117,8 @@ def applescript_window_titles() -> list[str]:
     open" and "this build will never see a table", and the two used to look
     identical in the log.
     """
+    if _system_events_blocked:
+        return []
     try:
         # Absolute path, fixed argv, no shell, and nothing interpolated into the script.
         result = subprocess.run(  # noqa: S603  # nosec B603
@@ -119,8 +129,10 @@ def applescript_window_titles() -> list[str]:
             check=False,
         )
     except subprocess.TimeoutExpired:
-        # The Automation prompt is on screen and nobody has answered it.
-        _report_automation_refused(f"osascript did not return within {APPLESCRIPT_TIMEOUT:.0f}s")
+        _report_system_events_blocked(
+            f"osascript did not return within {APPLESCRIPT_TIMEOUT:.0f}s",
+            "timeout",
+        )
         return []
     except OSError as exc:
         log.debug("Could not run %s: %s", OSASCRIPT, exc)
@@ -128,7 +140,11 @@ def applescript_window_titles() -> list[str]:
     if result.returncode != 0:
         stderr = result.stderr.strip()
         if any(marker in stderr for marker in AUTOMATION_REFUSED_MARKERS):
-            _report_automation_refused(stderr)
+            _report_system_events_blocked(stderr, "Automation")
+        elif any(marker in stderr for marker in ACCESSIBILITY_REFUSED_MARKERS):
+            _report_system_events_blocked(stderr, "Accessibility")
+        elif any(marker in stderr for marker in SYSTEM_EVENTS_TIMEOUT_MARKERS):
+            _report_system_events_blocked(stderr, "timeout")
         else:
             log.debug("System Events refused the Winamax window list: %s", stderr)
         return []

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -25,131 +25,10 @@ import logging
 import math
 import platform
 import re
-import subprocess  # nosec B404 - only ever runs the fixed osascript command below
-import time
 from dataclasses import dataclass
 from typing import Any
 
 log = logging.getLogger(__name__)
-
-# Lists the client's window titles through System Events. Used when the
-# accessibility API itself is closed to us -- see WINDOW_SCAN_TTL.
-_WINDOW_TITLES_SCRIPT = """
-tell application "System Events"
-    set windowList to {}
-    repeat with proc in (processes whose name contains "Winamax")
-        repeat with win in (every window of proc)
-            try
-                set end of windowList to name of win
-            end try
-        end repeat
-    end repeat
-    return windowList
-end tell
-"""
-
-WINDOW_SCAN_TTL = 1.0
-"""Seconds an AppleScript window list stays good for.
-
-Each scan is a synchronous ``osascript`` call costing a couple of hundred
-milliseconds, and a busy pool starts hands faster than that. One scan per
-second is far below the rate at which windows are opened or closed, and keeps
-the fallback off the critical path.
-"""
-
-APPLESCRIPT_TIMEOUT = 5.0
-
-OSASCRIPT = "/usr/bin/osascript"
-"""Absolute, so the scan cannot be diverted by whatever PATH the app inherited."""
-
-AUTOMATION_REFUSED_MARKERS = (
-    "-1743",  # not authorised to send Apple events
-    "Not authorized to send Apple events",
-)
-
-ACCESSIBILITY_REFUSED_MARKERS = (
-    # Do not match bare -1719: Apple also uses it for an invalid list index.
-    "not allowed assistive access",
-    "does not have access to assistive devices",
-)
-
-SYSTEM_EVENTS_TIMEOUT_MARKERS = ("-1712", "AppleEvent timed out")
-
-_system_events_blocked = False
-"""Whether System Events has already refused or timed out for this process.
-
-Reset by restarting, which is also what granting the permission requires.
-"""
-
-
-def _report_system_events_blocked(detail: str, reason: str) -> None:
-    """Say once, at WARNING, that no table window can be read and why."""
-    global _system_events_blocked
-    if _system_events_blocked:
-        return
-    _system_events_blocked = True
-    if reason == "Automation":
-        action = "Allow FPDB -> System Events in Privacy & Security > Automation"
-    elif reason == "Accessibility":
-        action = "Allow FPDB in Privacy & Security > Accessibility"
-    else:
-        action = "Check for a pending permission prompt and that System Events is responsive"
-    log.warning(
-        "Fast HUD cannot see the Winamax table windows through System Events (%s). "
-        "%s, then restart FPDB. Screen Recording is the preferred path for window "
-        "titles; Accessibility is also required to read seats. Detail: %s",
-        reason,
-        action,
-        detail,
-    )
-
-
-def applescript_window_titles() -> list[str]:
-    """Titles of the client's windows, read through System Events.
-
-    This is GUI scripting: FPDB needs Automation to control System Events and
-    Accessibility to inspect its process/window tree. Quartz is preferred when
-    Screen Recording exposes the real title and CGWindowID.
-
-    Returns an empty list when the client is not running or the scan is
-    refused; the caller then falls back to waiting for an imported hand. A
-    refusal is reported once, loudly: it is the difference between "no table is
-    open" and "this build will never see a table", and the two used to look
-    identical in the log.
-    """
-    if _system_events_blocked:
-        return []
-    try:
-        # Absolute path, fixed argv, no shell, and nothing interpolated into the script.
-        result = subprocess.run(  # noqa: S603  # nosec B603
-            [OSASCRIPT, "-e", _WINDOW_TITLES_SCRIPT],
-            capture_output=True,
-            text=True,
-            timeout=APPLESCRIPT_TIMEOUT,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        _report_system_events_blocked(
-            f"osascript did not return within {APPLESCRIPT_TIMEOUT:.0f}s",
-            "timeout",
-        )
-        return []
-    except OSError as exc:
-        log.debug("Could not run %s: %s", OSASCRIPT, exc)
-        return []
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        if any(marker in stderr for marker in AUTOMATION_REFUSED_MARKERS):
-            _report_system_events_blocked(stderr, "Automation")
-        elif any(marker in stderr for marker in ACCESSIBILITY_REFUSED_MARKERS):
-            _report_system_events_blocked(stderr, "Accessibility")
-        elif any(marker in stderr for marker in SYSTEM_EVENTS_TIMEOUT_MARKERS):
-            _report_system_events_blocked(stderr, "timeout")
-        else:
-            log.debug("System Events refused the Winamax window list: %s", stderr)
-        return []
-    return [title.strip() for title in result.stdout.strip().split(",") if title.strip()]
-
 
 # A player's stack, e.g. "552,5 BB" or "7,64 €". The client draws it directly
 # under the name, and that pairing is what identifies a seat -- far steadier than
@@ -203,6 +82,9 @@ class AXTableWindow:
 
     description: str
     """The client's own header, e.g. ``ESCAPE - 0,01-0,02 € - Pot Limit Omaha``."""
+
+    window_id: int | None = None
+    """CGWindowID (or the detector's synthetic fallback ID), when resolved."""
 
     @property
     def table_name(self) -> str:
@@ -342,21 +224,13 @@ def seat_slots_from_positions(
 class WinamaxAXSeatReader:
     """Reads seated players from Winamax table windows through macOS accessibility."""
 
-    def __init__(self) -> None:
+    def __init__(self, table_detector: Any | None = None) -> None:
         self._app: Any = None
         self._pid: int | None = None
-        self._titles: list[str] = []
-        self._titles_read_at = 0.0
-        self._fallback_announced = False
-
-    def _window_titles(self) -> list[str]:
-        """The client's window titles via System Events, at most once a second."""
-        now = time.monotonic()
-        if now - self._titles_read_at < WINDOW_SCAN_TTL:
-            return self._titles
-        self._titles = applescript_window_titles()
-        self._titles_read_at = now
-        return self._titles
+        # Reuse the platform singleton also owned by OSXTables. Besides avoiding
+        # two independent System Events circuit breakers, this lets the window
+        # resolved at hand-start be handed straight to HUD creation.
+        self._table_detector: Any | None = table_detector
 
     def _application(self) -> Any:
         """The AX handle for the running client, with its web tree switched on."""
@@ -438,18 +312,64 @@ class WinamaxAXSeatReader:
         6"), which is the same index the log writes, so a pool can be tied to a
         window without waiting for any hand to be imported.
 
-        Tries the accessibility API first, because it also reads the header that
-        names the game. When that is closed to us -- the normal state of a
-        packaged build, which macOS treats as a new client with no
-        *Accessibility* grant -- the title alone is recovered through System
-        Events, and the game is left for the caller to supply.
+        Quartz is tried first through the shared platform detector, because it
+        yields the real CGWindowID without an Apple Event when Screen Recording
+        is granted. Accessibility then enriches that answer with the client
+        header and seats. Only when Quartz and AX cannot resolve the window does
+        the shared detector use its throttled System Events fallback.
         """
         if not is_supported():
             return None
-        window = self._find_table_window_ax(table_no)
-        if window is not None:
-            return window
-        return self._find_table_window_applescript(table_no)
+
+        detected = self._find_table_window_detector(table_no, allow_fallback=False)
+        accessible = self._find_table_window_ax(table_no)
+        if detected is not None:
+            if accessible is not None:
+                return AXTableWindow(
+                    title=detected.title,
+                    description=accessible.description,
+                    window_id=detected.window_id,
+                )
+            return detected
+
+        # AX can name the table without Screen Recording, but it cannot provide
+        # the CGWindowID needed to attach an overlay. Give the shared detector a
+        # final chance to pair it through System Events and preserve the AX
+        # header if it succeeds.
+        detected = self._find_table_window_detector(table_no, allow_fallback=True)
+        if detected is not None:
+            if accessible is not None:
+                return AXTableWindow(
+                    title=detected.title,
+                    description=accessible.description,
+                    window_id=detected.window_id,
+                )
+            return detected
+        return accessible
+
+    def _find_table_window_detector(self, table_no: str, *, allow_fallback: bool) -> AXTableWindow | None:
+        """Resolve one indexed Winamax window through the shared macOS detector."""
+        try:
+            if self._table_detector is None:
+                from fpdb.infrastructure.platform import get_table_detector
+
+                self._table_detector = get_table_detector()
+            search = rf"^Winamax\s+.*\s{re.escape(str(table_no))}\s*$"
+            tables = self._table_detector.find_tables(search, allow_fallback=allow_fallback)
+        except Exception:
+            log.debug("Shared macOS detector could not resolve Winamax table %s", table_no, exc_info=True)
+            return None
+
+        for table in tables:
+            title = str(getattr(table, "title", "") or "")
+            if not self._is_table_no(title, table_no):
+                continue
+            try:
+                window_id = int(table.window_id)
+            except (AttributeError, TypeError, ValueError):
+                window_id = None
+            return AXTableWindow(title=title, description="", window_id=window_id)
+        return None
 
     def _find_table_window_ax(self, table_no: str) -> AXTableWindow | None:
         """The table window and its header, read through the accessibility API."""
@@ -469,22 +389,6 @@ class WinamaxAXSeatReader:
                 return AXTableWindow(title=title, description=labels[0].login if labels else "")
         except Exception:
             log.exception("Could not look up the Winamax window for table %s", table_no)
-        return None
-
-    def _find_table_window_applescript(self, table_no: str) -> AXTableWindow | None:
-        """The table window by title only, read through System Events."""
-        for title in self._window_titles():
-            if not self._is_table_no(title, table_no):
-                continue
-            if not self._fallback_announced:
-                self._fallback_announced = True
-                log.info(
-                    "Reading Winamax table windows through System Events: the accessibility "
-                    "API returned nothing for this process. Table windows are still found, but "
-                    "seats come from the log rather than the window. Granting this application "
-                    "Accessibility in System Settings > Privacy & Security restores the direct read.",
-                )
-            return AXTableWindow(title=title, description="")
         return None
 
     @staticmethod

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -70,6 +70,10 @@ def make_exe(dist):
         "import runpy",
         "import sys",
         "sys.frozen = 'pyoxidizer'",
+        # A signed .app must stay byte-for-byte immutable after launch. The
+        # embedded interpreter does not reliably honour PYTHONDONTWRITEBYTECODE,
+        # so enforce this before any filesystem module is imported.
+        "sys.dont_write_bytecode = True",
         "root = os.path.dirname(sys.executable)",
         "bundle_resources = os.path.join(os.path.dirname(root), 'Resources')",
         "if os.path.isdir(os.path.join(bundle_resources, 'fpdb_3_legacy')):",

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -13,11 +13,10 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 pytestmark = pytest.mark.qt
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QApplication
 
 from fpdb.infrastructure.platform import permissions as macos_permissions
-from fpdb.infrastructure.platform.macos import MacOSTableDetector
 
 # import zmq
 
@@ -127,34 +126,79 @@ def test_hud_main_initialization(hud_main) -> None:
     assert hud_main._table_stat_set_overrides == {}
 
 
+def _winamax_source_owner(enabled_sites: list[str]) -> SimpleNamespace:
+    config = MagicMock()
+    config.get_supported_sites.return_value = enabled_sites
+    return SimpleNamespace(
+        config=config,
+        winamax_table_update=MagicMock(),
+        _on_winamax_table_update=MagicMock(),
+        _site_enabled_in_config=HUD_main.HudMain._site_enabled_in_config,
+    )
+
+
+def test_winamax_live_sources_are_not_constructed_when_site_is_disabled() -> None:
+    owner = _winamax_source_owner(["PokerStars"])
+    with (
+        patch("fpdb_3_legacy.winamax_ax_seats.is_supported") as is_supported,
+        patch("fpdb_3_legacy.winamax_ax_seats.WinamaxAXSeatReader") as ax_reader,
+        patch("fpdb_3_legacy.winamax_pool_games.WinamaxPoolGames") as pool_games,
+        patch("fpdb_3_legacy.winamax_live_log_reader.WinamaxLiveLogReader") as log_reader,
+    ):
+        HUD_main.HudMain._initialize_winamax_live_sources(owner)
+
+    assert owner.winamax_ax_seats is None
+    assert owner.winamax_pool_games is None
+    assert owner.winamax_log_reader is None
+    is_supported.assert_not_called()
+    ax_reader.assert_not_called()
+    pool_games.assert_not_called()
+    log_reader.assert_not_called()
+    owner.winamax_table_update.connect.assert_not_called()
+
+
+def test_winamax_live_sources_start_when_site_is_enabled() -> None:
+    owner = _winamax_source_owner(["PokerStars", "Winamax"])
+    ax_instance = MagicMock()
+    pool_instance = MagicMock()
+    log_instance = MagicMock()
+    with (
+        patch("fpdb_3_legacy.winamax_ax_seats.is_supported", return_value=True),
+        patch("fpdb_3_legacy.winamax_ax_seats.WinamaxAXSeatReader", return_value=ax_instance) as ax_reader,
+        patch("fpdb_3_legacy.winamax_pool_games.WinamaxPoolGames", return_value=pool_instance) as pool_games,
+        patch(
+            "fpdb_3_legacy.winamax_live_log_reader.WinamaxLiveLogReader",
+            return_value=log_instance,
+        ) as log_reader,
+    ):
+        HUD_main.HudMain._initialize_winamax_live_sources(owner)
+
+    assert owner.winamax_ax_seats is ax_instance
+    assert owner.winamax_pool_games is pool_instance
+    assert owner.winamax_log_reader is log_instance
+    ax_reader.assert_called_once_with()
+    pool_games.assert_called_once()
+    log_reader.assert_called_once_with(on_table_update=owner.winamax_table_update.emit)
+    log_instance.start.assert_called_once_with()
+    owner.winamax_table_update.connect.assert_called_once_with(owner._on_winamax_table_update)
+
+
 @pytest.mark.parametrize(
-    ("status", "requested", "restart_message"),
+    "status",
     [
-        (
-            macos_permissions.PermissionStatus(screen_recording=False, accessibility=False),
-            "screen",
-            "After granting Screen Recording permission, restart FPDB for it to take effect.",
-        ),
-        (
-            macos_permissions.PermissionStatus(screen_recording=True, accessibility=False),
-            "accessibility",
-            "After granting Accessibility permission, restart FPDB for it to take effect.",
-        ),
-        (macos_permissions.PermissionStatus(screen_recording=True, accessibility=True), None, None),
+        macos_permissions.PermissionStatus(screen_recording=False, accessibility=False),
+        macos_permissions.PermissionStatus(screen_recording=True, accessibility=False),
+        macos_permissions.PermissionStatus(screen_recording=True, accessibility=True),
     ],
 )
-def test_hud_main_is_the_single_sequenced_macos_permission_prompt_owner(
+def test_hud_main_startup_permission_preflight_is_diagnostic_only(
     status: macos_permissions.PermissionStatus,
-    requested: str | None,
-    restart_message: str | None,
 ) -> None:
-    """A detector preflight after HUD startup must not duplicate its prompt."""
-    detector = object.__new__(MacOSTableDetector)
-    detector._permissions_checked = False
-    detector._permission_status = None
+    """Frozen startup and the legacy opt-in never prompt or open Settings."""
+    owner = SimpleNamespace()
 
     with (
-        patch.dict(os.environ, {}, clear=True),
+        patch.dict(os.environ, {"FPDB_REQUEST_MACOS_PERMISSIONS": "1"}, clear=True),
         patch.object(HUD_main.sys, "frozen", True, create=True),
         patch.object(macos_permissions, "get_status", return_value=status),
         patch.object(macos_permissions, "describe_missing", return_value=[]),
@@ -162,23 +206,134 @@ def test_hud_main_is_the_single_sequenced_macos_permission_prompt_owner(
         patch.object(macos_permissions, "open_screen_recording_settings") as open_screen,
         patch.object(macos_permissions, "request_accessibility_permission") as request_accessibility,
         patch.object(macos_permissions, "open_accessibility_settings") as open_accessibility,
-        patch.object(HUD_main.log, "warning") as warning,
     ):
-        HUD_main.HudMain._check_macos_permissions(SimpleNamespace())
-        detector._check_permissions_once()
+        HUD_main.HudMain._check_macos_permissions(owner)
 
-    expected_screen_calls = 1 if requested == "screen" else 0
-    expected_accessibility_calls = 1 if requested == "accessibility" else 0
-    assert request_screen.call_count == expected_screen_calls
-    assert open_screen.call_count == expected_screen_calls
-    assert request_accessibility.call_count == expected_accessibility_calls
-    assert open_accessibility.call_count == expected_accessibility_calls
-    if requested == "accessibility":
+    assert owner._macos_permission_status is status
+    request_screen.assert_not_called()
+    open_screen.assert_not_called()
+    request_accessibility.assert_not_called()
+    open_accessibility.assert_not_called()
+
+
+def test_macos_permission_dialog_refresh_is_diagnostic_only(app) -> None:
+    status = macos_permissions.PermissionStatus(False, True, app_data=None)
+    with (
+        patch.object(macos_permissions, "get_status", return_value=status),
+        patch.object(macos_permissions, "request_screen_recording_permission") as request_screen,
+        patch.object(macos_permissions, "request_accessibility_permission") as request_accessibility,
+        patch.object(macos_permissions, "open_screen_recording_settings") as open_screen,
+        patch.object(macos_permissions, "open_accessibility_settings") as open_accessibility,
+    ):
+        dialog = HUD_main.MacOSPermissionsDialog()
+        dialog.refresh_status()
+
+        assert dialog.screen_status_label.text() == "Missing"
+        assert dialog.accessibility_status_label.text() == "Granted"
+        assert dialog.app_data_status_label.text() == "Not preflightable"
+        assert "NSAppDataUsageDescription" in dialog.app_data_info_label.text()
+        assert not hasattr(dialog, "app_data_settings_button")
+        assert not hasattr(dialog, "_open_app_data_settings")
+        request_screen.assert_not_called()
+        request_accessibility.assert_not_called()
+        open_screen.assert_not_called()
+        open_accessibility.assert_not_called()
+        dialog.close()
+
+
+def test_macos_permission_dialog_request_buttons_are_isolated(app) -> None:
+    status = macos_permissions.PermissionStatus(False, False)
+    with (
+        patch.object(macos_permissions, "get_status", return_value=status),
+        patch.object(macos_permissions, "request_screen_recording_permission") as request_screen,
+        patch.object(macos_permissions, "request_accessibility_permission") as request_accessibility,
+        patch.object(macos_permissions, "open_screen_recording_settings") as open_screen,
+        patch.object(macos_permissions, "open_accessibility_settings") as open_accessibility,
+    ):
+        dialog = HUD_main.MacOSPermissionsDialog()
+        dialog.set_status(status)
+
+        dialog.screen_request_button.click()
+        request_screen.assert_called_once_with()
+        request_accessibility.assert_not_called()
+        open_screen.assert_not_called()
+        open_accessibility.assert_not_called()
+
+        request_screen.reset_mock()
+        dialog.accessibility_request_button.click()
         request_accessibility.assert_called_once_with(prompt=True)
-    if restart_message is None:
-        warning.assert_not_called()
-    else:
-        warning.assert_called_once_with(restart_message)
+        request_screen.assert_not_called()
+        open_screen.assert_not_called()
+        open_accessibility.assert_not_called()
+        dialog.close()
+
+
+def test_macos_permission_dialog_settings_buttons_open_only_their_pane(app) -> None:
+    status = macos_permissions.PermissionStatus(False, False)
+    with (
+        patch.object(macos_permissions, "open_screen_recording_settings") as open_screen,
+        patch.object(macos_permissions, "open_accessibility_settings") as open_accessibility,
+    ):
+        dialog = HUD_main.MacOSPermissionsDialog()
+        dialog.set_status(status)
+
+        dialog.screen_settings_button.click()
+        open_screen.assert_called_once_with()
+        open_accessibility.assert_not_called()
+
+        open_screen.reset_mock()
+        dialog.accessibility_settings_button.click()
+        open_accessibility.assert_called_once_with()
+        open_screen.assert_not_called()
+        assert not hasattr(dialog, "app_data_settings_button")
+        dialog.close()
+
+
+def test_macos_permission_dialog_rechecks_without_prompt_on_app_activation() -> None:
+    dialog = MagicMock()
+    dialog.isVisible.return_value = True
+    owner = SimpleNamespace(_macos_permissions_dialog=dialog)
+
+    HUD_main.HudMain._on_application_state_changed(owner, Qt.ApplicationState.ApplicationInactive)
+    dialog.refresh_status.assert_not_called()
+
+    HUD_main.HudMain._on_application_state_changed(owner, Qt.ApplicationState.ApplicationActive)
+    dialog.refresh_status.assert_called_once_with()
+
+
+def test_macos_permission_action_exists_before_any_table_without_auto_show(tmp_path) -> None:
+    """The HUD main window exposes onboarding without needing a detected table."""
+    owner = SimpleNamespace(
+        options=SimpleNamespace(xloc=None, yloc=None),
+        config=SimpleNamespace(os_family="Mac", graphics_path=str(tmp_path)),
+        close_event_handler=MagicMock(),
+        destroy=MagicMock(),
+        check_tables=MagicMock(),
+        show_macos_permissions=MagicMock(),
+        _on_application_state_changed=MagicMock(),
+    )
+    main_window = MagicMock()
+    layout = MagicMock()
+    permissions_button = MagicMock()
+    timer = MagicMock()
+    app_instance = MagicMock()
+
+    with (
+        patch.object(HUD_main, "HudMainWindow", return_value=main_window),
+        patch.object(HUD_main, "QVBoxLayout", return_value=layout),
+        patch.object(HUD_main, "QLabel"),
+        patch.object(HUD_main, "QPushButton", return_value=permissions_button),
+        patch.object(HUD_main, "QTimer", return_value=timer),
+        patch.object(HUD_main.QApplication, "instance", return_value=app_instance),
+        patch.object(HUD_main, "MacOSPermissionsDialog") as permissions_dialog,
+    ):
+        HUD_main.HudMain.init_main_window(owner)
+
+    assert owner._macos_permissions_dialog is None
+    permissions_dialog.assert_not_called()
+    permissions_button.clicked.connect.assert_called_once_with(owner.show_macos_permissions)
+    layout.addWidget.assert_any_call(permissions_button)
+    main_window.show.assert_called_once_with()
 
 
 def test_table_stat_set_override_is_scoped_by_table_and_game(hud_main) -> None:
@@ -1975,7 +2130,7 @@ def test_a_saved_rule_rebuilds_only_the_tables_whose_profile_changed(hud_main, t
 
     hud_main.config.get_supported_games_parameters.side_effect = resolve
     hud_main.config.reload.return_value = True
-    path.write_text("<config changed=\"1\"/>", encoding="utf-8")
+    path.write_text('<config changed="1"/>', encoding="utf-8")
     os.utime(path, (time.time() + 5, time.time() + 5))
 
     assert hud_main.refresh_profiles_from_config() == 1

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -16,6 +16,9 @@ pytestmark = pytest.mark.qt
 from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QApplication
 
+from fpdb.infrastructure.platform import permissions as macos_permissions
+from fpdb.infrastructure.platform.macos import MacOSTableDetector
+
 # import zmq
 
 # Add parent directory to path before imports
@@ -122,6 +125,60 @@ def test_hud_main_initialization(hud_main) -> None:
     assert hasattr(hud_main, "zmq_worker")
     assert hasattr(hud_main, "main_window")
     assert hud_main._table_stat_set_overrides == {}
+
+
+@pytest.mark.parametrize(
+    ("status", "requested", "restart_message"),
+    [
+        (
+            macos_permissions.PermissionStatus(screen_recording=False, accessibility=False),
+            "screen",
+            "After granting Screen Recording permission, restart FPDB for it to take effect.",
+        ),
+        (
+            macos_permissions.PermissionStatus(screen_recording=True, accessibility=False),
+            "accessibility",
+            "After granting Accessibility permission, restart FPDB for it to take effect.",
+        ),
+        (macos_permissions.PermissionStatus(screen_recording=True, accessibility=True), None, None),
+    ],
+)
+def test_hud_main_is_the_single_sequenced_macos_permission_prompt_owner(
+    status: macos_permissions.PermissionStatus,
+    requested: str | None,
+    restart_message: str | None,
+) -> None:
+    """A detector preflight after HUD startup must not duplicate its prompt."""
+    detector = object.__new__(MacOSTableDetector)
+    detector._permissions_checked = False
+    detector._permission_status = None
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(HUD_main.sys, "frozen", True, create=True),
+        patch.object(macos_permissions, "get_status", return_value=status),
+        patch.object(macos_permissions, "describe_missing", return_value=[]),
+        patch.object(macos_permissions, "request_screen_recording_permission") as request_screen,
+        patch.object(macos_permissions, "open_screen_recording_settings") as open_screen,
+        patch.object(macos_permissions, "request_accessibility_permission") as request_accessibility,
+        patch.object(macos_permissions, "open_accessibility_settings") as open_accessibility,
+        patch.object(HUD_main.log, "warning") as warning,
+    ):
+        HUD_main.HudMain._check_macos_permissions(SimpleNamespace())
+        detector._check_permissions_once()
+
+    expected_screen_calls = 1 if requested == "screen" else 0
+    expected_accessibility_calls = 1 if requested == "accessibility" else 0
+    assert request_screen.call_count == expected_screen_calls
+    assert open_screen.call_count == expected_screen_calls
+    assert request_accessibility.call_count == expected_accessibility_calls
+    assert open_accessibility.call_count == expected_accessibility_calls
+    if requested == "accessibility":
+        request_accessibility.assert_called_once_with(prompt=True)
+    if restart_message is None:
+        warning.assert_not_called()
+    else:
+        warning.assert_called_once_with(restart_message)
 
 
 def test_table_stat_set_override_is_scoped_by_table_and_game(hud_main) -> None:
@@ -335,6 +392,7 @@ def test_loading_hud_builds_empty_creation_args_without_querying_stats(hud_main)
         width=800,
         height=600,
     )
+    resolved_window = SimpleNamespace(window_id=12, title="Winamax table-a")
 
     with (
         patch.object(hud_main.db_connection, "get_stats_from_hand") as get_stats,
@@ -343,13 +401,31 @@ def test_loading_hud_builds_empty_creation_args_without_querying_stats(hud_main)
         patch.object(hud_main, "_set_table_stats") as set_table_stats,
     ):
         create_hud.side_effect = lambda args: hud_main.hud_dict.__setitem__(args.temp_key, MagicMock())
-        hud_main._create_new_hud("101", "table-a", table_info, 1, 6, "site", loading=True)
+        hud_main._create_new_hud(
+            "101",
+            "table-a",
+            table_info,
+            1,
+            6,
+            "site",
+            loading=True,
+            resolved_window=resolved_window,
+        )
 
     get_stats.assert_not_called()
     args = create_hud.call_args.args[0]
     assert args.stat_dict == {}
     assert args.cards == {}
     assert args.loading is True
+    hud_main.Tables.Table.assert_called_once_with(
+        hud_main.config,
+        "site",
+        table_name="table-a",
+        tournament=None,
+        table_number=None,
+        tourney_name=None,
+        resolved_window=resolved_window,
+    )
     seat_players.assert_not_called()
     set_table_stats.assert_not_called()
 
@@ -2312,10 +2388,14 @@ def test_recheck_replays_the_readers_current_state_for_a_pool(hud_main) -> None:
     applied.assert_called_once_with(table)
 
 
-def _ax_window(title="Winamax Casablanca 6", description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha"):
+def _ax_window(
+    title="Winamax Casablanca 6",
+    description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha",
+    window_id=None,
+):
     from fpdb_3_legacy.winamax_ax_seats import AXTableWindow
 
-    return AXTableWindow(title=title, description=description)
+    return AXTableWindow(title=title, description=description, window_id=window_id)
 
 
 def test_a_hud_is_created_from_the_log_without_waiting_for_an_import(hud_main) -> None:
@@ -2344,6 +2424,36 @@ def test_a_hud_is_created_from_the_log_without_waiting_for_an_import(hud_main) -
         # No real hand exists, so a stand-in keeps the loading HUD off the database.
         assert created["hand_id"].startswith("live:")
         assert hud_main.hud_dict["Casablanca 6"].is_fast_fold is True
+    finally:
+        hud_main.hud_dict = {}
+
+
+def test_fast_fold_reuses_the_window_resolved_at_hand_start(hud_main) -> None:
+    """HUD construction must not perform a second macOS window lookup."""
+    resolved = _ax_window(window_id=48_782)
+    hud_main.winamax_ax_seats = SimpleNamespace(find_table_window=lambda table_no: resolved)
+    hud_main.hud_dict = {}
+    created = {}
+
+    def fake_create(
+        hand_id,
+        temp_key,
+        info,
+        site_id,
+        num_seats,
+        site,
+        *,
+        loading=False,
+        stats=None,
+        resolved_window=None,
+    ):
+        created.update(resolved_window=resolved_window)
+        hud_main.hud_dict[temp_key] = SimpleNamespace(site="Winamax", table=SimpleNamespace(title=info.table_name))
+
+    try:
+        with patch.object(hud_main, "_create_new_hud", side_effect=fake_create):
+            assert hud_main._find_fast_fold_hud(_log_update(table_no="6")) is not None
+        assert created["resolved_window"] is resolved
     finally:
         hud_main.hud_dict = {}
 

--- a/test/test_bundle_pyinstaller_hud.py
+++ b/test/test_bundle_pyinstaller_hud.py
@@ -45,24 +45,24 @@ def test_bundles_macos_hud_inside_main_app(tmp_path: Path) -> None:
     (hud_contents / "MacOS").mkdir(parents=True)
     (hud_contents / "Frameworks" / "hud_only").mkdir(parents=True)
     (hud_contents / "Resources" / "hud_data").mkdir(parents=True)
+    (fpdb_contents / "MacOS" / "fpdb").write_text("main executable", encoding="utf-8")
     (hud_contents / "MacOS" / "HUD_main").write_text("executable", encoding="utf-8")
     (hud_contents / "Frameworks" / "hud_only" / "module.dylib").write_text("dependency", encoding="utf-8")
     (hud_contents / "Resources" / "hud_data" / "config.xml").write_text("data", encoding="utf-8")
 
     bundled = bundle_pyinstaller_hud(dist)
 
-    assert bundled == fpdb_contents / "MacOS" / "HUD_main"
+    assert bundled == fpdb_contents / "MacOS" / "fpdb"
     assert bundled.is_file()
-    assert os.access(bundled, os.X_OK)
     assert (fpdb_contents / "Frameworks" / "hud_only" / "module.dylib").is_file()
     assert (fpdb_contents / "Resources" / "hud_data" / "config.xml").is_file()
+    assert not (fpdb_contents / "MacOS" / "HUD_main").exists()
     assert not (dist / "HUD_main.app").exists()
 
 
 def test_info_plist_gains_the_privacy_descriptions(tmp_path: Path) -> None:
-    # macOS only remembers a granted permission when the bundle declares why it
-    # wants it and keeps a stable identifier, so these four keys are the whole
-    # point of the step.
+    # Usage descriptions make the native privacy prompts actionable; the code
+    # signature, tested separately, provides the stable TCC identity.
     info_plist = tmp_path / "Info.plist"
     with info_plist.open("wb") as handle:
         plistlib.dump({"CFBundleName": "fpdb", "CFBundleIdentifier": "com.example.fpdb"}, handle)
@@ -72,6 +72,8 @@ def test_info_plist_gains_the_privacy_descriptions(tmp_path: Path) -> None:
     with info_plist.open("rb") as handle:
         info = plistlib.load(handle)
     assert info["CFBundleIdentifier"] == "org.fpdb.fpdb3"
+    assert info["CFBundleShortVersionString"] != "0.0.0"
+    assert info["CFBundleVersion"] == info["CFBundleShortVersionString"]
     assert "AppleScript" in info["NSAppleEventsUsageDescription"]
     assert info["NSScreenCaptureUsageDescription"]
     assert info["NSAccessibilityUsageDescription"]
@@ -112,6 +114,7 @@ def test_runs_as_a_script_the_way_ci_invokes_it(tmp_path: Path) -> None:
     for directory in ("MacOS", "Frameworks", "Resources"):
         (fpdb_contents / directory).mkdir(parents=True)
     (hud_contents / "MacOS").mkdir(parents=True)
+    (fpdb_contents / "MacOS" / "fpdb").write_text("main executable", encoding="utf-8")
     (hud_contents / "MacOS" / "HUD_main").write_text("executable", encoding="utf-8")
     with (fpdb_contents / "Info.plist").open("wb") as handle:
         plistlib.dump({"CFBundleName": "fpdb"}, handle)

--- a/test/test_bundle_pyinstaller_hud.py
+++ b/test/test_bundle_pyinstaller_hud.py
@@ -77,6 +77,7 @@ def test_info_plist_gains_the_privacy_descriptions(tmp_path: Path) -> None:
     assert "AppleScript" in info["NSAppleEventsUsageDescription"]
     assert info["NSScreenCaptureUsageDescription"]
     assert info["NSAccessibilityUsageDescription"]
+    assert "poker client data files" in info["NSAppDataUsageDescription"]
     # Untouched keys survive the rewrite.
     assert info["CFBundleName"] == "fpdb"
 

--- a/test/test_fpdb_lazy_default_paths.py
+++ b/test/test_fpdb_lazy_default_paths.py
@@ -1,0 +1,107 @@
+"""Default-path discovery must be tied to an active import workflow.
+
+``Configuration.get_default_paths()`` can recover stale room paths by probing
+platform-specific fallback locations. That is useful once an import workflow is
+requested, but calling it from ``fpdb.load_profile()`` also did those probes at
+application startup and on routine profile refreshes.
+
+The tests inspect/exercise just the relevant methods from ``fpdb.pyw`` so they
+do not construct the heavy Qt main window.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+SOURCE = Path(__file__).resolve().parents[1] / "fpdb_3_legacy" / "fpdb.pyw"
+TREE = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
+
+
+def _fpdb_method(name: str) -> ast.FunctionDef:
+    fpdb_class = next(node for node in TREE.body if isinstance(node, ast.ClassDef) and node.name == "fpdb")
+    return next(node for node in fpdb_class.body if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _calls_get_default_paths(method: ast.FunctionDef) -> bool:
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "get_default_paths"
+        for node in ast.walk(method)
+    )
+
+
+def _load_method(name: str, namespace: dict[str, Any]) -> Any:
+    module = ast.Module(body=[_fpdb_method(name)], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(SOURCE), "exec"), namespace)  # noqa: S102 - executes repository source under test
+    return namespace[name]
+
+
+def test_profile_loading_never_resolves_import_default_paths() -> None:
+    """Startup/profile refresh stays passive even when saved paths are stale."""
+    assert not _calls_get_default_paths(_fpdb_method("load_profile"))
+
+
+def test_bulk_import_resolves_default_paths_only_when_opened() -> None:
+    """Opening Bulk Import retains its detected/custom initial directory."""
+    widget = object()
+    constructor = MagicMock(return_value=widget)
+    tab_bulk_import = _load_method(
+        "tab_bulk_import",
+        {"GuiBulkImport": SimpleNamespace(GuiBulkImport=constructor)},
+    )
+
+    settings = {"global_lock": object(), "db-host": "localhost"}
+    config = MagicMock()
+    config.get_default_paths.return_value = {
+        "bulkImport-defaultPath": "/Users/player/Documents/Poker/Hands",
+        "hud-defaultPath": "/Users/player/Documents/Poker/Hands",
+    }
+    window = SimpleNamespace(
+        settings=settings,
+        config=config,
+        sql=object(),
+        threads=[],
+        add_and_display_tab=MagicMock(),
+    )
+
+    tab_bulk_import(window, None)
+
+    config.get_default_paths.assert_called_once_with()
+    assert settings["bulkImport-defaultPath"] == "/Users/player/Documents/Poker/Hands"
+    constructor.assert_called_once_with(settings, config, window.sql, window)
+    assert window.threads == [widget]
+    window.add_and_display_tab.assert_called_once_with(widget, "Bulk Import")
+
+
+def test_opening_auto_import_does_not_trigger_global_default_detection() -> None:
+    """Auto Import performs enabled-site resolution later, after Start."""
+    widget = SimpleNamespace(startButton=object())
+    constructor = MagicMock(return_value=widget)
+    tab_auto_import = _load_method(
+        "tab_auto_import",
+        {
+            "GuiAutoImport": SimpleNamespace(GuiAutoImport=constructor),
+            "options": SimpleNamespace(autoimport=False),
+        },
+    )
+
+    settings = {"global_lock": object(), "db-host": "localhost"}
+    config = MagicMock()
+    config.get_default_paths.side_effect = AssertionError("opening the tab must remain passive")
+    window = SimpleNamespace(
+        settings=settings,
+        config=config,
+        sql=object(),
+        threads=[],
+        add_and_display_tab=MagicMock(),
+    )
+
+    tab_auto_import(window, None)
+
+    config.get_default_paths.assert_not_called()
+    constructor.assert_called_once_with(settings, config, window.sql, window)
+    assert window.threads == [widget]

--- a/test/test_grant_macos_permissions.py
+++ b/test/test_grant_macos_permissions.py
@@ -18,7 +18,7 @@ def test_re_sign_bundle_returns_false_for_non_existent_path(tmp_path: Path) -> N
     assert not grant_macos_permissions.re_sign_bundle(non_existent)
 
 
-def test_setup_app_bundle_invokes_quarantine_and_sign(tmp_path: Path, monkeypatch) -> None:
+def test_setup_app_bundle_does_not_destroy_a_stable_signature_by_default(tmp_path: Path, monkeypatch) -> None:
     app_path = tmp_path / "fpdb.app"
     app_path.mkdir()
 
@@ -27,7 +27,7 @@ def test_setup_app_bundle_invokes_quarantine_and_sign(tmp_path: Path, monkeypatc
 
     results = grant_macos_permissions.setup_app_bundle(app_path)
     assert results["quarantine_cleared"] is True
-    assert results["signed"] is True
+    assert results["signed"] is False
 
 
 def test_check_and_print_permission_status(monkeypatch, capsys) -> None:
@@ -53,7 +53,7 @@ def test_setup_app_bundle_flags_select_one_step(tmp_path: Path, monkeypatch) -> 
     only_clear = grant_macos_permissions.setup_app_bundle(app_path, sign=False)
     assert only_clear == {"quarantine_cleared": True, "signed": False}
 
-    only_sign = grant_macos_permissions.setup_app_bundle(app_path, clear=False)
+    only_sign = grant_macos_permissions.setup_app_bundle(app_path, clear=False, sign=True)
     assert only_sign == {"quarantine_cleared": False, "signed": True}
 
 

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -84,6 +84,8 @@ def test_run_headless_imports_then_shuts_down_cleanly():
     lock.acquire.return_value = True
     gui = _make_gui(_make_settings(lock), _make_config(interval=1))
     gui.updatePaths = MagicMock()
+    path_sync_states = []
+    gui.updatePaths.side_effect = lambda: path_sync_states.append(gui.doAutoImportBool)
 
     # Stop the otherwise-infinite loop after the first sleep.
     with patch.object(sys.modules["fpdb_3_legacy.GuiAutoImport"].time, "sleep", side_effect=KeyboardInterrupt):
@@ -91,6 +93,7 @@ def test_run_headless_imports_then_shuts_down_cleanly():
 
     assert rc == 0
     gui.updatePaths.assert_called_once()
+    assert path_sync_states == [True]
     gui.importer.autoSummaryGrab.assert_any_call()  # per-cycle grab
     gui.importer.runUpdated.assert_called_once()
     gui.importer.autoSummaryGrab.assert_called_with(force=True)  # final grab
@@ -118,7 +121,6 @@ def test_update_paths_monitors_multiple_sites_and_content_types(tmp_path):
     sites = ["PokerStars", "Winamax"]
     config.get_supported_sites.return_value = sites
     config.get_site_parameters.side_effect = lambda site: {"enabled": site in sites}
-
     paths = {}
     for site in sites:
         hh_path = tmp_path / site / "hands"
@@ -134,6 +136,7 @@ def test_update_paths_monitors_multiple_sites_and_content_types(tmp_path):
     gui = _make_gui(_make_settings(MagicMock()), config)
     gui.importer.dirlist = {}
     gui.addText = MagicMock()
+    gui.doAutoImportBool = True
 
     gui.updatePaths()
 
@@ -145,6 +148,111 @@ def test_update_paths_monitors_multiple_sites_and_content_types(tmp_path):
     assert gui.importer.addImportDirectory.call_count == 4
     for site_key, path in expected.items():
         gui.importer.addImportDirectory.assert_any_call(path, monitor=True, site=site_key)
+    assert [entry.args[0] for entry in config.get_default_paths.call_args_list] == sites
+
+
+def test_passive_path_refresh_does_not_reload_or_probe_configuration():
+    """Opening the tab or receiving a passive observer refresh touches no paths."""
+    config = _make_config()
+    config.get_supported_sites.side_effect = AssertionError("site paths must remain untouched while stopped")
+    gui = _make_gui(_make_settings(MagicMock()), config)
+    gui.importer.dirlist = {("Winamax", "hh"): ["/previous/path", "passthrough"]}
+
+    gui.updatePaths()
+
+    config.reload.assert_not_called()
+    config.get_supported_sites.assert_not_called()
+    config.get_default_paths.assert_not_called()
+    gui.importer.addImportDirectory.assert_not_called()
+    gui.importer.removeImportDirectory.assert_not_called()
+
+
+def test_update_paths_resolves_enabled_sites_but_never_disabled_sites(tmp_path):
+    """Active path recovery is allowed only for enabled sites."""
+    detected_hands = tmp_path / "Winamax" / "accounts" / "Hero" / "history"
+    detected_hands.mkdir(parents=True)
+    config = _make_config()
+    config.get_supported_sites.return_value = ["Winamax", "Disabled", "NoPaths"]
+    config.get_site_parameters.side_effect = {
+        "Winamax": {
+            "enabled": True,
+        },
+        "Disabled": {
+            "enabled": False,
+            "HH_path": "~/Downloads/disabled/hands",
+            "TS_path": "~/Library/Application Support/disabled/summaries",
+        },
+        "NoPaths": {"enabled": True},
+    }.__getitem__
+
+    def detected_paths(site):
+        if site == "Disabled":
+            raise AssertionError("disabled site path detection must never run")
+        if site == "Winamax":
+            return {"hud-defaultPath": str(detected_hands)}
+        return {}
+
+    config.get_default_paths.side_effect = detected_paths
+
+    gui = _make_gui(_make_settings(MagicMock()), config)
+    gui.importer.dirlist = {}
+    gui.addText = MagicMock()
+    gui.doAutoImportBool = True
+
+    gui.updatePaths()
+
+    gui.importer.addImportDirectory.assert_called_once_with(
+        str(detected_hands),
+        monitor=True,
+        site=("Winamax", "hh"),
+    )
+    assert [entry.args[0] for entry in config.get_default_paths.call_args_list] == ["Winamax", "NoPaths"]
+
+
+def test_active_config_refresh_replaces_only_the_changed_watch(tmp_path):
+    """Dynamic path changes still resynchronise an active auto-import session."""
+    old_hands = tmp_path / "old" / "hands"
+    new_hands = tmp_path / "new" / "hands"
+    new_hands.mkdir(parents=True)
+    config = _make_config()
+    config.get_supported_sites.return_value = ["Winamax"]
+    config.get_site_parameters.return_value = {"enabled": True}
+    config.get_default_paths.return_value = {"hud-defaultPath": str(new_hands)}
+    gui = _make_gui(_make_settings(MagicMock()), config)
+    gui.importer.dirlist = {("Winamax", "hh"): [str(old_hands), "passthrough"]}
+    gui.addText = MagicMock()
+    gui.doAutoImportBool = True
+
+    gui.updatePaths()
+
+    config.reload.assert_called_once_with()
+    gui.importer.removeImportDirectory.assert_called_once_with(str(old_hands), site=("Winamax", "hh"))
+    gui.importer.addImportDirectory.assert_called_once_with(
+        str(new_hands),
+        monitor=True,
+        site=("Winamax", "hh"),
+    )
+
+
+def test_standalone_main_does_not_resolve_paths_before_headless_start():
+    """The standalone entry point must not auto-detect a default site path."""
+    from fpdb_3_legacy import GuiAutoImport
+
+    config = _make_config()
+    config.get_default_paths.side_effect = AssertionError("default path resolution is not startup work")
+    runner = MagicMock()
+    runner.run_headless.return_value = 0
+
+    with (
+        patch.object(GuiAutoImport.Configuration, "Config", return_value=config),
+        patch.object(GuiAutoImport, "GuiAutoImport", return_value=runner) as gui_class,
+        patch.object(GuiAutoImport.interlocks, "InterProcessLock", return_value=MagicMock()),
+    ):
+        assert GuiAutoImport.main(["-q"]) == 0
+
+    config.get_default_paths.assert_not_called()
+    gui_class.assert_called_once()
+    assert gui_class.call_args.kwargs["cli"] is True
 
 
 def test_hud_base_path_is_module_dir_and_holds_hud_main():

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -193,13 +193,8 @@ def test_launch_hud_uses_bundled_sibling_executable(monkeypatch, tmp_path, platf
     assert popen_kwargs["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
 
 
-def test_launch_hud_pyinstaller_macos_uses_the_sibling_executable(monkeypatch, tmp_path):
-    """'fpdb --hud' has no HUD in it: only HUD_main's own archive is complete.
-
-    The fpdb executable is analysed from fpdb.pyw, which never imports the HUD's
-    backend, so running the HUD inside it died on startup with
-    ModuleNotFoundError (OSXTables, then fpdb.infrastructure).
-    """
+def test_launch_hud_pyinstaller_macos_reuses_the_main_executable(monkeypatch, tmp_path):
+    """The macOS HUD must retain the main bundle's privacy identity."""
     settings = _make_settings(MagicMock())
     settings["cl_options"] = "--config bundled.xml"
     config = _make_config()
@@ -209,10 +204,6 @@ def test_launch_hud_pyinstaller_macos_uses_the_sibling_executable(monkeypatch, t
     gui_mod = sys.modules["fpdb_3_legacy.GuiAutoImport"]
     fpdb_executable = tmp_path / "fpdb"
     fpdb_executable.touch()
-    # Chosen from os.name, not sys.platform, so follow the host: the Windows
-    # runner looks for HUD_main.exe even with sys.platform faked to darwin.
-    hud_executable = tmp_path / ("HUD_main.exe" if os.name == "nt" else "HUD_main")
-    hud_executable.touch()
     monkeypatch.setattr(gui_mod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(gui_mod.sys, "executable", str(fpdb_executable))
     monkeypatch.setattr(gui_mod.sys, "platform", "darwin")
@@ -222,12 +213,9 @@ def test_launch_hud_pyinstaller_macos_uses_the_sibling_executable(monkeypatch, t
         gui._launch_hud()
 
     command = mock_popen.call_args.args[0]
-    assert command == [str(hud_executable), "--config", "bundled.xml"]
+    assert command == [str(fpdb_executable), "--hud", "--config", "bundled.xml"]
     child_env = mock_popen.call_args.kwargs["env"]
     assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
-    # Finding table windows no longer depends on macOS Accessibility, so the
-    # HUD must not push the user at System Settings on every launch.
-    assert "FPDB_REQUEST_MACOS_PERMISSIONS" not in child_env
 
 
 def test_launch_hud_pyoxidizer_reuses_main_executable(monkeypatch, tmp_path):

--- a/test/test_hud_main_backend_imports.py
+++ b/test/test_hud_main_backend_imports.py
@@ -1,9 +1,8 @@
 """The OS backend must be imported through the package, not as a bare module.
 
 On macOS the frozen build runs the HUD inside the *fpdb* executable
-(``fpdb --hud``), whose dependency analysis only ever saw ``fpdb_3_legacy.*``
-imports. A bare ``import OSXTables`` is therefore absent from that executable's
-archive, and the HUD died on startup with::
+(``fpdb --hud``). HUD_main is reached through ``runpy``, so PyInstaller needs a
+hook to include its dynamic backend graph; a bare import also used to die with::
 
     ModuleNotFoundError: No module named 'OSXTables'
 
@@ -20,6 +19,9 @@ from pathlib import Path
 import pytest
 
 HUD_MAIN = Path(__file__).parent.parent / "fpdb_3_legacy" / "HUD_main.pyw"
+PYINSTALLER_HOOK = (
+    Path(__file__).parent.parent / "tools" / "pyinstaller_hooks" / "hook-fpdb_3_legacy.subprocess_launch.py"
+)
 BACKENDS = ("OSXTables", "XTables", "WinTables")
 
 
@@ -43,6 +45,15 @@ def test_no_backend_is_imported_as_a_bare_top_level_module() -> None:
         f"runs the HUD inside the fpdb executable, which has no such modules; import "
         f"them as 'from fpdb_3_legacy import <name> as Tables' instead."
     )
+
+
+def test_pyinstaller_main_hook_includes_the_macos_hud_backend_graph() -> None:
+    """runpy hides these imports from analysis of the main fpdb executable."""
+    tree = ast.parse(PYINSTALLER_HOOK.read_text(encoding="utf-8"))
+    strings = {node.value for node in ast.walk(tree) if isinstance(node, ast.Constant) and isinstance(node.value, str)}
+
+    assert "fpdb_3_legacy.OSXTables" in strings
+    assert "fpdb.infrastructure.platform.macos" in strings
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -171,6 +171,12 @@ def test_ci_smokes_precede_final_pyoxidizer_signature() -> None:
     assert "Contents/MacOS/fpdb" not in assemble[final_sign:]
 
 
+def test_pyoxidizer_runtime_cannot_mutate_a_signed_bundle_with_bytecode() -> None:
+    config = (Path(__file__).resolve().parent.parent / "pyoxidizer.bzl").read_text()
+
+    assert '"sys.dont_write_bytecode = True"' in config
+
+
 def test_bundle_declares_the_launcher_and_icon(install_dir: Path, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(package_pyoxidizer_macos, "sign", lambda paths, **kwargs: None)
     monkeypatch.setattr(package_pyoxidizer_macos, "sign_bundle", lambda app, **kwargs: None)

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -116,6 +116,61 @@ def test_bundle_keeps_only_the_launcher_in_macos(install_dir: Path, tmp_path: Pa
     assert not (resources / "fpdb").exists()
 
 
+def test_deferred_bundle_is_not_signed(install_dir: Path, tmp_path: Path, monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign_app", lambda *args, **kwargs: calls.append("sign"))
+    monkeypatch.setattr(package_pyoxidizer_macos.subprocess, "run", lambda *args, **kwargs: None)
+
+    package_pyoxidizer_macos.build_app(
+        install_dir,
+        tmp_path / "fpdb.app",
+        "fpdb",
+        "3.0.0",
+        None,
+        defer_signing=True,
+    )
+
+    assert calls == []
+
+
+def test_sign_existing_seals_nested_code_before_bundle(tmp_path: Path, monkeypatch) -> None:
+    app = tmp_path / "fpdb.app"
+    resources = app / "Contents" / "Resources"
+    resources.mkdir(parents=True)
+    nested = resources / "libexample.dylib"
+    nested.write_bytes(MACH_O_HEADER)
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(package_pyoxidizer_macos, "resolve_signing_identity", lambda identity: "identity")
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign", lambda paths, **kwargs: calls.append(("nested", paths)))
+    monkeypatch.setattr(
+        package_pyoxidizer_macos,
+        "sign_bundle",
+        lambda bundle, **kwargs: calls.append(("bundle", bundle)),
+    )
+
+    result = package_pyoxidizer_macos.sign_app(app)
+
+    assert result == app
+    assert calls == [("nested", [nested]), ("bundle", app)]
+
+
+def test_ci_smokes_precede_final_pyoxidizer_signature() -> None:
+    workflow = (Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml").read_text()
+    start = workflow.index("- name: Assemble PyOxidizer macOS application")
+    end = workflow.index("- name: Notarize and staple PyOxidizer macOS release", start)
+    assemble = workflow[start:end]
+
+    unsigned = assemble.index("--defer-signing")
+    last_smoke = assemble.index("--run-module fpdb.infrastructure.platform.macos")
+    final_sign = assemble.index("--sign-existing dist/fpdb.app")
+    final_verify = assemble.index("codesign --verify --deep --strict dist/fpdb.app")
+
+    assert unsigned < last_smoke < final_sign < final_verify
+    assert 'PYTHONDONTWRITEBYTECODE: "1"' in assemble
+    assert "Contents/MacOS/fpdb" not in assemble[final_sign:]
+
+
 def test_bundle_declares_the_launcher_and_icon(install_dir: Path, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(package_pyoxidizer_macos, "sign", lambda paths, **kwargs: None)
     monkeypatch.setattr(package_pyoxidizer_macos, "sign_bundle", lambda app, **kwargs: None)

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -164,11 +164,12 @@ def test_ci_smokes_precede_final_pyoxidizer_signature() -> None:
     unsigned = assemble.index("--defer-signing")
     last_smoke = assemble.index("--run-module fpdb.infrastructure.platform.macos")
     final_sign = assemble.index("--sign-existing dist/fpdb.app")
+    immutable_smoke = assemble.index("--run-module fpdb_3_legacy.winamax_ax_seats")
     final_verify = assemble.index("codesign --verify --deep --strict dist/fpdb.app")
 
-    assert unsigned < last_smoke < final_sign < final_verify
+    assert unsigned < last_smoke < final_sign < immutable_smoke < final_verify
     assert 'PYTHONDONTWRITEBYTECODE: "1"' in assemble
-    assert "Contents/MacOS/fpdb" not in assemble[final_sign:]
+    assert "Contents/MacOS/fpdb" not in assemble[final_verify:]
 
 
 def test_pyoxidizer_runtime_cannot_mutate_a_signed_bundle_with_bytecode() -> None:

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -14,6 +14,15 @@ import pytest
 from tools import adhoc_sign_macos, package_pyoxidizer_macos
 
 MACH_O_HEADER = b"\xcf\xfa\xed\xfe" + b"\x00" * 60
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow_job(workflow: str, job: str, next_job: str | None = None) -> str:
+    start = workflow.index(f"  {job}:\n")
+    if next_job is None:
+        return workflow[start:]
+    return workflow[start : workflow.index(f"\n  {next_job}:\n", start)]
 
 
 @pytest.fixture
@@ -155,8 +164,20 @@ def test_sign_existing_seals_nested_code_before_bundle(tmp_path: Path, monkeypat
     assert calls == [("nested", [nested]), ("bundle", app)]
 
 
+def test_release_pyoxidizer_rejects_a_non_developer_id_identity(tmp_path: Path, monkeypatch) -> None:
+    app = tmp_path / "fpdb.app"
+    (app / "Contents" / "Resources").mkdir(parents=True)
+    monkeypatch.setenv(adhoc_sign_macos.REQUIRE_STABLE_SIGNING_ENV, "1")
+
+    with pytest.raises(RuntimeError, match="Developer ID Application"):
+        package_pyoxidizer_macos.sign_app(
+            app,
+            signing_identity="Apple Development: FPDB (TEAMID1234)",
+        )
+
+
 def test_ci_smokes_precede_final_pyoxidizer_signature() -> None:
-    workflow = (Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml").read_text()
+    workflow = CI_WORKFLOW.read_text()
     start = workflow.index("- name: Assemble PyOxidizer macOS application")
     end = workflow.index("- name: Notarize and staple PyOxidizer macOS release", start)
     assemble = workflow[start:end]
@@ -170,6 +191,47 @@ def test_ci_smokes_precede_final_pyoxidizer_signature() -> None:
     assert unsigned < last_smoke < final_sign < immutable_smoke < final_verify
     assert 'PYTHONDONTWRITEBYTECODE: "1"' in assemble
     assert "Contents/MacOS/fpdb" not in assemble[final_verify:]
+
+
+def test_ci_distributes_macos_only_with_pyoxidizer() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    pyinstaller = _workflow_job(workflow, "build", "build-pyoxidizer")
+    pyoxidizer = _workflow_job(workflow, "build-pyoxidizer")
+
+    assert "os: ubuntu-latest" in pyinstaller
+    assert "os: windows-latest" in pyinstaller
+    assert "fpdb-pyinstaller-linux-x64" in pyinstaller
+    assert "fpdb-pyinstaller-windows-x64" in pyinstaller
+    assert "macos-latest" not in pyinstaller
+    assert "fpdb-pyinstaller-macos" not in workflow
+    assert "fpdb.app" not in pyinstaller
+    assert "if: runner.os != 'macOS'" in pyinstaller
+    assert "if: github.event_name == 'release' && runner.os != 'macOS'" in pyinstaller
+
+    assert "os: macos-latest" in pyoxidizer
+    assert "artifact: fpdb-pyoxidizer-macos-arm64" in pyoxidizer
+
+
+def test_release_and_rc_pyoxidizer_artifacts_require_stable_developer_id() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    pyoxidizer = _workflow_job(workflow, "build-pyoxidizer")
+
+    # GitHub sends release/published for public prereleases (including RCs) as
+    # well as final releases, so this is the shared distribution gate.
+    assert "release:\n    types: [ published ]" in workflow
+    assert "FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}" in pyoxidizer
+    assert '"Developer ID Application: "*' in pyoxidizer
+    assert 'grep -Fqx "Authority=$FPDB_MACOS_SIGNING_IDENTITY"' in pyoxidizer
+    assert 'grep -Fqx "TeamIdentifier=$expected_team_id"' in pyoxidizer
+    assert "grep -Fq 'anchor apple generic'" in pyoxidizer
+    assert "grep -q 'designated => cdhash'" in pyoxidizer
+    assert "spctl --assess --type execute --verbose=4 dist/fpdb.app" in pyoxidizer
+
+    archive = pyoxidizer.index('tar -czf "${{ matrix.artifact }}.tar.gz" -C dist fpdb.app')
+    extract = pyoxidizer.index('tar -xzf "${{ matrix.artifact }}.tar.gz" -C "$verify_dir"')
+    verify = pyoxidizer.index('codesign --verify --deep --strict --verbose=2 "$verify_dir/fpdb.app"')
+    upload = pyoxidizer.index("- name: Upload PyOxidizer artifact")
+    assert archive < extract < verify < upload
 
 
 def test_pyoxidizer_runtime_cannot_mutate_a_signed_bundle_with_bytecode() -> None:
@@ -196,6 +258,7 @@ def test_bundle_declares_the_launcher_and_icon(install_dir: Path, tmp_path: Path
     assert "NSAppleEventsUsageDescription" in info
     assert "NSScreenCaptureUsageDescription" in info
     assert "NSAccessibilityUsageDescription" in info
+    assert "poker client data files" in info["NSAppDataUsageDescription"]
     assert (app / "Contents" / "Resources" / "tribal.icns").is_file()
 
 

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -1,4 +1,4 @@
-"""Assembly and ad-hoc signing of the macOS PyOxidizer bundle.
+"""Assembly and signing of the macOS PyOxidizer bundle.
 
 codesign itself is not exercised here (it only exists on macOS runners); the
 layout it demands is, because getting that wrong is what breaks the build.
@@ -52,9 +52,55 @@ def test_mach_o_search_covers_extensionless_framework_binaries(tmp_path: Path) -
     assert found == [framework / "QtCore"]
 
 
+def test_release_signing_gate_rejects_ad_hoc_identity(monkeypatch) -> None:
+    monkeypatch.setenv(adhoc_sign_macos.REQUIRE_STABLE_SIGNING_ENV, "1")
+    monkeypatch.delenv(adhoc_sign_macos.SIGNING_IDENTITY_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match="Developer ID"):
+        adhoc_sign_macos.resolve_signing_identity()
+
+
+def test_developer_id_signing_enables_runtime_timestamp_and_entitlements(tmp_path: Path) -> None:
+    entitlements = tmp_path / "entitlements.plist"
+    entitlements.touch()
+
+    command = adhoc_sign_macos._codesign_command(  # noqa: SLF001
+        [tmp_path / "fpdb.app"],
+        identity="Developer ID Application: FPDB (TEAMID1234)",
+        deep=True,
+        entitlements=entitlements,
+    )
+
+    assert "--options" in command
+    assert "runtime" in command
+    assert "--timestamp" in command
+    assert command[command.index("--entitlements") + 1] == str(entitlements)
+
+
+def test_ad_hoc_signing_does_not_claim_hardened_runtime(tmp_path: Path) -> None:
+    command = adhoc_sign_macos._codesign_command(  # noqa: SLF001
+        [tmp_path / "fpdb.app"],
+        identity=adhoc_sign_macos.ADHOC_IDENTITY,
+        deep=True,
+        entitlements=package_pyoxidizer_macos.ENTITLEMENTS,
+    )
+
+    assert "runtime" not in command
+    assert "--timestamp" not in command
+    assert "--entitlements" not in command
+
+
+def test_release_entitlements_allow_apple_events() -> None:
+    with package_pyoxidizer_macos.ENTITLEMENTS.open("rb") as handle:
+        entitlements = plistlib.load(handle)
+
+    assert entitlements["com.apple.security.automation.apple-events"] is True
+
+
 def test_bundle_keeps_only_the_launcher_in_macos(install_dir: Path, tmp_path: Path, monkeypatch) -> None:
     """codesign refuses to seal a bundle whose MacOS directory holds payload."""
-    monkeypatch.setattr(package_pyoxidizer_macos, "adhoc_sign", lambda paths: None)
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign", lambda paths, **kwargs: None)
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign_bundle", lambda app, **kwargs: None)
     monkeypatch.setattr(package_pyoxidizer_macos.subprocess, "run", lambda *args, **kwargs: None)
     icon = tmp_path / "tribal.icns"
     icon.write_bytes(b"icns")
@@ -71,7 +117,8 @@ def test_bundle_keeps_only_the_launcher_in_macos(install_dir: Path, tmp_path: Pa
 
 
 def test_bundle_declares_the_launcher_and_icon(install_dir: Path, tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(package_pyoxidizer_macos, "adhoc_sign", lambda paths: None)
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign", lambda paths, **kwargs: None)
+    monkeypatch.setattr(package_pyoxidizer_macos, "sign_bundle", lambda app, **kwargs: None)
     monkeypatch.setattr(package_pyoxidizer_macos.subprocess, "run", lambda *args, **kwargs: None)
     icon = tmp_path / "tribal.icns"
     icon.write_bytes(b"icns")

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -27,8 +27,8 @@ def _detector(*, window_list: list[dict] | None = None) -> MacOSTableDetector:
     detector._applescript_last_result = []
     detector._permissions_checked = False
     detector._permission_status = None
-    detector._automation_warned = False
-    detector._automation_blocked = False
+    detector._system_events_warned = False
+    detector._system_events_blocked = False
     detector._NSWorkspace = Mock()
     detector._kCGNullWindowID = 0
     detector._kCGWindowListOptionOnScreenOnly = 8
@@ -37,7 +37,7 @@ def _detector(*, window_list: list[dict] | None = None) -> MacOSTableDetector:
 
 
 def _hung_osascript() -> TimeoutExpired:
-    """What osascript raises when the Automation prompt is left unanswered.
+    """What osascript raises for a pending prompt or unresponsive Apple Event.
 
     This constructs an exception, not a process: Semgrep's subprocess audit
     matches the constructor by name, which is why the suppression lives here
@@ -239,7 +239,7 @@ def test_run_applescript_scan_warns_on_automation_blocked() -> None:
         patch("fpdb.infrastructure.platform.macos.logger") as logger,
     ):
         detector._run_applescript_scan()
-    assert detector._automation_warned is True
+    assert detector._system_events_warned is True
     logger.warning.assert_called_once()
 
 
@@ -263,8 +263,8 @@ def test_run_applescript_scan_does_not_warn_on_other_errors() -> None:
         patch("fpdb.infrastructure.platform.macos.logger") as logger,
     ):
         detector._run_applescript_scan()
-    assert detector._automation_warned is False
-    assert detector._automation_blocked is False
+    assert detector._system_events_warned is False
+    assert detector._system_events_blocked is False
     logger.warning.assert_not_called()
 
 
@@ -273,11 +273,11 @@ def test_run_applescript_scan_treats_a_refusal_as_blocking() -> None:
     result = Mock(returncode=1, stdout="", stderr="-1743 operation not allowed")
     with patch("fpdb.infrastructure.platform.macos.subprocess.run", return_value=result):
         detector._run_applescript_scan()
-    assert detector._automation_blocked is True
+    assert detector._system_events_blocked is True
 
 
 def test_run_applescript_scan_treats_an_unanswered_prompt_as_blocking() -> None:
-    """-1712 means the Automation dialog is up and nobody has answered it.
+    """-1712 means the Apple Event timed out, often on a pending prompt.
 
     Every later scan would sit through the same multi-second timeout, and
     Fast-Fold reaches this path on every hand.
@@ -289,8 +289,39 @@ def test_run_applescript_scan_treats_an_unanswered_prompt_as_blocking() -> None:
         patch("fpdb.infrastructure.platform.macos.logger") as logger,
     ):
         detector._run_applescript_scan()
-    assert detector._automation_blocked is True
+    assert detector._system_events_blocked is True
     logger.warning.assert_called_once()
+
+
+def test_run_applescript_scan_reports_accessibility_refusal() -> None:
+    detector = _detector()
+    result = Mock(
+        returncode=1,
+        stdout="",
+        stderr="System Events got an error: osascript is not allowed assistive access. (-1719)",
+    )
+    with (
+        patch("fpdb.infrastructure.platform.macos.subprocess.run", return_value=result),
+        patch("fpdb.infrastructure.platform.macos.logger") as logger,
+    ):
+        detector._run_applescript_scan()
+
+    assert detector._system_events_blocked is True
+    assert "accessibility" in logger.warning.call_args.args
+
+
+def test_run_applescript_scan_does_not_treat_bare_1719_as_a_permission_error() -> None:
+    """Apple also uses -1719 for an invalid list index."""
+    detector = _detector()
+    result = Mock(returncode=1, stdout="", stderr="Can't get item 7 of list. (-1719)")
+    with (
+        patch("fpdb.infrastructure.platform.macos.subprocess.run", return_value=result),
+        patch("fpdb.infrastructure.platform.macos.logger") as logger,
+    ):
+        detector._run_applescript_scan()
+
+    assert detector._system_events_blocked is False
+    logger.warning.assert_not_called()
 
 
 def test_run_applescript_scan_swallows_errors() -> None:
@@ -612,6 +643,22 @@ def test_check_permissions_once_requests_when_env_set() -> None:
         permissions.open_accessibility_settings.assert_called_once()
 
 
+def test_check_permissions_once_requests_automatically_when_frozen() -> None:
+    detector = _detector()
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("fpdb.infrastructure.platform.macos.sys.frozen", True, create=True),
+        patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
+    ):
+        permissions.get_status.return_value = Mock(screen_recording=False, accessibility=False)
+        permissions.describe_missing.return_value = ["missing"]
+
+        detector._check_permissions_once()
+
+        permissions.request_screen_recording_permission.assert_called_once()
+        permissions.request_accessibility_permission.assert_called_once_with(prompt=True)
+
+
 def test_check_permissions_once_env_skips_granted_permissions() -> None:
     detector = _detector()
     with (
@@ -722,12 +769,7 @@ def test_find_tables_without_titles_uses_sole_blank_window() -> None:
 
 
 def test_find_tables_without_titles_still_scans_when_accessibility_is_missing() -> None:
-    """Driving System Events needs Automation, which is a different grant.
-
-    Gating the scan on Accessibility switched it off in every packaged build,
-    and for an Electron client like Winamax it is the only way left to read a
-    window title -- Quartz never exposes one.
-    """
+    """Try once so System Events can request Automation and explain the refusal."""
     detector = _detector()
     detector._match_target_window_by_pid = Mock(return_value=None)
     detector._check_permissions_once = Mock(return_value=Mock(accessibility=False))
@@ -746,7 +788,7 @@ def test_find_tables_without_titles_stops_scanning_once_system_events_refuses() 
     detector = _detector()
     detector._match_target_window_by_pid = Mock(return_value=None)
     detector.find_tables_applescript = Mock(return_value=[])
-    detector._automation_blocked = True
+    detector._system_events_blocked = True
     blank = TableInfo(window_id=3, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="Winamax")
 
     result = detector._find_tables_without_titles("Winamax Bucarest 6", [], [blank], 3, 0)
@@ -829,7 +871,7 @@ def test_run_applescript_scan_treats_a_hung_scan_as_blocking() -> None:
     ):
         detector._run_applescript_scan()
 
-    assert detector._automation_blocked is True
+    assert detector._system_events_blocked is True
     logger.warning.assert_called_once()
     logger.error.assert_not_called()
 

--- a/test/test_macos_table_detector.py
+++ b/test/test_macos_table_detector.py
@@ -7,6 +7,7 @@ stubbed ``subprocess.run`` for the AppleScript fallback.
 
 from __future__ import annotations
 
+import sys
 import time
 import zlib
 from subprocess import TimeoutExpired
@@ -131,6 +132,15 @@ def test_find_tables_returns_fallback_when_quartz_blank() -> None:
     fallback = [TableInfo(window_id=1, title="", geometry=TableGeometry(0, 0, 600, 500), process_name="PokerStars")]
     detector._find_tables_without_titles = Mock(return_value=fallback)
     assert detector.find_tables("pokerstars") == fallback
+
+
+def test_find_tables_can_make_a_quartz_only_first_pass() -> None:
+    detector = _detector(window_list=[_window(number=1, title="", owner="Winamax", pid=42)])
+    detector._find_tables_without_titles = Mock(return_value=[Mock()])
+
+    assert detector.find_tables(r"^Winamax\s+.*\s4\s*$", allow_fallback=False) == []
+
+    detector._find_tables_without_titles.assert_not_called()
 
 
 def test_find_tables_collects_blank_target_windows() -> None:
@@ -628,26 +638,11 @@ def test_check_permissions_once_logs_missing() -> None:
         assert logger.warning.call_count == 2
 
 
-def test_check_permissions_once_requests_when_env_set() -> None:
+def test_check_permissions_once_is_diagnostic_only_even_when_prompts_were_requested() -> None:
     detector = _detector()
     with (
         patch.dict("os.environ", {"FPDB_REQUEST_MACOS_PERMISSIONS": "1"}),
-        patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
-    ):
-        permissions.get_status.return_value = Mock(screen_recording=False, accessibility=False)
-        permissions.describe_missing.return_value = ["missing"]
-        detector._check_permissions_once()
-        permissions.request_screen_recording_permission.assert_called_once()
-        permissions.open_screen_recording_settings.assert_called_once()
-        permissions.request_accessibility_permission.assert_called_once_with(prompt=True)
-        permissions.open_accessibility_settings.assert_called_once()
-
-
-def test_check_permissions_once_requests_automatically_when_frozen() -> None:
-    detector = _detector()
-    with (
-        patch.dict("os.environ", {}, clear=True),
-        patch("fpdb.infrastructure.platform.macos.sys.frozen", True, create=True),
+        patch.object(sys, "frozen", True, create=True),
         patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
     ):
         permissions.get_status.return_value = Mock(screen_recording=False, accessibility=False)
@@ -655,52 +650,10 @@ def test_check_permissions_once_requests_automatically_when_frozen() -> None:
 
         detector._check_permissions_once()
 
-        permissions.request_screen_recording_permission.assert_called_once()
-        permissions.request_accessibility_permission.assert_called_once_with(prompt=True)
-
-
-def test_check_permissions_once_env_skips_granted_permissions() -> None:
-    detector = _detector()
-    with (
-        patch.dict("os.environ", {"FPDB_REQUEST_MACOS_PERMISSIONS": "1"}),
-        patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
-    ):
-        permissions.get_status.return_value = Mock(screen_recording=True, accessibility=False)
-        permissions.describe_missing.return_value = ["missing accessibility"]
-        detector._check_permissions_once()
-        permissions.request_screen_recording_permission.assert_not_called()
-        permissions.open_screen_recording_settings.assert_not_called()
-        permissions.request_accessibility_permission.assert_called_once()
-
-
-def test_check_permissions_once_env_skips_all_when_granted() -> None:
-    detector = _detector()
-    with (
-        patch.dict("os.environ", {"FPDB_REQUEST_MACOS_PERMISSIONS": "1"}),
-        patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
-    ):
-        permissions.get_status.return_value = Mock(screen_recording=True, accessibility=True)
-        permissions.describe_missing.return_value = []
-        detector._check_permissions_once()
         permissions.request_screen_recording_permission.assert_not_called()
         permissions.open_screen_recording_settings.assert_not_called()
         permissions.request_accessibility_permission.assert_not_called()
         permissions.open_accessibility_settings.assert_not_called()
-
-
-def test_check_permissions_once_env_accessibility_granted() -> None:
-    detector = _detector()
-    with (
-        patch.dict("os.environ", {"FPDB_REQUEST_MACOS_PERMISSIONS": "1"}),
-        patch("fpdb.infrastructure.platform.macos.permissions") as permissions,
-    ):
-        # Accessibility granted but Screen Recording missing: only the latter is
-        # requested, and the accessibility branch is skipped.
-        permissions.get_status.return_value = Mock(screen_recording=False, accessibility=True)
-        permissions.describe_missing.return_value = ["missing screen recording"]
-        detector._check_permissions_once()
-        permissions.request_screen_recording_permission.assert_called_once()
-        permissions.request_accessibility_permission.assert_not_called()
 
 
 def test_check_permissions_once_runs_at_most_once() -> None:

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -25,6 +25,7 @@ def test_off_macos_everything_is_a_safe_noop() -> None:
 
 def test_permission_status_aggregation() -> None:
     assert PermissionStatus(True, True).all_granted
+    assert PermissionStatus(True, True, app_data=False).all_granted
     assert not PermissionStatus(True, False).all_granted
     assert not PermissionStatus(False, True).all_granted
     assert not PermissionStatus(False, False).all_granted
@@ -133,6 +134,12 @@ def test_open_settings_uses_deep_link_on_macos() -> None:
             )
 
 
+def test_app_data_exposes_no_synthetic_request_or_settings_action() -> None:
+    assert not hasattr(permissions, "request_app_data_permission")
+    assert not hasattr(permissions, "open_app_data_settings")
+    assert not hasattr(permissions, "_APP_DATA_PANE")
+
+
 def test_open_settings_swallows_failures() -> None:
     with patch.object(permissions, "_IS_MACOS", True):
         with patch("fpdb.infrastructure.platform.permissions.subprocess.run", side_effect=OSError("no open")) as run:
@@ -146,7 +153,20 @@ def test_describe_missing_lists_only_missing_permissions() -> None:
         messages = permissions.describe_missing(status)
         assert len(messages) == 2
         assert "Screen Recording" in messages[0]
+        assert "quit and reopen FPDB manually only if" in messages[0]
         assert "Accessibility" in messages[1]
+        assert "Recheck" in messages[1]
+        assert "restart" not in messages[1].lower()
+
+
+def test_describe_missing_reports_known_app_data_denial_without_gating_hud() -> None:
+    with patch.object(permissions, "_IS_MACOS", True):
+        status = PermissionStatus(True, True, app_data=False)
+        messages = permissions.describe_missing(status)
+        assert status.all_granted is True
+        assert len(messages) == 1
+        assert "App Data" in messages[0]
+        assert "no safe preflight, request API, or dedicated Settings pane" in messages[0]
 
 
 def test_describe_missing_none_fetches_status() -> None:
@@ -164,3 +184,4 @@ def test_get_status_builds_snapshot() -> None:
             status = permissions.get_status()
             assert status.screen_recording is True
             assert status.accessibility is False
+            assert status.app_data is None

--- a/test/test_subprocess_launch.py
+++ b/test/test_subprocess_launch.py
@@ -41,27 +41,15 @@ def test_hud_command_uses_pyoxidizer_subcommand(monkeypatch) -> None:
     assert hud_main_command("-x") == [sys.executable, "--hud", "-x"]
 
 
-def test_hud_command_uses_the_sibling_executable_on_pyinstaller_macos(monkeypatch, tmp_path) -> None:
-    """Only PyOxidizer hosts both entry points in one binary.
-
-    Routing PyInstaller's macOS HUD through 'fpdb --hud' killed it on startup:
-    the fpdb executable's dependency analysis started at fpdb.pyw and never saw
-    the HUD's imports, so OSXTables and fpdb.infrastructure are simply not in
-    its archive. The sibling HUD_main executable carries its own complete one.
-    """
+def test_hud_command_reuses_the_main_executable_on_pyinstaller_macos(monkeypatch, tmp_path) -> None:
+    """One executable gives both processes the same macOS TCC identity."""
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(sys, "executable", str(tmp_path / "fpdb"))
-    # The name is chosen from os.name, not sys.platform, so this test has to
-    # follow the host it runs on -- the Windows runner builds HUD_main.exe.
-    hud = tmp_path / ("HUD_main.exe" if os.name == "nt" else "HUD_main")
-    hud.write_text("")
 
     command = hud_main_command("-x")
 
-    assert Path(command[0]) == hud.resolve()
-    assert command[1:] == ["-x"]
-    assert HUD_FLAG not in command
+    assert command == [str(tmp_path / "fpdb"), HUD_FLAG, "-x"]
 
 
 def test_hud_command_uses_sibling_executable_when_frozen(monkeypatch, tmp_path) -> None:

--- a/test/test_winamax_ax_seats.py
+++ b/test/test_winamax_ax_seats.py
@@ -307,7 +307,7 @@ class TestAutomationRefusalIsReported:
 
     @staticmethod
     def _run(monkeypatch, *, returncode: int, stderr: str):
-        monkeypatch.setattr(winamax_ax_seats, "_automation_refused", False)
+        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
         monkeypatch.setattr(
             winamax_ax_seats.subprocess,
             "run",
@@ -331,10 +331,27 @@ class TestAutomationRefusalIsReported:
         assert "Automation" in warnings[0].getMessage()
 
     def test_an_unanswered_prompt_counts_as_a_refusal(self, monkeypatch, caplog) -> None:
-        """-1712 means the permission dialog is up and nobody has answered it."""
+        """A timed-out Apple Event is blocked, whatever made it unresponsive."""
         with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
             assert self._run(monkeypatch, returncode=1, stderr="AppleEvent timed out. (-1712)") == []
         assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_accessibility_refusal_is_classified_from_its_text(self, monkeypatch, caplog) -> None:
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert (
+                self._run(
+                    monkeypatch,
+                    returncode=1,
+                    stderr="osascript is not allowed assistive access. (-1719)",
+                )
+                == []
+            )
+        assert "Accessibility" in caplog.records[0].getMessage()
+
+    def test_bare_1719_is_not_misclassified_as_accessibility(self, monkeypatch, caplog) -> None:
+        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
+            assert self._run(monkeypatch, returncode=1, stderr="Can't get item 8. (-1719)") == []
+        assert not [record for record in caplog.records if record.levelname == "WARNING"]
 
     def test_an_ordinary_failure_is_not_dressed_up_as_a_permission_problem(self, monkeypatch, caplog) -> None:
         with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
@@ -342,7 +359,7 @@ class TestAutomationRefusalIsReported:
         assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
     def test_a_hung_scan_is_reported_too(self, monkeypatch, caplog) -> None:
-        monkeypatch.setattr(winamax_ax_seats, "_automation_refused", False)
+        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
 
         def timeout(*_a, **_k):
             raise winamax_ax_seats.subprocess.TimeoutExpired(cmd="osascript", timeout=5)
@@ -351,6 +368,19 @@ class TestAutomationRefusalIsReported:
         with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
             assert winamax_ax_seats.applescript_window_titles() == []
         assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_a_blocked_scan_is_not_retried_after_the_ttl(self, monkeypatch) -> None:
+        calls = []
+        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
+        monkeypatch.setattr(
+            winamax_ax_seats.subprocess,
+            "run",
+            lambda *_a, **_k: (calls.append(1), SimpleNamespace(returncode=1, stdout="", stderr="(-1743)"))[1],
+        )
+
+        assert winamax_ax_seats.applescript_window_titles() == []
+        assert winamax_ax_seats.applescript_window_titles() == []
+        assert calls == [1]
 
     def test_the_scan_runs_from_an_absolute_path(self) -> None:
         """So it cannot be diverted by whatever PATH the packaged app inherited."""

--- a/test/test_winamax_ax_seats.py
+++ b/test/test_winamax_ax_seats.py
@@ -185,203 +185,94 @@ def test_the_pot_label_does_not_take_a_seat() -> None:
     assert [s.login for s in seats_from_labels(labels)] == ["Hero", "Player08"]
 
 
-class TestFindTableWindowWithoutAccessibility:
-    """A packaged build holds no macOS Accessibility grant, so the API answers nothing.
+class _Detector:
+    """Small stand-in for the shared MacOSTableDetector lookup order."""
 
-    Table windows must still be found -- otherwise the Fast-Fold HUD silently
-    waits for the hand history and appears seconds late.
-    """
+    def __init__(self, quartz=(), fallback=()) -> None:
+        self.quartz = list(quartz)
+        self.fallback = list(fallback)
+        self.calls: list[tuple[str, bool]] = []
+
+    def find_tables(self, search: str, *, allow_fallback: bool = True):
+        self.calls.append((search, allow_fallback))
+        return self.fallback if allow_fallback else self.quartz
+
+
+class TestFindTableWindow:
+    """Fast Fold shares the platform detector used later by OSXTables."""
 
     @staticmethod
-    def _reader(monkeypatch, titles: list[str]) -> WinamaxAXSeatReader:
+    def _table(title: str, window_id: int = 48_782) -> SimpleNamespace:
+        return SimpleNamespace(title=title, window_id=window_id)
+
+    @staticmethod
+    def _enable_macos(monkeypatch) -> None:
         monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
-        # The accessibility API is reachable but returns nothing, which is what
-        # macOS does for a process that was never granted Accessibility.
+
+    def test_quartz_window_is_preferred_and_enriched_by_accessibility(self, monkeypatch) -> None:
+        self._enable_macos(monkeypatch)
+        detector = _Detector(quartz=[self._table("Winamax Colorado 4")])
+        from_ax = AXTableWindow(
+            title="Winamax Colorado 4",
+            description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha",
+        )
+        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: from_ax)
+
+        window = WinamaxAXSeatReader(detector).find_table_window("4")
+
+        assert window == AXTableWindow(
+            title="Winamax Colorado 4",
+            description=from_ax.description,
+            window_id=48_782,
+        )
+        assert window.poker_game == "omahahi"
+        assert detector.calls == [(r"^Winamax\s+.*\s4\s*$", False)]
+
+    def test_system_events_is_only_the_shared_detectors_last_resort(self, monkeypatch) -> None:
+        self._enable_macos(monkeypatch)
+        detector = _Detector(fallback=[self._table("Winamax Colorado 4", 2_123_456)])
         monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: None)
-        monkeypatch.setattr(winamax_ax_seats, "applescript_window_titles", lambda: titles)
-        return WinamaxAXSeatReader()
-
-    def test_window_is_found_through_system_events(self, monkeypatch) -> None:
-        reader = self._reader(monkeypatch, ["Winamax", "Winamax Colorado 4"])
-
-        window = reader.find_table_window("4")
+        window = WinamaxAXSeatReader(detector).find_table_window("4")
 
         assert window is not None
         assert window.title == "Winamax Colorado 4"
-        assert window.table_name == "Colorado 4"
-        # System Events cannot read the client's header, so the game is unknown
-        # and the caller supplies it from an imported hand.
+        assert window.window_id == 2_123_456
         assert window.poker_game is None
+        assert detector.calls == [
+            (r"^Winamax\s+.*\s4\s*$", False),
+            (r"^Winamax\s+.*\s4\s*$", True),
+        ]
 
     def test_only_the_window_carrying_the_client_index_matches(self, monkeypatch) -> None:
-        reader = self._reader(monkeypatch, ["Winamax Colorado 3", "Winamax Colorado 4"])
-
-        assert reader.find_table_window("3").title == "Winamax Colorado 3"
-        assert reader.find_table_window("9") is None
-
-    def test_lobby_alone_is_not_a_table(self, monkeypatch) -> None:
-        reader = self._reader(monkeypatch, ["Winamax"])
-
-        assert reader.find_table_window("1") is None
-
-    def test_the_scan_is_throttled(self, monkeypatch) -> None:
-        """Hands start faster than osascript returns, so it must not run per hand."""
-        calls = []
-        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
-        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: None)
-        monkeypatch.setattr(
-            winamax_ax_seats,
-            "applescript_window_titles",
-            lambda: (calls.append(1), ["Winamax Colorado 4"])[1],
+        self._enable_macos(monkeypatch)
+        detector = _Detector(
+            quartz=[
+                self._table("Winamax Colorado 3", 101),
+                self._table("Winamax Colorado 4", 102),
+            ]
         )
-        reader = WinamaxAXSeatReader()
+        monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: None)
 
-        for _ in range(5):
-            assert reader.find_table_window("4") is not None
+        window = WinamaxAXSeatReader(detector).find_table_window("4")
 
-        assert len(calls) == 1
+        assert window is not None
+        assert window.title == "Winamax Colorado 4"
+        assert window.window_id == 102
 
-    def test_the_accessibility_answer_is_preferred(self, monkeypatch) -> None:
-        """It carries the header, which names the game; System Events cannot."""
-        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
-        from_ax = AXTableWindow(title="Winamax Colorado 4", description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha")
+    def test_accessibility_answer_survives_when_no_window_id_is_available(self, monkeypatch) -> None:
+        self._enable_macos(monkeypatch)
+        detector = _Detector()
+        from_ax = AXTableWindow(
+            title="Winamax Colorado 4",
+            description="ESCAPE - 0,01-0,02 € - Pot Limit Omaha",
+        )
         monkeypatch.setattr(WinamaxAXSeatReader, "_find_table_window_ax", lambda _self, _no: from_ax)
 
-        def unreachable() -> list[str]:
-            msg = "System Events must not be consulted when the API answered"
-            raise AssertionError(msg)
-
-        monkeypatch.setattr(winamax_ax_seats, "applescript_window_titles", unreachable)
-
-        assert WinamaxAXSeatReader().find_table_window("4").poker_game == "omahahi"
+        assert WinamaxAXSeatReader(detector).find_table_window("4") == from_ax
 
     def test_nothing_is_attempted_off_macos(self, monkeypatch) -> None:
         monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Linux")
+        detector = _Detector(quartz=[self._table("Winamax Colorado 4")])
 
-        assert WinamaxAXSeatReader().find_table_window("4") is None
-
-
-class TestApplescriptWindowTitles:
-    def test_a_refused_scan_is_not_an_error(self, monkeypatch) -> None:
-        """Automation may be denied too; the caller then waits for an import."""
-        monkeypatch.setattr(
-            winamax_ax_seats.subprocess,
-            "run",
-            lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="not authorized"),
-        )
-
-        assert winamax_ax_seats.applescript_window_titles() == []
-
-    def test_titles_are_split_and_stripped(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            winamax_ax_seats.subprocess,
-            "run",
-            lambda *_a, **_k: SimpleNamespace(
-                returncode=0,
-                stdout="Winamax, Winamax Colorado 3, Winamax Colorado 4\n",
-                stderr="",
-            ),
-        )
-
-        assert winamax_ax_seats.applescript_window_titles() == [
-            "Winamax",
-            "Winamax Colorado 3",
-            "Winamax Colorado 4",
-        ]
-
-    def test_a_timeout_is_survivable(self, monkeypatch) -> None:
-        def timeout(*_a, **_k):
-            raise winamax_ax_seats.subprocess.TimeoutExpired(cmd="osascript", timeout=5)
-
-        monkeypatch.setattr(winamax_ax_seats.subprocess, "run", timeout)
-
-        assert winamax_ax_seats.applescript_window_titles() == []
-
-
-class TestAutomationRefusalIsReported:
-    """A refused scan and an empty table list used to look identical in the log.
-
-    They are opposite situations: one means "no table is open", the other means
-    "this build will never see a table until the user grants Automation".
-    """
-
-    @staticmethod
-    def _run(monkeypatch, *, returncode: int, stderr: str):
-        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
-        monkeypatch.setattr(
-            winamax_ax_seats.subprocess,
-            "run",
-            lambda *_a, **_k: SimpleNamespace(returncode=returncode, stdout="", stderr=stderr),
-        )
-        return winamax_ax_seats.applescript_window_titles()
-
-    def test_a_refusal_is_reported_once_at_warning(self, monkeypatch, caplog) -> None:
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert self._run(monkeypatch, returncode=1, stderr="execution error: Not authorized (-1743)") == []
-            # Second call: still refused, but the user has already been told.
-            monkeypatch.setattr(
-                winamax_ax_seats.subprocess,
-                "run",
-                lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="(-1743)"),
-            )
-            assert winamax_ax_seats.applescript_window_titles() == []
-
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1
-        assert "Automation" in warnings[0].getMessage()
-
-    def test_an_unanswered_prompt_counts_as_a_refusal(self, monkeypatch, caplog) -> None:
-        """A timed-out Apple Event is blocked, whatever made it unresponsive."""
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert self._run(monkeypatch, returncode=1, stderr="AppleEvent timed out. (-1712)") == []
-        assert any(r.levelname == "WARNING" for r in caplog.records)
-
-    def test_accessibility_refusal_is_classified_from_its_text(self, monkeypatch, caplog) -> None:
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert (
-                self._run(
-                    monkeypatch,
-                    returncode=1,
-                    stderr="osascript is not allowed assistive access. (-1719)",
-                )
-                == []
-            )
-        assert "Accessibility" in caplog.records[0].getMessage()
-
-    def test_bare_1719_is_not_misclassified_as_accessibility(self, monkeypatch, caplog) -> None:
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert self._run(monkeypatch, returncode=1, stderr="Can't get item 8. (-1719)") == []
-        assert not [record for record in caplog.records if record.levelname == "WARNING"]
-
-    def test_an_ordinary_failure_is_not_dressed_up_as_a_permission_problem(self, monkeypatch, caplog) -> None:
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert self._run(monkeypatch, returncode=1, stderr="syntax error somewhere") == []
-        assert not [r for r in caplog.records if r.levelname == "WARNING"]
-
-    def test_a_hung_scan_is_reported_too(self, monkeypatch, caplog) -> None:
-        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
-
-        def timeout(*_a, **_k):
-            raise winamax_ax_seats.subprocess.TimeoutExpired(cmd="osascript", timeout=5)
-
-        monkeypatch.setattr(winamax_ax_seats.subprocess, "run", timeout)
-        with caplog.at_level("WARNING", logger=winamax_ax_seats.log.name):
-            assert winamax_ax_seats.applescript_window_titles() == []
-        assert any(r.levelname == "WARNING" for r in caplog.records)
-
-    def test_a_blocked_scan_is_not_retried_after_the_ttl(self, monkeypatch) -> None:
-        calls = []
-        monkeypatch.setattr(winamax_ax_seats, "_system_events_blocked", False)
-        monkeypatch.setattr(
-            winamax_ax_seats.subprocess,
-            "run",
-            lambda *_a, **_k: (calls.append(1), SimpleNamespace(returncode=1, stdout="", stderr="(-1743)"))[1],
-        )
-
-        assert winamax_ax_seats.applescript_window_titles() == []
-        assert winamax_ax_seats.applescript_window_titles() == []
-        assert calls == [1]
-
-    def test_the_scan_runs_from_an_absolute_path(self) -> None:
-        """So it cannot be diverted by whatever PATH the packaged app inherited."""
-        assert winamax_ax_seats.OSASCRIPT.startswith("/")
+        assert WinamaxAXSeatReader(detector).find_table_window("4") is None
+        assert detector.calls == []

--- a/tools/adhoc_sign_macos.py
+++ b/tools/adhoc_sign_macos.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ad-hoc sign every Mach-O file in a macOS distribution tree.
+"""Sign every Mach-O file in a macOS distribution tree.
 
 PySide6 and friends ship *linker-signed* binaries. macOS treats those as
 unsigned, so as soon as a download carries ``com.apple.quarantine`` Gatekeeper
@@ -7,13 +7,15 @@ refuses to load them ("library load disallowed by system policy") and prompts
 about each library in turn. A real ad-hoc signature (``codesign --sign -``)
 loads even while quarantined.
 
-This is not a replacement for Developer ID signing and notarization: it makes an
-unsigned build usable, it does not make it trusted.
+Local/PR builds default to ad-hoc signing. Release builds set
+``FPDB_MACOS_SIGNING_IDENTITY`` to a Developer ID Application identity and
+``FPDB_REQUIRE_STABLE_MACOS_SIGNING=1`` so an unstable build fails closed.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +34,10 @@ MACH_O_MAGICS = frozenset(
 
 # codesign takes many paths at once; chunk them to keep the argument list sane.
 _BATCH = 64
+
+SIGNING_IDENTITY_ENV = "FPDB_MACOS_SIGNING_IDENTITY"
+REQUIRE_STABLE_SIGNING_ENV = "FPDB_REQUIRE_STABLE_MACOS_SIGNING"
+ADHOC_IDENTITY = "-"
 
 
 def is_mach_o(path: Path) -> bool:
@@ -53,29 +59,67 @@ def find_mach_o_files(root: Path) -> list[Path]:
     return sorted(path for path in root.rglob("*") if path.is_file() and not path.is_symlink() and is_mach_o(path))
 
 
-def _codesign(paths: list[Path]) -> subprocess.CompletedProcess[str]:
+def resolve_signing_identity(identity: str | None = None) -> str:
+    """Resolve the requested identity and enforce the release signing gate."""
+    resolved = identity if identity is not None else os.getenv(SIGNING_IDENTITY_ENV, ADHOC_IDENTITY)
+    resolved = resolved.strip() or ADHOC_IDENTITY
+    if os.getenv(REQUIRE_STABLE_SIGNING_ENV) == "1" and resolved == ADHOC_IDENTITY:
+        msg = (
+            "stable macOS signing is required, but no Developer ID identity was configured; "
+            f"set {SIGNING_IDENTITY_ENV}"
+        )
+        raise RuntimeError(msg)
+    return resolved
+
+
+def _codesign_command(
+    paths: list[Path],
+    *,
+    identity: str,
+    deep: bool = False,
+    entitlements: Path | None = None,
+) -> list[str]:
+    command = ["/usr/bin/codesign", "--force"]
+    if deep:
+        command.append("--deep")
+    if identity != ADHOC_IDENTITY:
+        command.extend(("--options", "runtime", "--timestamp"))
+        if entitlements is not None:
+            command.extend(("--entitlements", str(entitlements)))
+    command.extend(("--sign", identity, *(str(path) for path in paths)))
+    return command
+
+
+def _codesign(
+    paths: list[Path],
+    *,
+    identity: str,
+    deep: bool = False,
+    entitlements: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603
-        ["/usr/bin/codesign", "--force", "--sign", "-", *(str(path) for path in paths)],  # noqa: S607
+        _codesign_command(paths, identity=identity, deep=deep, entitlements=entitlements),
         capture_output=True,
         text=True,
         check=False,
     )
 
 
-def sign(paths: list[Path]) -> None:
-    """Ad-hoc sign the given binaries.
+def sign(paths: list[Path], *, identity: str | None = None) -> None:
+    """Sign the given binaries, replaying a failed batch one file at a time.
 
     Raises:
         RuntimeError: naming the binaries codesign rejected. It reports only a
             batch exit status, so a failed batch is replayed one file at a time.
     """
+    resolved_identity = resolve_signing_identity(identity)
     failures: list[str] = []
     for start in range(0, len(paths), _BATCH):
         batch = paths[start : start + _BATCH]
-        if _codesign(batch).returncode == 0:
+        if _codesign(batch, identity=resolved_identity).returncode == 0:
             continue
         for path in batch:
-            result = _codesign([path])
+            result = _codesign([path], identity=resolved_identity)
             if result.returncode != 0:
                 failures.append(f"{path}: {result.stderr.strip()}")
     if failures:
@@ -83,9 +127,34 @@ def sign(paths: list[Path]) -> None:
         raise RuntimeError(msg)
 
 
+def sign_bundle(
+    bundle: Path,
+    *,
+    identity: str | None = None,
+    entitlements: Path | None = None,
+) -> None:
+    """Seal an app bundle after its nested Mach-O files have been signed."""
+    resolved_identity = resolve_signing_identity(identity)
+    if resolved_identity != ADHOC_IDENTITY and entitlements is not None and not entitlements.is_file():
+        raise FileNotFoundError(f"macOS entitlements not found: {entitlements}")
+    result = _codesign(
+        [bundle],
+        identity=resolved_identity,
+        deep=True,
+        entitlements=entitlements,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"codesign failed for {bundle}: {result.stderr.strip()}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("root", type=Path, help="Directory to sign in place.")
+    parser.add_argument(
+        "--identity",
+        default=None,
+        help=f"codesign identity (defaults to ${SIGNING_IDENTITY_ENV}, then ad-hoc '-').",
+    )
     args = parser.parse_args(argv)
 
     if not args.root.is_dir():
@@ -95,8 +164,10 @@ def main(argv: list[str] | None = None) -> int:
     if not binaries:
         parser.error(f"no Mach-O files found under {args.root}")
 
-    sign(binaries)
-    print(f"ad-hoc signed {len(binaries)} Mach-O files under {args.root}")
+    identity = resolve_signing_identity(args.identity)
+    sign(binaries, identity=identity)
+    label = "ad-hoc" if identity == ADHOC_IDENTITY else identity
+    print(f"signed {len(binaries)} Mach-O files under {args.root} with {label}")
     return 0
 
 

--- a/tools/bundle_pyinstaller_hud.py
+++ b/tools/bundle_pyinstaller_hud.py
@@ -72,6 +72,10 @@ def _update_mac_info_plist(info_plist: Path, *, version: str | None = None) -> b
         info["NSAccessibilityUsageDescription"] = (
             "FPDB requires Accessibility permission to locate and position HUD windows over poker tables."
         )
+        info["NSAppDataUsageDescription"] = (
+            "FPDB needs access to poker client data files, including hand histories and logs, "
+            "to import hands and display the HUD."
+        )
         with info_plist.open("wb") as handle:
             plistlib.dump(info, handle)
     except (OSError, plistlib.InvalidFileException) as exc:

--- a/tools/bundle_pyinstaller_hud.py
+++ b/tools/bundle_pyinstaller_hud.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bundle the PyInstaller HUD executable inside the main fpdb distribution."""
+"""Merge the PyInstaller HUD dependencies into the main fpdb distribution."""
 
 from __future__ import annotations
 
@@ -10,9 +10,11 @@ import shutil
 import stat
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+_ENTITLEMENTS = Path(__file__).resolve().with_name("macos-entitlements.plist")
 
 
 def _merge_tree(source: Path, destination: Path) -> None:
@@ -36,13 +38,20 @@ def _copy_executable(source: Path, destination: Path) -> None:
     destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _update_mac_info_plist(info_plist: Path) -> bool:
+def _project_version() -> str:
+    try:
+        with (_REPO_ROOT / "pyproject.toml").open("rb") as handle:
+            return str(tomllib.load(handle)["project"]["version"])
+    except (OSError, KeyError, tomllib.TOMLDecodeError):
+        return "0.0.0"
+
+
+def _update_mac_info_plist(info_plist: Path, *, version: str | None = None) -> bool:
     """Write the privacy usage descriptions and bundle id into an Info.plist.
 
     Returns whether the file was rewritten. A failure here is reported rather
-    than swallowed: the whole point of this step is that macOS remembers the
-    permissions the user grants, and a bundle shipped without the keys asks
-    again on every launch -- the exact symptom, arriving silently.
+    than swallowed because missing privacy descriptions prevent macOS from
+    presenting the corresponding consent correctly.
     """
     if not info_plist.is_file():
         print(f"No Info.plist at {info_plist}; privacy descriptions not written")
@@ -51,6 +60,9 @@ def _update_mac_info_plist(info_plist: Path) -> bool:
         with info_plist.open("rb") as handle:
             info = plistlib.load(handle)
         info["CFBundleIdentifier"] = "org.fpdb.fpdb3"
+        bundle_version = version or _project_version()
+        info["CFBundleShortVersionString"] = bundle_version
+        info["CFBundleVersion"] = bundle_version
         info["NSAppleEventsUsageDescription"] = (
             "FPDB requires Automation access to detect poker table window titles via AppleScript."
         )
@@ -81,8 +93,8 @@ def _run_macos_tool(command: list[str]) -> None:
         print(f"Could not run {command[0]}: {exc}")
 
 
-def _sign_macos_bundle(fpdb_app: Path, resources: Path) -> None:
-    """Ad-hoc sign the merged bundle, innermost Mach-O files first.
+def _sign_macos_bundle(fpdb_app: Path, contents: Path) -> None:
+    """Sign the merged bundle, innermost Mach-O files first.
 
     Gatekeeper assesses a bundle as a unit, so the nested binaries the merge
     just moved in have to be signed before the bundle itself is sealed.
@@ -95,13 +107,11 @@ def _sign_macos_bundle(fpdb_app: Path, resources: Path) -> None:
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
 
-    from tools.adhoc_sign_macos import find_mach_o_files
-    from tools.adhoc_sign_macos import sign as adhoc_sign
+    from tools.adhoc_sign_macos import find_mach_o_files, resolve_signing_identity, sign, sign_bundle
 
-    adhoc_sign(find_mach_o_files(resources))
-
-    codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
-    _run_macos_tool([codesign_bin, "--force", "--deep", "--sign", "-", str(fpdb_app)])
+    identity = resolve_signing_identity()
+    sign(find_mach_o_files(contents), identity=identity)
+    sign_bundle(fpdb_app, identity=identity, entitlements=_ENTITLEMENTS)
 
 
 def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
@@ -120,8 +130,12 @@ def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
             if source.is_dir():
                 _merge_tree(source, fpdb_contents / directory)
 
-        bundled_executable = fpdb_contents / "MacOS" / "HUD_main"
-        _copy_executable(hud_contents / "MacOS" / "HUD_main", bundled_executable)
+        # The HUD_main build contributes dependencies only. Launching its
+        # separate executable would give PyInstaller two macOS TCC identities;
+        # the main executable dispatches ``--hud`` instead.
+        bundled_executable = fpdb_contents / "MacOS" / "fpdb"
+        if not bundled_executable.is_file():
+            raise FileNotFoundError(f"fpdb executable not found: {bundled_executable}")
         shutil.rmtree(hud_app)
 
         # Update Info.plist privacy usage descriptions & bundle ID
@@ -133,7 +147,7 @@ def bundle_pyinstaller_hud(dist_dir: Path) -> Path:
         if sys.platform == "darwin":
             # Strip quarantine so Gatekeeper does not block execution
             _run_macos_tool(["/usr/bin/xattr", "-cr", str(fpdb_app)])
-            _sign_macos_bundle(fpdb_app, fpdb_contents / "Resources")
+            _sign_macos_bundle(fpdb_app, fpdb_contents)
 
         return bundled_executable
 

--- a/tools/grant_macos_permissions.py
+++ b/tools/grant_macos_permissions.py
@@ -1,12 +1,9 @@
 """Utility to assist with macOS Gatekeeper quarantine removal and privacy permissions setup.
 
-macOS Gatekeeper and TCC (Transparency, Consent, and Control) security policies enforce:
-1. Gatekeeper checks unverified downloads. Stripping 'com.apple.quarantine' and applying
-   ad-hoc codesign allows fpdb.app to run without 'Unidentified Developer' blocks.
-2. TCC permissions (Screen Recording, Accessibility, AppleScript Automation). Including
-   NSAppleEventsUsageDescription, NSScreenCaptureUsageDescription, and NSAccessibilityUsageDescription
-   in Info.plist with a stable bundle ID (org.fpdb.fpdb3) ensures macOS retains the user's
-   approval permanently across launches.
+macOS Gatekeeper and TCC (Transparency, Consent, and Control) are separate:
+quarantine can translocate or block an unnotarized download, while TCC grants
+Screen Recording, Accessibility, and Automation to a code-signing requirement.
+A stable bundle ID alone cannot make an ad-hoc signature stable between builds.
 
 Run from command line:
     python -m tools.grant_macos_permissions [--app-path PATH] [--clear-quarantine] [--check-status]
@@ -45,7 +42,11 @@ def clear_quarantine(app_path: Path) -> bool:
 
 
 def re_sign_bundle(app_path: Path) -> bool:
-    """Apply an ad-hoc code signature to seal the app bundle."""
+    """Replace the bundle signature with ad-hoc signing (development only).
+
+    This intentionally destroys a Developer ID signature and its stable TCC
+    identity. It is never part of the default setup path.
+    """
     if not _IS_MACOS or not app_path.exists():
         return False
     codesign_bin = shutil.which("codesign") or "/usr/bin/codesign"
@@ -83,12 +84,12 @@ def setup_app_bundle(
     app_path: Path,
     *,
     clear: bool = True,
-    sign: bool = True,
+    sign: bool = False,
 ) -> dict[str, bool]:
-    """Strip quarantine and/or ad-hoc sign the given .app bundle.
+    """Strip quarantine and, only when explicit, ad-hoc sign the bundle.
 
-    Both steps run by default: that is what someone who just passes a bundle
-    path wants. ``clear`` and ``sign`` let the CLI flags select one of them.
+    Re-signing is off by default because it invalidates a published Developer
+    ID signature and the privacy grants tied to it.
     """
     return {
         "quarantine_cleared": clear_quarantine(app_path) if clear else False,
@@ -120,12 +121,12 @@ def main(argv: list[str] | None = None) -> int:
             # point of the tool is to tell the user where they stand.
             print(f"No bundle at {args.app_path}", file=sys.stderr)
             return 1
-        # Neither flag means "do the usual thing", which is both steps.
+        # Neither flag means the safe local workaround: clear quarantine only.
         selected = args.clear_quarantine or args.re_sign
         res = setup_app_bundle(
             args.app_path,
             clear=args.clear_quarantine or not selected,
-            sign=args.re_sign or not selected,
+            sign=args.re_sign,
         )
         print(f"Quarantine cleared: {res['quarantine_cleared']}")
         print(f"Ad-hoc signed:     {res['signed']}")

--- a/tools/macos-entitlements.plist
+++ b/tools/macos-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/tools/package_pyoxidizer_macos.py
+++ b/tools/package_pyoxidizer_macos.py
@@ -12,7 +12,8 @@ invalid, or unsuitable") -- so the payload goes to ``Contents/Resources``, which
 the interpreter config in pyoxidizer.bzl knows how to find.
 
 Local builds are ad-hoc signed. Release CI supplies a Developer ID identity,
-then notarizes and staples the completed bundle.
+then notarizes and staples the completed bundle. CI can defer signing until its
+launcher smokes have run, then seal the already assembled app exactly once.
 
 Run it from the repository root: ``python -m tools.package_pyoxidizer_macos``.
 """
@@ -74,8 +75,9 @@ def build_app(
     icon: Path | None,
     *,
     signing_identity: str | None = None,
+    defer_signing: bool = False,
 ) -> Path:
-    """Assemble, sign and return the .app bundle."""
+    """Assemble and return the .app bundle, signing it unless deferred."""
     if not (install_dir / executable).is_file():
         msg = f"no {executable} executable in {install_dir}"
         raise FileNotFoundError(msg)
@@ -103,6 +105,18 @@ def build_app(
         check=False,
     )
 
+    if not defer_signing:
+        sign_app(app_path, signing_identity=signing_identity)
+    return app_path
+
+
+def sign_app(app_path: Path, *, signing_identity: str | None = None) -> Path:
+    """Sign an assembled app after every command that may mutate its resources."""
+    resources = app_path / "Contents" / "Resources"
+    if not resources.is_dir():
+        msg = f"no app resources in {app_path}"
+        raise FileNotFoundError(msg)
+
     # Sign inside out: nested Mach-O files first, then seal the bundle. Wheels
     # ship linker-signed binaries, which macOS treats as unsigned.
     identity = resolve_signing_identity(signing_identity)
@@ -113,11 +127,22 @@ def build_app(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("install_dir", type=Path, help="PyOxidizer install directory.")
-    parser.add_argument("app_path", type=Path, help="Path of the .app bundle to create.")
+    parser.add_argument("install_dir", type=Path, nargs="?", help="PyOxidizer install directory.")
+    parser.add_argument("app_path", type=Path, nargs="?", help="Path of the .app bundle to create.")
     parser.add_argument("--executable", default="fpdb", help="Launcher name inside the install directory.")
     parser.add_argument("--icon", type=Path, default=None, help="Optional .icns file.")
     parser.add_argument("--version", default=None, help="Bundle version (defaults to the pyproject version).")
+    parser.add_argument(
+        "--defer-signing",
+        action="store_true",
+        help="Assemble without signing so launcher smokes can run before the final seal.",
+    )
+    parser.add_argument(
+        "--sign-existing",
+        type=Path,
+        metavar="APP",
+        help="Sign an already assembled app and exit; accepts no positional paths.",
+    )
     parser.add_argument(
         "--signing-identity",
         default=None,
@@ -125,6 +150,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.sign_existing is not None:
+        if args.install_dir is not None or args.app_path is not None or args.defer_signing:
+            parser.error("--sign-existing accepts no positional paths or --defer-signing")
+        app = sign_app(args.sign_existing, signing_identity=args.signing_identity)
+        print(f"signed {app}")
+        return 0
+
+    if args.install_dir is None or args.app_path is None:
+        parser.error("install_dir and app_path are required unless --sign-existing is used")
     if not args.install_dir.is_dir():
         parser.error(f"not a directory: {args.install_dir}")
 
@@ -136,8 +170,10 @@ def main(argv: list[str] | None = None) -> int:
         version,
         args.icon,
         signing_identity=args.signing_identity,
+        defer_signing=args.defer_signing,
     )
-    print(f"built {app} (version {version})")
+    state = "unsigned" if args.defer_signing else "signed"
+    print(f"built {app} (version {version}, {state})")
     return 0
 
 

--- a/tools/package_pyoxidizer_macos.py
+++ b/tools/package_pyoxidizer_macos.py
@@ -11,7 +11,8 @@ bundle whose MacOS directory holds anything else ("bundle format unrecognized,
 invalid, or unsuitable") -- so the payload goes to ``Contents/Resources``, which
 the interpreter config in pyoxidizer.bzl knows how to find.
 
-This is ad-hoc signing, not notarization: macOS still asks the user once.
+Local builds are ad-hoc signed. Release CI supplies a Developer ID identity,
+then notarizes and staples the completed bundle.
 
 Run it from the repository root: ``python -m tools.package_pyoxidizer_macos``.
 """
@@ -26,11 +27,11 @@ import sys
 import tomllib
 from pathlib import Path
 
-from tools.adhoc_sign_macos import find_mach_o_files
-from tools.adhoc_sign_macos import sign as adhoc_sign
+from tools.adhoc_sign_macos import find_mach_o_files, resolve_signing_identity, sign, sign_bundle
 
 BUNDLE_IDENTIFIER = "org.fpdb.fpdb3"
 DEFAULT_VERSION = "0.0.0"
+ENTITLEMENTS = Path(__file__).resolve().with_name("macos-entitlements.plist")
 
 
 def read_version(pyproject: Path) -> str:
@@ -65,8 +66,16 @@ def write_info_plist(contents: Path, executable: str, version: str, icon: str | 
         plistlib.dump(info, handle)
 
 
-def build_app(install_dir: Path, app_path: Path, executable: str, version: str, icon: Path | None) -> Path:
-    """Assemble, ad-hoc sign and return the .app bundle."""
+def build_app(
+    install_dir: Path,
+    app_path: Path,
+    executable: str,
+    version: str,
+    icon: Path | None,
+    *,
+    signing_identity: str | None = None,
+) -> Path:
+    """Assemble, sign and return the .app bundle."""
     if not (install_dir / executable).is_file():
         msg = f"no {executable} executable in {install_dir}"
         raise FileNotFoundError(msg)
@@ -87,19 +96,18 @@ def build_app(install_dir: Path, app_path: Path, executable: str, version: str, 
         icon_name = icon.name
     write_info_plist(contents, executable, version, icon_name)
 
-    # Strip quarantine extended attribute if present so Gatekeeper does not block execution
+    # Clean build inputs can carry quarantine. A browser may attach it again to
+    # the download; release notarization, not this build-time xattr, handles that.
     subprocess.run(  # noqa: S603
         ["/usr/bin/xattr", "-dr", "com.apple.quarantine", str(app_path)],  # noqa: S607
         check=False,
     )
 
-    # Sign inside out: nested Mach-O files first, then seal the bundle. The
-    # wheels ship linker-signed binaries, which macOS treats as unsigned.
-    adhoc_sign(find_mach_o_files(resources))
-    subprocess.run(  # noqa: S603
-        ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app_path)],  # noqa: S607
-        check=True,
-    )
+    # Sign inside out: nested Mach-O files first, then seal the bundle. Wheels
+    # ship linker-signed binaries, which macOS treats as unsigned.
+    identity = resolve_signing_identity(signing_identity)
+    sign(find_mach_o_files(resources), identity=identity)
+    sign_bundle(app_path, identity=identity, entitlements=ENTITLEMENTS)
     return app_path
 
 
@@ -110,13 +118,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--executable", default="fpdb", help="Launcher name inside the install directory.")
     parser.add_argument("--icon", type=Path, default=None, help="Optional .icns file.")
     parser.add_argument("--version", default=None, help="Bundle version (defaults to the pyproject version).")
+    parser.add_argument(
+        "--signing-identity",
+        default=None,
+        help="codesign identity (defaults to FPDB_MACOS_SIGNING_IDENTITY, then ad-hoc '-').",
+    )
     args = parser.parse_args(argv)
 
     if not args.install_dir.is_dir():
         parser.error(f"not a directory: {args.install_dir}")
 
     version = args.version or read_version(Path(__file__).resolve().parent.parent / "pyproject.toml")
-    app = build_app(args.install_dir, args.app_path, args.executable, version, args.icon)
+    app = build_app(
+        args.install_dir,
+        args.app_path,
+        args.executable,
+        version,
+        args.icon,
+        signing_identity=args.signing_identity,
+    )
     print(f"built {app} (version {version})")
     return 0
 

--- a/tools/package_pyoxidizer_macos.py
+++ b/tools/package_pyoxidizer_macos.py
@@ -21,18 +21,27 @@ Run it from the repository root: ``python -m tools.package_pyoxidizer_macos``.
 from __future__ import annotations
 
 import argparse
+import os
 import plistlib
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
 from pathlib import Path
 
-from tools.adhoc_sign_macos import find_mach_o_files, resolve_signing_identity, sign, sign_bundle
+from tools.adhoc_sign_macos import (
+    REQUIRE_STABLE_SIGNING_ENV,
+    find_mach_o_files,
+    resolve_signing_identity,
+    sign,
+    sign_bundle,
+)
 
 BUNDLE_IDENTIFIER = "org.fpdb.fpdb3"
 DEFAULT_VERSION = "0.0.0"
 ENTITLEMENTS = Path(__file__).resolve().with_name("macos-entitlements.plist")
+_DEVELOPER_ID_APPLICATION = re.compile(r"Developer ID Application: .+ \([A-Z0-9]{10}\)")
 
 
 def read_version(pyproject: Path) -> str:
@@ -60,6 +69,7 @@ def write_info_plist(contents: Path, executable: str, version: str, icon: str | 
         "NSAppleEventsUsageDescription": "FPDB requires Automation access to detect poker table window titles via AppleScript.",
         "NSScreenCaptureUsageDescription": "FPDB requires Screen Recording permission to identify poker table window titles for the HUD.",
         "NSAccessibilityUsageDescription": "FPDB requires Accessibility permission to locate and position HUD windows over poker tables.",
+        "NSAppDataUsageDescription": "FPDB needs access to poker client data files, including hand histories and logs, to import hands and display the HUD.",
     }
     if icon:
         info["CFBundleIconFile"] = icon
@@ -120,6 +130,9 @@ def sign_app(app_path: Path, *, signing_identity: str | None = None) -> Path:
     # Sign inside out: nested Mach-O files first, then seal the bundle. Wheels
     # ship linker-signed binaries, which macOS treats as unsigned.
     identity = resolve_signing_identity(signing_identity)
+    if os.getenv(REQUIRE_STABLE_SIGNING_ENV) == "1" and _DEVELOPER_ID_APPLICATION.fullmatch(identity) is None:
+        msg = "PyOxidizer release signing requires a Developer ID Application identity with a 10-character Team ID"
+        raise RuntimeError(msg)
     sign(find_mach_o_files(resources), identity=identity)
     sign_bundle(app_path, identity=identity, entitlements=ENTITLEMENTS)
     return app_path

--- a/tools/pyinstaller_hooks/hook-fpdb_3_legacy.subprocess_launch.py
+++ b/tools/pyinstaller_hooks/hook-fpdb_3_legacy.subprocess_launch.py
@@ -1,0 +1,16 @@
+"""Include the HUD backend hidden behind the macOS ``--hud`` dispatcher."""
+
+from PyInstaller import compat
+
+# fpdb.pyw reaches HUD_main.pyw through runpy, so PyInstaller cannot see the
+# platform import inside that data file.  The main executable nevertheless has
+# to contain this graph: macOS launches the HUD through that same executable to
+# preserve one TCC/code-signing identity.
+hiddenimports = (
+    [
+        "fpdb_3_legacy.OSXTables",
+        "fpdb.infrastructure.platform.macos",
+    ]
+    if compat.is_darwin
+    else []
+)


### PR DESCRIPTION
## Root causes

The macOS 3.6.3 bundles used ad-hoc signatures, whose designated requirements are build-specific CDHashes. TCC therefore rejected rebuilt apps even though `CFBundleIdentifier` remained `org.fpdb.fpdb3`.

PyInstaller also launched a separately signed HUD helper because the main archive lacked the dynamically imported macOS backend.

A second runtime investigation found three additional failures:

- PyOxidizer signed its app, ran launcher smokes that created thousands of `.pyc` resources, then archived the mutated bundle without re-verifying it.
- Both `HudMain` and `MacOSTableDetector` independently requested Screen Recording and Accessibility and opened both Settings panes.
- Fast Fold first searched through a separate AX/System Events implementation, then `OSXTables` searched for the same window again. The two lookups could disagree and the first one never preferred the real Quartz `CGWindowID`.

## What changed

- Route the macOS HUD through the main frozen executable with `fpdb --hud`.
- Include `fpdb_3_legacy.OSXTables` and `fpdb.infrastructure.platform.macos` in the main PyInstaller archive and remove the separate macOS HUD executable.
- Make `HudMain` the only permission-prompt owner; request Screen Recording first and Accessibility on the following launch. The detector is diagnostic-only.
- Resolve Fast Fold windows through the shared macOS detector: Quartz first, AX enrichment second, throttled System Events only as a last resort.
- Pass the resolved window ID into `OSXTables` so HUD creation does not perform a second lookup.
- Assemble PyOxidizer unsigned, run its smokes with bytecode writes disabled, sign only after the final launch, and verify again immediately before packaging.
- Add Developer ID signing, hardened runtime, Apple Events entitlement, notarization/stapling, and release gates rejecting ad-hoc/CDHash identities.
- Preserve Developer ID signatures in the local permission helper and write the actual bundle version.

## User impact

A properly signed release has one executable and one stable TCC identity. Permission onboarding is sequenced instead of duplicated, and Fast Fold reuses the real window that was found when the hand started.

Pull-request builds remain ad-hoc and cannot preserve TCC grants between rebuilds. Published releases now fail closed until the Developer ID and notarization secrets are configured.

## Validation

- PyOxidizer end-to-end: assemble → pre-sign smokes → final sign → fresh post-sign import → `codesign --verify --deep --strict`: passes.
- PyInstaller dispatcher/import smokes: pass.
- Final macOS bundle contains only `Contents/MacOS/fpdb`.
- Targeted macOS/packaging tests: 103 passed.
- HUD Qt suite: 145 passed.
- Complete non-Qt suite: 7,550 passed, 16 skipped.
- Ruff on all changed files: passes.
- `git diff --check`: passes.
- Final GitHub Actions workflow: all 20 jobs pass, including both macOS packagers and coverage.
- Downloaded PyOxidizer artifact stays valid after a fresh filesystem import and creates zero project-level `.pyc` files.

Actual Developer ID signing and notarization still require the repository secrets; this machine has no valid Developer ID identity.