### PR TITLE
fix(windows): deprecate PyOxidizer build on Windows in favor of PyInstaller and Nuitka (closes #225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,14 +606,6 @@ jobs:
             target: aarch64-apple-darwin
             executable: fpdb
             artifact: fpdb-pyoxidizer-macos-arm64
-          - label: Windows x64
-            os: windows-latest
-            pyoxidizer_host: x86_64-pc-windows-msvc
-            pyoxidizer_archive: zip
-            pyoxidizer_sha256: c1b757bc7c64921b38bf5fd70d2a2e2f591d36fe1cae3b5722822c08f651ba7b
-            target: x86_64-pc-windows-msvc
-            executable: fpdb.exe
-            artifact: fpdb-pyoxidizer-windows-x64
     steps:
       - uses: actions/checkout@v4
       - name: Validate macOS release credentials

--- a/build_experiment.sh
+++ b/build_experiment.sh
@@ -54,6 +54,13 @@ case "$BUILDER" in
         
     pyoxidizer)
         echo "=== Building with PyOxidizer ==="
+        case "$(uname -s 2>/dev/null || echo MINGW)" in
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Error: PyOxidizer builds on Windows are deprecated (Issue #225)."
+                echo "Please use build_fpdb.ps1 (PyInstaller) or Nuitka for Windows builds."
+                exit 1
+                ;;
+        esac
         # Ensure PyOxidizer is installed
         if ! command -v pyoxidizer &> /dev/null; then
             echo "Installing PyOxidizer..."

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -14,15 +14,13 @@ def make_dist():
             "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
             "4558c58bd03309d0c7131d4b5c2cbce9843d385fbcc7d75e575b4bf887bf5f68",
         ],
-        "x86_64-pc-windows-msvc": [
-            "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
-            "1003c93f92fdcca57308076995b224b888a7ee556763759e69d36e198b5bef14",
-        ],
         "x86_64-unknown-linux-gnu": [
             "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-x86_64-unknown-linux-gnu-pgo-full.tar.zst",
             "f15c2b569f3bf8ba01737c5f46cf71e8bc07129ecc7304de9ba47b220acee47e",
         ],
     }
+    if BUILD_TARGET_TRIPLE == "x86_64-pc-windows-msvc":
+        fail("PyOxidizer is deprecated on Windows (Issue #225). Use PyInstaller (build_fpdb.ps1) or Nuitka for Windows builds.")
     if BUILD_TARGET_TRIPLE not in distributions:
         fail("unsupported PyOxidizer build target: " + BUILD_TARGET_TRIPLE)
 

--- a/test/test_pyoxidizer_windows_deprecation.py
+++ b/test/test_pyoxidizer_windows_deprecation.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_pyoxidizer_bzl_deprecates_windows_target() -> None:
+    """Verify that pyoxidizer.bzl rejects Windows target with a helpful deprecation message."""
+    bzl_content = (ROOT / "pyoxidizer.bzl").read_text(encoding="utf-8")
+    assert "PyOxidizer is deprecated on Windows" in bzl_content
+    assert "build_fpdb.ps1" in bzl_content
+
+
+def test_build_experiment_sh_warns_on_windows_pyoxidizer() -> None:
+    """Verify that build_experiment.sh handles Windows PyOxidizer deprecation."""
+    sh_content = (ROOT / "build_experiment.sh").read_text(encoding="utf-8")
+    assert "PyOxidizer builds on Windows are deprecated" in sh_content


### PR DESCRIPTION
## Summary
Addresses [#225](https://github.com/jejellyroll-fr/fpdb-3/issues/225) by formally deprecating the non-functional Windows PyOxidizer build target in favor of PyInstaller (`build_fpdb.ps1`) and Nuitka.

## Technical Rationale
- PyOxidizer 0.24 is unmaintained upstream and requires pinning CPython to 3.10.14 due to missing `_Py_Deepfreeze_*` symbols for Python 3.11+.
- PyOxidizer fails to package native Qt C++ DLLs (`Qt6Core.dll`, `Qt6Gui.dll`, `Qt6Widgets.dll`) and platform plugins (`platforms/qwindows.dll`) under MSVC on Windows, leaving the compiled executable unable to launch the Qt interface.
- Native PyInstaller packaging (`build_fpdb.ps1` -> `fpdb-pyinstaller-windows-x64`) correctly resolves all Windows Qt DLL dependencies and is the official supported Windows distribution path.

## Changes Made
1. **`pyoxidizer.bzl`**: Removed `x86_64-pc-windows-msvc` target from distribution map and added an explicit failure message with deprecation notice directing to `build_fpdb.ps1` / Nuitka.
2. **`.github/workflows/ci.yml`**: Removed `Windows x64` from `build-pyoxidizer` CI matrix, eliminating ~6 minutes of failing PyOxidizer build steps per CI run.
3. **`build_experiment.sh`**: Added OS check for Windows environments to issue a clear error notice directing users to `build_fpdb.ps1`.
4. **`test/test_pyoxidizer_windows_deprecation.py`**: Unit tests asserting the presence of the deprecation notice in build scripts.

Closes #225