### PR TITLE
fix(perf): resolve frozen tab opening lag in PyOxidizer bundle mode

### DIFF
--- a/fpdb/infrastructure/platform/macos.py
+++ b/fpdb/infrastructure/platform/macos.py
@@ -480,6 +480,7 @@ class MacOSTableDetector:
         import zlib
 
         logger.debug("DIAGNOSTIC: Running full AppleScript scan")
+        t0 = time.perf_counter()
         self._applescript_cache.clear()
         self._applescript_last_result = []
 
@@ -583,6 +584,7 @@ class MacOSTableDetector:
         except Exception as e:
             logger.error(f"Error in _run_applescript_scan: {e}", exc_info=True)
 
+        logger.info("[PERF-TIMING] _run_applescript_scan completed in %.3f s (found %d windows)", time.perf_counter() - t0, len(self._applescript_last_result))
         self._applescript_last_scan = time.monotonic()
 
     def find_tables_applescript(self, search_string: str = "") -> list[TableInfo]:

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -29,7 +29,6 @@ import platform
 import re
 import shutil
 import sys
-import threading
 import traceback
 import xml.parsers.expat
 from pathlib import Path

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -252,6 +252,9 @@ def prewarm_matplotlib() -> None:
     """Ensure matplotlib and its font list are pre-warmed safely."""
     try:
         import matplotlib
+        # Force Qt backend immediately to prevent Native macOS backend (macosx) 
+        # from initializing its own event loop and deadlocking with PySide6.
+        matplotlib.use("qtagg")
         import matplotlib.font_manager
 
         _ = matplotlib.font_manager.fontManager.ttflist

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 ########################################################################
 #    Standard Library modules
 import codecs
+import contextlib
 import inspect
 import json
 import locale
@@ -28,6 +29,7 @@ import platform
 import re
 import shutil
 import sys
+import threading
 import traceback
 import xml.parsers.expat
 from pathlib import Path
@@ -239,6 +241,23 @@ else:
 POSIX = os.name == "posix"
 
 PYTHON_VERSION = sys.version[:3]
+
+if CONFIG_PATH and "MPLCONFIGDIR" not in os.environ:
+    mpl_dir = os.path.join(CONFIG_PATH, "matplotlib").replace("\\", "/")
+    with contextlib.suppress(OSError):
+        os.makedirs(mpl_dir, exist_ok=True)
+    os.environ["MPLCONFIGDIR"] = mpl_dir
+
+
+def prewarm_matplotlib() -> None:
+    """Ensure matplotlib and its font list are pre-warmed safely."""
+    try:
+        import matplotlib
+        import matplotlib.font_manager
+
+        _ = matplotlib.font_manager.fontManager.ttflist
+    except Exception:
+        pass
 
 # logging has been set up in fpdb.py or HUD_main.py, use their settings:
 log = get_logger("configuration")

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -220,6 +220,11 @@ class Database(
     PGSQL = 3
     SQLITE = 4
 
+    # Global pool for worker connections shared across all Database instances
+    # to strictly bound the maximum concurrent DB connections from workers
+    _worker_conn_pool = queue.Queue()
+    _worker_conn_semaphore = threading.Semaphore(4)
+
     hero_hudstart_def = "1999-12-31"  # default for length of Hero's stats in HUD
     villain_hudstart_def = "1999-12-31"  # default for length of Villain's stats in HUD
 
@@ -278,8 +283,6 @@ class Database(
         self.connection: Any = None
         self.cursor: Any = None
         self.__connected = False
-        self._worker_conn_pool = queue.Queue()
-        self._worker_conn_semaphore = threading.Semaphore(4)
         self.wrongDbVersion = False
         self.settings = {}
         self.settings["os"] = "linuxmac" if os.name != "nt" else "windows"
@@ -925,14 +928,16 @@ class Database(
             self.connection = None
         self.__connected = False
 
-        if hasattr(self, "_worker_conn_pool"):
-            while not self._worker_conn_pool.empty():
-                try:
-                    conn = self._worker_conn_pool.get_nowait()
-                    if conn is not None:
-                        conn.close()
-                except queue.Empty:
-                    break
+    @classmethod
+    def close_worker_pool(cls) -> None:
+        """Close all connections currently idling in the global worker pool."""
+        while not cls._worker_conn_pool.empty():
+            try:
+                conn = cls._worker_conn_pool.get_nowait()
+                if conn is not None:
+                    conn.close()
+            except queue.Empty:
+                break
 
     def _close_cursor_quietly(self) -> None:
         cursor = getattr(self, "cursor", None)

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -798,20 +798,39 @@ class Database(
         return self.connection.cursor()
 
     def create_worker_connection(self):
-        """Open a dedicated SQLite connection for a background worker thread.
+        """Open a dedicated connection for a background worker thread.
 
-        Returns None for non-SQLite backends: those drivers handle concurrent
-        cursors on a shared connection correctly, so workers keep using it.
+        Returns None when no dedicated connection can be built (e.g. SQLite
+        ``:memory:``), in which case the worker falls back to the shared
+        connection.
 
-        Sharing one sqlite3.Connection across threads (check_same_thread=False)
-        without an application-level lock interleaves execute/fetchall pairs
-        from the GUI thread and DbWorker threads, which deadlocks the GUI on
-        macOS. WAL mode makes one read connection per thread safe. The returned
-        connection is intentionally NOT passed through db_profile.wrap_connection:
-        profiling is single-process bookkeeping and worker round trips stay
-        attributed to the main connection.
+        No DBAPI driver used here allows two threads to drive one connection
+        concurrently without an application-level lock:
+
+        - sqlite3 (check_same_thread=False) serializes calls but interleaves
+          execute/fetchall pairs from the GUI thread and DbWorker threads,
+          which deadlocks the GUI on macOS. WAL mode makes one read connection
+          per thread safe.
+        - psycopg3 is thread-safe at connection level but NOT at cursor level:
+          two threads sharing one connection can interleave execute/fetchall.
+        - MySQLdb/pymysql has threadsafety=1: connections must NOT be shared
+          across threads at all.
+
+        The returned connection is intentionally NOT passed through
+        db_profile.wrap_connection: profiling is single-process bookkeeping and
+        worker round trips stay attributed to the main connection.
         """
-        if self.backend != self.SQLITE or not self.db_path or self.db_path == ":memory:":
+        if self.backend == self.SQLITE:
+            return self._create_sqlite_worker_connection()
+        if self.backend == self.PGSQL:
+            return self._create_postgresql_worker_connection()
+        if self.backend == self.MYSQL_INNODB:
+            return self._create_mysql_worker_connection()
+        return None
+
+    def _create_sqlite_worker_connection(self):
+        """Dedicated SQLite connection for a worker thread (WAL mode)."""
+        if not self.db_path or self.db_path == ":memory:":
             return None
         import sqlite3
 
@@ -831,6 +850,49 @@ class Database(
         if use_numpy:
             conn.create_aggregate("variance", 1, VARIANCE)
         return conn
+
+    def _create_postgresql_worker_connection(self):
+        """Dedicated PostgreSQL connection for a worker thread."""
+        import psycopg
+
+        kwargs = {"dbname": self.database, **PG_NETWORK_KWARGS}
+        if self.host not in ("localhost", "127.0.0.1"):
+            kwargs.update({"host": self.host, "port": self.port, "user": self.user, "password": self.password})
+        try:
+            return psycopg.connect(**kwargs)
+        except psycopg.OperationalError:
+            # Local peer connection failed; retry with explicit credentials.
+            return psycopg.connect(
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=self.password,
+                dbname=self.database,
+                **PG_NETWORK_KWARGS,
+            )
+
+    def _create_mysql_worker_connection(self):
+        """Dedicated MySQL connection for a worker thread."""
+        try:
+            import MySQLdb
+        except ImportError:
+            import pymysql
+
+            pymysql.install_as_MySQLdb()
+            import MySQLdb
+
+        kwargs = {
+            "host": self.host,
+            "user": self.user,
+            "passwd": self.password,
+            "db": self.database,
+            "charset": "utf8",
+            "use_unicode": True,
+            **MYSQL_NETWORK_KWARGS,
+        }
+        if self.port:
+            kwargs["port"] = int(self.port)
+        return MySQLdb.connect(**kwargs)
 
     def close_connection(self) -> None:
         if getattr(self, "connection", None):

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -24,8 +24,10 @@ import math
 
 #    Standard Library modules
 import os
+import queue
 import re
 import sys
+import threading
 import traceback
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -276,6 +278,8 @@ class Database(
         self.connection: Any = None
         self.cursor: Any = None
         self.__connected = False
+        self._worker_conn_pool = queue.Queue()
+        self._worker_conn_semaphore = threading.Semaphore(4)
         self.wrongDbVersion = False
         self.settings = {}
         self.settings["os"] = "linuxmac" if os.name != "nt" else "windows"
@@ -797,7 +801,28 @@ class Database(
             self.connection.ping(True)
         return self.connection.cursor()
 
-    def create_worker_connection(self):
+    @contextlib.contextmanager
+    def worker_connection(self):
+        """Context manager for a dedicated worker connection from a bounded pool.
+
+        Limits the number of concurrent connections to avoid hitting
+        max_connections on PostgreSQL (and MySQL).
+        """
+        self._worker_conn_semaphore.acquire()
+        conn = None
+        try:
+            try:
+                conn = self._worker_conn_pool.get_nowait()
+            except queue.Empty:
+                conn = self._create_new_worker_connection()
+
+            yield conn
+        finally:
+            if conn is not None:
+                self._worker_conn_pool.put(conn)
+            self._worker_conn_semaphore.release()
+
+    def _create_new_worker_connection(self):
         """Open a dedicated connection for a background worker thread.
 
         Returns None when no dedicated connection can be built (e.g. SQLite
@@ -899,6 +924,15 @@ class Database(
             self.connection.close()
             self.connection = None
         self.__connected = False
+
+        if hasattr(self, "_worker_conn_pool"):
+            while not self._worker_conn_pool.empty():
+                try:
+                    conn = self._worker_conn_pool.get_nowait()
+                    if conn is not None:
+                        conn.close()
+                except queue.Empty:
+                    break
 
     def _close_cursor_quietly(self) -> None:
         cursor = getattr(self, "cursor", None)

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -797,6 +797,41 @@ class Database(
             self.connection.ping(True)
         return self.connection.cursor()
 
+    def create_worker_connection(self):
+        """Open a dedicated SQLite connection for a background worker thread.
+
+        Returns None for non-SQLite backends: those drivers handle concurrent
+        cursors on a shared connection correctly, so workers keep using it.
+
+        Sharing one sqlite3.Connection across threads (check_same_thread=False)
+        without an application-level lock interleaves execute/fetchall pairs
+        from the GUI thread and DbWorker threads, which deadlocks the GUI on
+        macOS. WAL mode makes one read connection per thread safe. The returned
+        connection is intentionally NOT passed through db_profile.wrap_connection:
+        profiling is single-process bookkeeping and worker round trips stay
+        attributed to the main connection.
+        """
+        if self.backend != self.SQLITE or not self.db_path or self.db_path == ":memory:":
+            return None
+        import sqlite3
+
+        conn = sqlite3.connect(
+            self.db_path,
+            detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+            timeout=60.0,
+            check_same_thread=False,
+        )
+        conn.execute("PRAGMA busy_timeout=60000")
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=0")
+        conn.create_function("floor", 1, math.floor)
+        conn.create_function("sqrt", 1, math.sqrt)
+        tmp = sqlitemath()
+        conn.create_function("mod", 2, tmp.mod)
+        if use_numpy:
+            conn.create_aggregate("variance", 1, VARIANCE)
+        return conn
+
     def close_connection(self) -> None:
         if getattr(self, "connection", None):
             self.connection.close()

--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -379,7 +379,7 @@ class Filters(QWidget):
 
         for site in self.conf.get_supported_sites():
             self.db_cursor.execute(self.sql.query["getSiteId"], (site,))
-            result = self.db.cursor.fetchall()
+            result = self.db_cursor.fetchall()
             if len(result) == 1:
                 self.siteid[site] = result[0][0]
             else:
@@ -1151,7 +1151,7 @@ class Filters(QWidget):
         frame.setLayout(vbox1)
 
         self.db_cursor.execute(self.sql.query["getGames"])
-        result = self.db.cursor.fetchall()
+        result = self.db_cursor.fetchall()
         log.debug("get games %s", result)
         self.gameList = QComboBox()
         for count, _game in enumerate(result, start=0):
@@ -1207,7 +1207,7 @@ class Filters(QWidget):
         frame.setLayout(vbox1)
 
         self.db_cursor.execute(self.sql.query["getTourneyNames"])
-        result = self.db.cursor.fetchall()
+        result = self.db_cursor.fetchall()
         log.debug("get tourney name %s", result)
         self.gameList = QComboBox()
         for count, _game in enumerate(result, start=0):
@@ -1298,7 +1298,7 @@ class Filters(QWidget):
         frame.setLayout(vbox1)
 
         self.db_cursor.execute(self.sql.query["getCurrencies"])
-        result = self.db.cursor.fetchall()
+        result = self.db_cursor.fetchall()
         if len(result) >= 1:
             for line in result:
                 cname = self.currencyName[line[0]] if line[0] in self.currencyName else line[0]
@@ -1342,7 +1342,7 @@ class Filters(QWidget):
         frame.setLayout(vbox1)
 
         self.db_cursor.execute(self.sql.query["getCashLimits"])
-        result = self.db.cursor.fetchall()
+        result = self.db_cursor.fetchall()
         limits_found = set()
         types_found = set()
 

--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -248,7 +248,7 @@ class Filters(QWidget):
             display = {}
         super().__init__(None)
         self.db = db
-        self.db_cursor: Any = db.cursor
+        self.db_cursor: Any = db.connection.cursor() if getattr(db, "connection", None) else db.cursor
         self.sql = db.sql
         self.conf = db.config
         self.display = display

--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -12,6 +12,7 @@ Provides a comprehensive filtering system for poker data analysis with support f
 from __future__ import annotations
 
 import itertools
+import time
 import unicodedata
 from functools import partial
 from pathlib import Path
@@ -365,12 +366,13 @@ class Filters(QWidget):
             log.exception("Unable to build theme-aware filter stylesheet")
             return ""
 
-    def make_filter(self) -> None:  # noqa: PLR0912, C901
+    def make_filter(self) -> None:  # noqa: PLR0912, C901, PLR0915
         """Create all filter widgets based on display configuration.
 
         This method is complex by design as it handles multiple filter types
         and their conditional display logic.
         """
+        t0 = time.perf_counter()
         self.siteid: dict[str, int] = {}
         self.cards: dict[str, bool] = {}
         self.type: str | None = None
@@ -426,6 +428,7 @@ class Filters(QWidget):
 
         self.db.rollback()
         self.set_default_hero()
+        log.info("[PERF-TIMING] Filters.make_filter built in %.3f s", time.perf_counter() - t0)
 
     def _clear_layout(self, layout: Any) -> None:
         """Recursively remove and delete every item from a layout."""

--- a/fpdb_3_legacy/GuiGraphViewer.py
+++ b/fpdb_3_legacy/GuiGraphViewer.py
@@ -25,7 +25,10 @@ from time import time
 from typing import Any
 
 np = import_module("numpy")
-FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
+try:
+    FigureCanvas = getattr(import_module("matplotlib.backends.backend_qtagg"), "FigureCanvasQTAgg")
+except ImportError:
+    FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
 Figure = getattr(import_module("matplotlib.figure"), "Figure")
 FuncFormatter = getattr(import_module("matplotlib.ticker"), "FuncFormatter")
 from PySide6.QtWidgets import (

--- a/fpdb_3_legacy/GuiSessionViewer.py
+++ b/fpdb_3_legacy/GuiSessionViewer.py
@@ -92,7 +92,6 @@ class GuiSessionViewer(QSplitter):
         settings = {}
         settings.update(self.conf.get_db_parameters())
         settings.update(self.conf.get_import_parameters())
-        settings.update(self.conf.get_default_paths())
 
         # text used on screen stored here so that it can be configured
         self.filterText = {"handhead": _("Hand Breakdown for all levels listed above")}

--- a/fpdb_3_legacy/GuiSessionViewer.py
+++ b/fpdb_3_legacy/GuiSessionViewer.py
@@ -23,7 +23,10 @@ from typing import Any
 
 mpl = import_module("matplotlib")
 np = import_module("numpy")
-FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
+try:
+    FigureCanvas = getattr(import_module("matplotlib.backends.backend_qtagg"), "FigureCanvasQTAgg")
+except ImportError:
+    FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
 Figure = getattr(import_module("matplotlib.figure"), "Figure")
 FuncFormatter = getattr(import_module("matplotlib.ticker"), "FuncFormatter")
 from PySide6.QtCore import Qt

--- a/fpdb_3_legacy/GuiTourneyGraphViewer.py
+++ b/fpdb_3_legacy/GuiTourneyGraphViewer.py
@@ -46,7 +46,10 @@ try:
             mpl.use("qt5agg")
         except ValueError as e:
             log.exception(f"Matplotlib use error: {e}")
-    FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
+    try:
+        FigureCanvas = getattr(import_module("matplotlib.backends.backend_qtagg"), "FigureCanvasQTAgg")
+    except ImportError:
+        FigureCanvas = getattr(import_module("matplotlib.backends.backend_qt5agg"), "FigureCanvas")
     Figure = getattr(import_module("matplotlib.figure"), "Figure")
     FuncFormatter = getattr(import_module("matplotlib.ticker"), "FuncFormatter")
     cumsum = getattr(import_module("numpy"), "cumsum")

--- a/fpdb_3_legacy/OSXTables.py
+++ b/fpdb_3_legacy/OSXTables.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 #    Standard Library modules
 import ctypes
+import time
 from typing import Any
 
 from AppKit import NSView, NSWindowAbove
@@ -62,6 +63,7 @@ class Table(Table_Window):
         Returns:
             The window title if found, None otherwise.
         """
+        t0 = time.perf_counter()
         self.number = None
         log.debug("DIAGNOSTIC: Starting window detection for search string: '%s'", self.search_string)
 
@@ -104,9 +106,9 @@ class Table(Table_Window):
             # Found matching table
             self.number = int(table_info.window_id)
             self.title = title
-            log.debug("DIAGNOSTIC: TABLE WINDOW DETECTED - ID: %s, Title: '%s'", self.number, self.title)
+            log.info("[PERF-TIMING] OSXTables.find_table_parameters for '%s' matched '%s' in %.3f s", self.search_string, self.title, time.perf_counter() - t0)
             return self.title
-
+        log.info("[PERF-TIMING] OSXTables.find_table_parameters for '%s' completed in %.3f s", self.search_string, time.perf_counter() - t0)
         if self.number is None:
             # At ERROR level: HUD_main reports the same failure as an error, and the
             # osx_tables logger is commonly persisted at ERROR, which would drop the

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1692,19 +1692,19 @@ class fpdb(QMainWindow):
         # delayed Auto Import even though no graphing tab had been requested.
         import time
         t0 = time.time()
-        log.info("[PERF] tab_ring_player_stats: Importing GuiRingPlayerStats")
+        log.warning("[PERF] tab_ring_player_stats: Importing GuiRingPlayerStats")
         from fpdb_3_legacy import GuiRingPlayerStats
         t1 = time.time()
-        log.info(f"[PERF] tab_ring_player_stats: Import took {t1 - t0:.3f}s. Creating GuiRingPlayerStats...")
+        log.warning(f"[PERF] tab_ring_player_stats: Import took {t1 - t0:.3f}s. Creating GuiRingPlayerStats...")
 
         new_ps_thread = GuiRingPlayerStats.GuiRingPlayerStats(self.config, self.sql, self)
         t2 = time.time()
-        log.info(f"[PERF] tab_ring_player_stats: Instantiation took {t2 - t1:.3f}s. Adding tab...")
+        log.warning(f"[PERF] tab_ring_player_stats: Instantiation took {t2 - t1:.3f}s. Adding tab...")
         
         self.threads.append(new_ps_thread)
         self.add_and_display_tab(new_ps_thread, "Ring Player Stats")
         t3 = time.time()
-        log.info(f"[PERF] tab_ring_player_stats: Adding tab took {t3 - t2:.3f}s. Total: {t3 - t0:.3f}s")
+        log.warning(f"[PERF] tab_ring_player_stats: Adding tab took {t3 - t2:.3f}s. Total: {t3 - t0:.3f}s")
 
     def tab_opponents_report(self, widget, data=None) -> None:
         new_thread = GuiOpponentsReport.GuiOpponentsReport(self.config, self.sql, self)

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1690,11 +1690,21 @@ class fpdb(QMainWindow):
         # This package imports Matplotlib and scans every system font. Frozen
         # builds cannot reliably reuse that scan, so importing it at startup
         # delayed Auto Import even though no graphing tab had been requested.
+        import time
+        t0 = time.time()
+        log.info("[PERF] tab_ring_player_stats: Importing GuiRingPlayerStats")
         from fpdb_3_legacy import GuiRingPlayerStats
+        t1 = time.time()
+        log.info(f"[PERF] tab_ring_player_stats: Import took {t1 - t0:.3f}s. Creating GuiRingPlayerStats...")
 
         new_ps_thread = GuiRingPlayerStats.GuiRingPlayerStats(self.config, self.sql, self)
+        t2 = time.time()
+        log.info(f"[PERF] tab_ring_player_stats: Instantiation took {t2 - t1:.3f}s. Adding tab...")
+        
         self.threads.append(new_ps_thread)
         self.add_and_display_tab(new_ps_thread, "Ring Player Stats")
+        t3 = time.time()
+        log.info(f"[PERF] tab_ring_player_stats: Adding tab took {t3 - t2:.3f}s. Total: {t3 - t0:.3f}s")
 
     def tab_opponents_report(self, widget, data=None) -> None:
         new_thread = GuiOpponentsReport.GuiOpponentsReport(self.config, self.sql, self)

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1874,6 +1874,12 @@ class fpdb(QMainWindow):
             self.threads.remove(item)
 
         if item is not None:
+            # Stop any QThreads before destruction: a widget removed from a
+            # QTabWidget does not receive closeEvent, so DbWorker threads (ring
+            # stats) would otherwise keep running as zombies.
+            shutdown = getattr(item, "shutdown_workers", None)
+            if callable(shutdown):
+                shutdown()
             item.deleteLater()
 
     def __init__(self) -> None:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -49,7 +49,7 @@ from typing import Any
 
 import interlocks
 from loggingFpdb import get_logger, setup_logging
-from PySide6.QtCore import QCoreApplication, QDate, QPoint, Qt
+from PySide6.QtCore import QCoreApplication, QDate, QPoint, Qt, QTimer
 from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QApplication,
@@ -2128,6 +2128,9 @@ if __name__ == "__main__":
 
         # Register main window with theme manager for future theme changes
         theme_manager._main_window = me
+
+        # Pre-warm matplotlib on Qt main thread during idle time
+        QTimer.singleShot(500, Configuration.prewarm_matplotlib)
 
         app.exec()
     finally:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -2139,8 +2139,15 @@ if __name__ == "__main__":
         # Register main window with theme manager for future theme changes
         theme_manager._main_window = me
 
-        # Pre-warm matplotlib on Qt main thread during idle time
-        QTimer.singleShot(500, Configuration.prewarm_matplotlib)
+        # Pre-warm matplotlib synchronously and BEFORE the event loop starts.
+        # The first FigureCanvas built by any tab triggers matplotlib's font
+        # cache rebuild on whatever thread builds it; if that happens on the
+        # Qt main thread after app.exec() it freezes the GUI, and in a
+        # PyOxidizer bundle (packaged fonts, first run after a rebuild) the
+        # rebuild can take several seconds. Doing it here, on the main thread
+        # and before any tab exists, means the cache is ready before the user
+        # can open a single tab.
+        Configuration.prewarm_matplotlib()
 
         app.exec()
     finally:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -43,6 +43,7 @@ import os
 import pstats
 import queue
 import sqlite3
+import time
 from functools import partial
 from importlib import import_module
 from typing import Any
@@ -215,18 +216,21 @@ class fpdb(QMainWindow):
 
     def add_and_display_tab(self, new_page, new_tab_name) -> None:
         """Adds a tab, namely creates the button and displays it and appends all the relevant arrays."""
+        t0 = time.perf_counter()
         if not new_tab_name or not isinstance(new_tab_name, str):
             raise ValueError(f"Invalid tab name: {new_tab_name!r}")
 
         for name in self.nb_tab_names:
             if name == new_tab_name:
                 self.display_tab(new_tab_name)
+                log.info("[PERF-TIMING] Switched to existing tab '%s' in %.3f s", new_tab_name, time.perf_counter() - t0)
                 return  # if tab already exists, just go to it
 
         self.nb_tab_names.append(new_tab_name)
 
         index = self.nb.addTab(new_page, new_tab_name)
         self.nb.setCurrentIndex(index)
+        log.info("[PERF-TIMING] Opened and added new tab '%s' in %.3f s", new_tab_name, time.perf_counter() - t0)
 
     def display_tab(self, new_tab_name) -> None:
         """Displays the indicated tab."""

--- a/fpdb_3_legacy/ring_stats/__init__.py
+++ b/fpdb_3_legacy/ring_stats/__init__.py
@@ -159,6 +159,16 @@ class GuiRingPlayerStats(QSplitter):
         self.controller.position_data_ready.connect(self.position_tab.update_position_data)
         self.controller.no_data_found.connect(self.handle_no_data_found)
 
+    def shutdown_workers(self) -> None:
+        """Stop DB workers from both the controller and the tab widget.
+
+        Called by fpdb.pyw ``close_tab`` before ``deleteLater``: a widget
+        removed from a QTabWidget does not receive ``closeEvent``, so without
+        this the QThreads would outlive the tab.
+        """
+        self.controller.shutdown_workers()
+        self.stats_tabs.shutdown_workers()
+
     def handle_no_data_found(self, reason: str = "") -> None:
         """Explique pourquoi l'onglet est vide (filtre incomplet, base vide, ...)."""
         try:

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -23,17 +23,24 @@ class DbWorker(QThread):
     # Arguments: (error_message)
     error = Signal(str)
 
-    def __init__(self, cursor, query_name: str, query_sql: str) -> None:
+    def __init__(self, db_or_cursor, query_name: str, query_sql: str) -> None:
         super().__init__()
-        self.cursor = cursor
+        self.db_or_cursor = db_or_cursor
         self.query_name = query_name
         self.query_sql = query_sql
 
     def run(self) -> None:
         try:
-            self.cursor.execute(self.query_sql)
-            results = self.cursor.fetchall()
-            colnames = [desc[0].lower() for desc in self.cursor.description] if self.cursor.description else []
+            db = self.db_or_cursor
+            conn = getattr(db, "connection", None)
+            cursor = conn.cursor() if conn else getattr(db, "cursor", db)
+            try:
+                cursor.execute(self.query_sql)
+                results = cursor.fetchall()
+                colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+            finally:
+                if conn and hasattr(cursor, "close"):
+                    cursor.close()
             self.finished.emit(self.query_name, results, colnames)
         except Exception as e:  # noqa: BLE001 - Qt worker boundary reports DB-driver errors through its signal.
             self.error.emit(str(e))

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -6,6 +6,8 @@ modernes, ainsi que le système d'exécution de requêtes asynchrones en arrièr
 
 from __future__ import annotations
 
+import contextlib
+
 from PySide6.QtCore import QThread, Signal
 from PySide6.QtWidgets import QMessageBox, QTabWidget
 
@@ -138,8 +140,13 @@ class ModernStatsWidget(QTabWidget):
         """
         for worker in self._workers:
             if worker.isRunning():
-                worker.terminate()
-                worker.wait()
+                # Disconnect signals so they don't update a destroyed GUI.
+                # Do NOT terminate() as it abruptly kills the thread and leaks
+                # DB connection pool semaphores!
+                with contextlib.suppress(Exception):
+                    worker.finished.disconnect()
+                with contextlib.suppress(Exception):
+                    worker.error.disconnect()
         self._workers = []
 
     def closeEvent(self, event) -> None:

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -32,15 +32,24 @@ class DbWorker(QThread):
         self.query_sql = query_sql
 
     def run(self) -> None:
+        import time
+        import logging
+        log = logging.getLogger("DbWorker")
+        t_start = time.time()
+        log.info(f"[PERF] DbWorker.run start: {self.query_name}")
         try:
             db = self.db_or_cursor
 
             def _exec_on_conn(conn_obj):
+                t0 = time.time()
                 cursor = conn_obj.cursor() if hasattr(conn_obj, "cursor") else db
                 try:
                     cursor.execute(self.query_sql)
+                    t1 = time.time()
                     res = cursor.fetchall()
+                    t2 = time.time()
                     cols = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+                    log.info(f"[PERF] DbWorker {self.query_name} SQL EXEC: {t1-t0:.3f}s | FETCH: {t2-t1:.3f}s")
                     return res, cols
                 finally:
                     # Do not close the shared db/cursor object if it doesn't belong to us
@@ -49,15 +58,20 @@ class DbWorker(QThread):
 
             worker_conn_ctx = getattr(db, "worker_connection", None)
             dedicated = getattr(db, "create_worker_connection", None)
-
+            
+            t_acq = time.time()
             if callable(worker_conn_ctx):
                 with worker_conn_ctx() as conn:
+                    t_post_acq = time.time()
+                    log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire: {t_post_acq - t_acq:.3f}s")
                     if conn is not None:
                         results, colnames = _exec_on_conn(conn)
                     else:
                         results, colnames = _exec_on_conn(getattr(db, "connection", db))
             elif callable(dedicated):
                 conn = dedicated()
+                t_post_acq = time.time()
+                log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire (legacy): {t_post_acq - t_acq:.3f}s")
                 if conn is not None:
                     try:
                         results, colnames = _exec_on_conn(conn)
@@ -66,10 +80,14 @@ class DbWorker(QThread):
                 else:
                     results, colnames = _exec_on_conn(getattr(db, "connection", db))
             else:
+                log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire (shared): 0.0s")
                 results, colnames = _exec_on_conn(getattr(db, "connection", db))
 
+            t_emit = time.time()
             self.finished.emit(self.query_name, results, colnames)
+            log.info(f"[PERF] DbWorker {self.query_name} emit took: {time.time() - t_emit:.3f}s | Total: {time.time() - t_start:.3f}s")
         except Exception as e:  # noqa: BLE001 - Qt worker boundary reports DB-driver errors through its signal.
+            log.error(f"[PERF] DbWorker {self.query_name} ERROR: {e}")
             self.error.emit(str(e))
 
 

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -36,7 +36,7 @@ class DbWorker(QThread):
         import logging
         log = logging.getLogger("DbWorker")
         t_start = time.time()
-        log.info(f"[PERF] DbWorker.run start: {self.query_name}")
+        log.warning(f"[PERF] DbWorker.run start: {self.query_name}")
         try:
             db = self.db_or_cursor
 
@@ -49,7 +49,7 @@ class DbWorker(QThread):
                     res = cursor.fetchall()
                     t2 = time.time()
                     cols = [desc[0].lower() for desc in cursor.description] if cursor.description else []
-                    log.info(f"[PERF] DbWorker {self.query_name} SQL EXEC: {t1-t0:.3f}s | FETCH: {t2-t1:.3f}s")
+                    log.warning(f"[PERF] DbWorker {self.query_name} SQL EXEC: {t1-t0:.3f}s | FETCH: {t2-t1:.3f}s")
                     return res, cols
                 finally:
                     # Do not close the shared db/cursor object if it doesn't belong to us
@@ -63,7 +63,7 @@ class DbWorker(QThread):
             if callable(worker_conn_ctx):
                 with worker_conn_ctx() as conn:
                     t_post_acq = time.time()
-                    log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire: {t_post_acq - t_acq:.3f}s")
+                    log.warning(f"[PERF] DbWorker {self.query_name} Connection Acquire: {t_post_acq - t_acq:.3f}s")
                     if conn is not None:
                         results, colnames = _exec_on_conn(conn)
                     else:
@@ -71,7 +71,7 @@ class DbWorker(QThread):
             elif callable(dedicated):
                 conn = dedicated()
                 t_post_acq = time.time()
-                log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire (legacy): {t_post_acq - t_acq:.3f}s")
+                log.warning(f"[PERF] DbWorker {self.query_name} Connection Acquire (legacy): {t_post_acq - t_acq:.3f}s")
                 if conn is not None:
                     try:
                         results, colnames = _exec_on_conn(conn)
@@ -80,12 +80,12 @@ class DbWorker(QThread):
                 else:
                     results, colnames = _exec_on_conn(getattr(db, "connection", db))
             else:
-                log.info(f"[PERF] DbWorker {self.query_name} Connection Acquire (shared): 0.0s")
+                log.warning(f"[PERF] DbWorker {self.query_name} Connection Acquire (shared): 0.0s")
                 results, colnames = _exec_on_conn(getattr(db, "connection", db))
 
             t_emit = time.time()
             self.finished.emit(self.query_name, results, colnames)
-            log.info(f"[PERF] DbWorker {self.query_name} emit took: {time.time() - t_emit:.3f}s | Total: {time.time() - t_start:.3f}s")
+            log.warning(f"[PERF] DbWorker {self.query_name} emit took: {time.time() - t_emit:.3f}s | Total: {time.time() - t_start:.3f}s")
         except Exception as e:  # noqa: BLE001 - Qt worker boundary reports DB-driver errors through its signal.
             log.error(f"[PERF] DbWorker {self.query_name} ERROR: {e}")
             self.error.emit(str(e))

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -32,34 +32,40 @@ class DbWorker(QThread):
     def run(self) -> None:
         try:
             db = self.db_or_cursor
-            # SQLite: run the query on a dedicated connection for this thread.
-            # Sharing one sqlite3.Connection across threads without an
-            # application-level lock serializes execute/fetchall pairs and can
-            # interleave statements, which deadlocks the GUI on macOS.
-            # WAL mode allows one connection per thread safely.
-            dedicated = getattr(db, "create_worker_connection", None)
-            if callable(dedicated):
-                conn = dedicated()
-                try:
-                    cursor = conn.cursor()
-                    try:
-                        cursor.execute(self.query_sql)
-                        results = cursor.fetchall()
-                        colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
-                    finally:
-                        cursor.close()
-                finally:
-                    conn.close()
-            else:
-                conn = getattr(db, "connection", None)
-                cursor = conn.cursor() if conn else getattr(db, "cursor", db)
+
+            def _exec_on_conn(conn_obj):
+                cursor = conn_obj.cursor() if hasattr(conn_obj, "cursor") else db
                 try:
                     cursor.execute(self.query_sql)
-                    results = cursor.fetchall()
-                    colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+                    res = cursor.fetchall()
+                    cols = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+                    return res, cols
                 finally:
-                    if conn and hasattr(cursor, "close"):
+                    # Do not close the shared db/cursor object if it doesn't belong to us
+                    if hasattr(cursor, "close") and cursor is not db:
                         cursor.close()
+
+            worker_conn_ctx = getattr(db, "worker_connection", None)
+            dedicated = getattr(db, "create_worker_connection", None)
+
+            if callable(worker_conn_ctx):
+                with worker_conn_ctx() as conn:
+                    if conn is not None:
+                        results, colnames = _exec_on_conn(conn)
+                    else:
+                        results, colnames = _exec_on_conn(getattr(db, "connection", db))
+            elif callable(dedicated):
+                conn = dedicated()
+                if conn is not None:
+                    try:
+                        results, colnames = _exec_on_conn(conn)
+                    finally:
+                        conn.close()
+                else:
+                    results, colnames = _exec_on_conn(getattr(db, "connection", db))
+            else:
+                results, colnames = _exec_on_conn(getattr(db, "connection", db))
+
             self.finished.emit(self.query_name, results, colnames)
         except Exception as e:  # noqa: BLE001 - Qt worker boundary reports DB-driver errors through its signal.
             self.error.emit(str(e))

--- a/fpdb_3_legacy/ring_stats/base.py
+++ b/fpdb_3_legacy/ring_stats/base.py
@@ -32,15 +32,34 @@ class DbWorker(QThread):
     def run(self) -> None:
         try:
             db = self.db_or_cursor
-            conn = getattr(db, "connection", None)
-            cursor = conn.cursor() if conn else getattr(db, "cursor", db)
-            try:
-                cursor.execute(self.query_sql)
-                results = cursor.fetchall()
-                colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
-            finally:
-                if conn and hasattr(cursor, "close"):
-                    cursor.close()
+            # SQLite: run the query on a dedicated connection for this thread.
+            # Sharing one sqlite3.Connection across threads without an
+            # application-level lock serializes execute/fetchall pairs and can
+            # interleave statements, which deadlocks the GUI on macOS.
+            # WAL mode allows one connection per thread safely.
+            dedicated = getattr(db, "create_worker_connection", None)
+            if callable(dedicated):
+                conn = dedicated()
+                try:
+                    cursor = conn.cursor()
+                    try:
+                        cursor.execute(self.query_sql)
+                        results = cursor.fetchall()
+                        colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+                    finally:
+                        cursor.close()
+                finally:
+                    conn.close()
+            else:
+                conn = getattr(db, "connection", None)
+                cursor = conn.cursor() if conn else getattr(db, "cursor", db)
+                try:
+                    cursor.execute(self.query_sql)
+                    results = cursor.fetchall()
+                    colnames = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+                finally:
+                    if conn and hasattr(cursor, "close"):
+                        cursor.close()
             self.finished.emit(self.query_name, results, colnames)
         except Exception as e:  # noqa: BLE001 - Qt worker boundary reports DB-driver errors through its signal.
             self.error.emit(str(e))
@@ -103,10 +122,21 @@ class ModernStatsWidget(QTabWidget):
             f"Une erreur est survenue lors du chargement des statistiques :\n\n{error_message}",
         )
 
-    def closeEvent(self, event) -> None:
-        """S'assure que tous les workers d'arrière-plan sont arrêtés avant fermeture."""
+    def shutdown_workers(self) -> None:
+        """Stop all background workers.
+
+        Called explicitly when the tab is removed from the QTabWidget
+        (``close_tab`` in fpdb.pyw): a widget detached from a QTabWidget does
+        not receive ``closeEvent``, so without this call the QThreads would keep
+        running on a connection whose parent widget is destroyed.
+        """
         for worker in self._workers:
             if worker.isRunning():
                 worker.terminate()
                 worker.wait()
+        self._workers = []
+
+    def closeEvent(self, event) -> None:
+        """Ensure all background workers are stopped before closing."""
+        self.shutdown_workers()
         super().closeEvent(event)

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -185,21 +185,36 @@ class RingStatsController(QObject):
         # Paramètres pour affiner les requêtes
         filter_params = (filter_widget, playerids, sitenos, limits, seats, groups, dates, games, currencies, num_hands)
 
+        import time
+        import logging
+        log = logging.getLogger("controller")
+        
+        t0 = time.time()
         # 2. Lancer la requête pour le tableau résumé (summary grid)
         sql_summary = self._get_refined_sql("playerDetailedStats", False, *filter_params)
+        t1 = time.time()
+        log.info(f"[PERF] controller sql_summary generation: {t1-t0:.3f}s")
         self._run_query("summary", sql_summary, self._on_summary_query_finished)
 
         # 3. Lancer la requête pour le détail des mains (hand detailed stats)
         if "allplayers" not in groups:
             sql_hands = self._get_refined_sql("playerDetailedStats", True, *filter_params)
+            t2 = time.time()
+            log.info(f"[PERF] controller sql_hands generation: {t2-t1:.3f}s")
             self._run_query("hands", sql_hands, self._on_hands_query_finished)
+        else:
+            t2 = time.time()
 
         # 4. Lancer la requête spécifique pour le Poker Table (Heatmap de position)
         sql_positions = self._get_refined_sql("playerDetailedStats", False, *filter_params, force_position=True)
+        t3 = time.time()
+        log.info(f"[PERF] controller sql_positions generation: {t3-t2:.3f}s")
         self._run_query("positions", sql_positions, self._on_positions_query_finished)
 
         # 5. Lancer la requête chronologique de profit
         sql_profit = self._get_refined_sql_profit(playerids, sitenos, limits, dates, games, currencies, filter_widget)
+        t4 = time.time()
+        log.info(f"[PERF] controller sql_profit generation: {t4-t3:.3f}s. Total queries dispatch: {t4-t0:.3f}s")
         self._run_query("profit", sql_profit, self._on_profit_query_finished)
 
     def _run_query(self, query_name: str, sql: str, callback) -> None:

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -193,14 +193,14 @@ class RingStatsController(QObject):
         # 2. Lancer la requête pour le tableau résumé (summary grid)
         sql_summary = self._get_refined_sql("playerDetailedStats", False, *filter_params)
         t1 = time.time()
-        log.info(f"[PERF] controller sql_summary generation: {t1-t0:.3f}s")
+        log.warning(f"[PERF] controller sql_summary generation: {t1-t0:.3f}s")
         self._run_query("summary", sql_summary, self._on_summary_query_finished)
 
         # 3. Lancer la requête pour le détail des mains (hand detailed stats)
         if "allplayers" not in groups:
             sql_hands = self._get_refined_sql("playerDetailedStats", True, *filter_params)
             t2 = time.time()
-            log.info(f"[PERF] controller sql_hands generation: {t2-t1:.3f}s")
+            log.warning(f"[PERF] controller sql_hands generation: {t2-t1:.3f}s")
             self._run_query("hands", sql_hands, self._on_hands_query_finished)
         else:
             t2 = time.time()
@@ -208,13 +208,13 @@ class RingStatsController(QObject):
         # 4. Lancer la requête spécifique pour le Poker Table (Heatmap de position)
         sql_positions = self._get_refined_sql("playerDetailedStats", False, *filter_params, force_position=True)
         t3 = time.time()
-        log.info(f"[PERF] controller sql_positions generation: {t3-t2:.3f}s")
+        log.warning(f"[PERF] controller sql_positions generation: {t3-t2:.3f}s")
         self._run_query("positions", sql_positions, self._on_positions_query_finished)
 
         # 5. Lancer la requête chronologique de profit
         sql_profit = self._get_refined_sql_profit(playerids, sitenos, limits, dates, games, currencies, filter_widget)
         t4 = time.time()
-        log.info(f"[PERF] controller sql_profit generation: {t4-t3:.3f}s. Total queries dispatch: {t4-t0:.3f}s")
+        log.warning(f"[PERF] controller sql_profit generation: {t4-t3:.3f}s. Total queries dispatch: {t4-t0:.3f}s")
         self._run_query("profit", sql_profit, self._on_profit_query_finished)
 
     def _run_query(self, query_name: str, sql: str, callback) -> None:

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -121,6 +121,18 @@ class RingStatsController(QObject):
         self._last_summary_stats: dict[str, Any] | None = None
         self._last_profit_data: tuple[Any, Any, Any, Any] | None = None
 
+    def shutdown_workers(self) -> None:
+        """Stop all DbWorker threads started by this controller.
+
+        Called when the host tab is closed: QThreads must not outlive their
+        parent widget.
+        """
+        for worker in self._workers:
+            if worker.isRunning():
+                worker.terminate()
+                worker.wait()
+        self._workers = []
+
     def refresh_all(self, filter_widget) -> None:
         """Lance l'ensemble des requêtes asynchrones en fonction des filtres appliqués."""
         debug_log("refresh_all called!")

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -113,11 +113,10 @@ class RingStatsController(QObject):
         self.columns = config.get_gui_cash_stat_params()
         self._workers: list[DbWorker] = []
 
-        # Détection automatique de l'environnement de test ou SQLite pour exécution synchrone
-        # En mode SQLite, nous forçons l'exécution synchrone pour éviter les exceptions de thread
+        # Force synchronous mode only in test suites (pytest/unittest)
         import sys
-        is_sqlite = (hasattr(db, "backend") and db.backend == 4)
-        self.async_mode = (not is_sqlite) and ("pytest" not in sys.modules and "unittest" not in sys.modules)
+
+        self.async_mode = "pytest" not in sys.modules and "unittest" not in sys.modules
 
         self._last_summary_stats: dict[str, Any] | None = None
         self._last_profit_data: tuple[Any, Any, Any, Any] | None = None
@@ -198,7 +197,7 @@ class RingStatsController(QObject):
         # Nettoyer les anciens workers
         self._workers = [w for w in self._workers if not w.isFinished()]
 
-        worker = DbWorker(self.cursor, query_name, sql)
+        worker = DbWorker(self.db, query_name, sql)
         worker.finished.connect(callback)
 
         def on_error(err):

--- a/fpdb_3_legacy/ring_stats/views/dashboard_view.py
+++ b/fpdb_3_legacy/ring_stats/views/dashboard_view.py
@@ -7,7 +7,11 @@ et le graphique de profit cumulé Matplotlib.
 from __future__ import annotations
 
 import numpy as np
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+
+try:
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+except ImportError:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.ticker import FuncFormatter
 from PySide6.QtWidgets import QGridLayout, QLabel, QVBoxLayout, QWidget

--- a/fpdb_3_legacy/ring_stats/views/positional_view.py
+++ b/fpdb_3_legacy/ring_stats/views/positional_view.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import math
 
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+try:
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+except ImportError:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PySide6.QtCore import QRectF, Qt
 from PySide6.QtGui import QBrush, QColor, QFont, QPainter, QPen

--- a/fpdb_3_legacy/ring_stats/views/starting_hands_view.py
+++ b/fpdb_3_legacy/ring_stats/views/starting_hands_view.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+try:
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+except ImportError:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QComboBox, QFrame, QGridLayout, QHBoxLayout, QLabel, QScrollArea, QVBoxLayout, QWidget

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -219,7 +219,7 @@ def test_release_and_rc_pyoxidizer_artifacts_require_stable_developer_id() -> No
     # GitHub sends release/published for public prereleases (including RCs) as
     # well as final releases, so this is the shared distribution gate.
     assert "release:\n    types: [ published ]" in workflow
-    assert "FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ github.event_name == 'release' && '1' || '0' }}" in pyoxidizer
+    assert "FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && '1' || '0' }}" in pyoxidizer
     assert '"Developer ID Application: "*' in pyoxidizer
     assert 'grep -Fqx "Authority=$FPDB_MACOS_SIGNING_IDENTITY"' in pyoxidizer
     assert 'grep -Fqx "TeamIdentifier=$expected_team_id"' in pyoxidizer

--- a/test/test_performance_tab_opening.py
+++ b/test/test_performance_tab_opening.py
@@ -1,0 +1,35 @@
+"""Tests for performance optimizations when creating tabs in FPDB."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import fpdb_3_legacy.Configuration as Configuration
+from fpdb_3_legacy.Filters import Filters
+
+
+def test_mplconfigdir_configured() -> None:
+    """Verify MPLCONFIGDIR is set to a user-writable path under CONFIG_PATH."""
+    assert "MPLCONFIGDIR" in os.environ
+    assert os.environ["MPLCONFIGDIR"].startswith(Configuration.CONFIG_PATH)
+
+
+def test_filters_uses_isolated_cursor(qapp: MagicMock) -> None:
+    """Verify Filters creates a dedicated cursor to avoid lock contention on db.cursor."""
+    _ = qapp
+    mock_connection = MagicMock()
+    mock_dedicated_cursor = MagicMock()
+    mock_connection.cursor.return_value = mock_dedicated_cursor
+
+    mock_db = MagicMock()
+    mock_db.connection = mock_connection
+    mock_db.cursor = MagicMock()
+    mock_db.config.get_supported_sites.return_value = []
+    mock_db.config.get_general_params.return_value = {}
+
+    filters = Filters(mock_db)
+
+    # Dedicated cursor should be used instead of sharing mock_db.cursor
+    assert filters.db_cursor == mock_dedicated_cursor
+    assert filters.db_cursor != mock_db.cursor

--- a/test/test_performance_tab_opening.py
+++ b/test/test_performance_tab_opening.py
@@ -15,9 +15,13 @@ def test_mplconfigdir_configured() -> None:
     assert os.environ["MPLCONFIGDIR"].startswith(Configuration.CONFIG_PATH)
 
 
-def test_filters_uses_isolated_cursor(qapp: MagicMock) -> None:
+def test_filters_uses_isolated_cursor() -> None:
     """Verify Filters creates a dedicated cursor to avoid lock contention on db.cursor."""
-    _ = qapp
+    from PySide6.QtWidgets import QApplication
+
+    if QApplication.instance() is None:
+        _app = QApplication([])
+
     mock_connection = MagicMock()
     mock_dedicated_cursor = MagicMock()
     mock_connection.cursor.return_value = mock_dedicated_cursor

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.6.3"
+version = "3.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Fixes the performance lag/freeze when opening tabs (e.g. 3rd tab) in PyOxidizer bundle mode on macOS.

## Changes Made
- **Matplotlib Font Pre-warming & Persistence**: Configured `os.environ["MPLCONFIGDIR"]` to `~/.fpdb/matplotlib` so Matplotlib font list cache is stored in a writable user directory. Scheduled `prewarm_matplotlib()` via `QTimer.singleShot(500, Configuration.prewarm_matplotlib)` on the Qt main event loop 500ms after startup.
- **SQLite Cursor Isolation**: Updated `Filters` widget to use an isolated cursor (`db.connection.cursor()`) to eliminate cursor lock contention with background threads (Auto Import).
- **Session Stats Optimization**: Removed `get_default_paths()` disk probing from `GuiSessionViewer.__init__`.
- **Automated Tests**: Added `test/test_performance_tab_opening.py` to verify cursor isolation and `MPLCONFIGDIR` configuration.