### PR TITLE
Harden FastHUD request lifecycle

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -249,14 +249,6 @@ class HudReadWorker(QThread):
                 info = database.get_gameinfo_from_hid(request.hand_id)
                 gametype_id = info["gametypeId"] if info else None
 
-            if gametype_id is None and hasattr(database, "connection") and database.connection:
-                with contextlib.suppress(Exception):
-                    c = database.connection.cursor()
-                    c.execute("SELECT id FROM Gametypes ORDER BY id DESC LIMIT 1")
-                    r = c.fetchone()
-                    if r:
-                        gametype_id = r[0]
-
             stat_dict = FastFoldEngine(db_connection=database).get_player_stats_for_seat_map(
                 request.seat_map,
                 db_conn=database,
@@ -271,6 +263,7 @@ class HudReadWorker(QThread):
             temp_key=request.temp_key,
             seat_map=dict(request.seat_map),
             stat_dict=stat_dict,
+            request_id=request.request_id,
         )
 
     def run(self) -> None:
@@ -795,6 +788,10 @@ class HudMain(QObject):
             # Winamax log pool -> hud_dict key, learned once a hand from that
             # table has been imported and reused while the table stays open.
             self._winamax_pool_huds: dict[str, str] = {}
+            # Imported hands use the human table key while a live FastFold HUD
+            # may also carry a window discriminator. Keep that alias explicit
+            # instead of making every caller guess with string prefixes.
+            self._fast_fold_aliases: dict[str, str] = {}
             # hud_dict keys known to be Fast-Fold tables.
             self._fast_fold_tables: set[str] = set()
             # hud_dict key -> the seat map last sent to the worker, so an
@@ -808,9 +805,11 @@ class HudMain(QObject):
             # because each read walks another process's accessibility tree.
             self._ax_rings: dict[str, tuple[str, dict[int, str], int]] = {}
             # Timeline bookkeeping: when each hand's first log line arrived, and
-            # which hand a table's in-flight stats request belongs to.
+            # which hand/table request is currently allowed to update the HUD.
             self._ff_started: dict[str, float] = {}
             self._ff_pending_hand: dict[str, str] = {}
+            self._ff_pending_request: dict[str, int] = {}
+            self._ff_request_sequence = 0
             # Learned from the first imported Winamax hand. A log-created HUD
             # does not need it (it reads nothing from the database), but keeping
             # it lets the table carry the same identity as an imported one.
@@ -1164,7 +1163,10 @@ class HudMain(QObject):
         temp_key = self._get_temp_key(info.game_type, info.tour_number, info.tab_number, table_name)
         if info.fast:
             self._fast_fold_tables.add(temp_key)
-        if any(k == temp_key or k.startswith(f"{temp_key} #") for k in self.hud_dict):
+        resolved_key = self._resolve_fast_fold_key(temp_key)
+        if resolved_key != temp_key:
+            return resolved_key
+        if temp_key in self.hud_dict:
             return temp_key
         if self._handle_tournament_table_changes(info.game_type, temp_key, info.tour_number):
             return None
@@ -1181,6 +1183,19 @@ class HudMain(QObject):
             self._last_table_info[temp_key] = table_info
             return temp_key
         return None
+
+    def _resolve_fast_fold_key(self, temp_key: str) -> str:
+        """Resolve an imported human key to its active window HUD key."""
+        aliases = getattr(self, "_fast_fold_aliases", {})
+        aliased = aliases.get(temp_key)
+        if aliased in getattr(self, "hud_dict", {}):
+            return aliased
+        candidates = [
+            key
+            for key in getattr(self, "hud_dict", {})
+            if key.startswith(f"{temp_key} #")
+        ]
+        return candidates[0] if len(candidates) == 1 else temp_key
 
     def _on_db_snapshot(self, snapshot: HudBatchSnapshot) -> None:
         """Apply a database-free snapshot on the Qt thread."""
@@ -1370,7 +1385,14 @@ class HudMain(QObject):
         The seat windows hide themselves when their seat holds nobody, so
         emptying the seats is what removes them from an idle felt.
         """
-        if self._fast_fold_pending.pop(temp_key, None) is None and not getattr(hud, "stat_dict", None) and not getattr(hud, "seat_players", None):
+        pending = self._fast_fold_pending.pop(temp_key, None)
+        pending_requests = getattr(self, "_ff_pending_request", None)
+        if pending_requests is not None:
+            pending_requests.pop(temp_key, None)
+        pending_hands = getattr(self, "_ff_pending_hand", None)
+        if pending_hands is not None:
+            pending_hands.pop(temp_key, None)
+        if pending is None and not getattr(hud, "stat_dict", None) and not getattr(hud, "seat_players", None):
             return  # already down
         FastFoldEngine.clear_seats(hud)
         self._ff_trace(hand_id, "cleared", f"table={temp_key} ({reason})")
@@ -1402,6 +1424,11 @@ class HudMain(QObject):
                 with contextlib.suppress(Exception):
                     close_hud()
             self.hud_dict.pop(temp_key, None)
+            aliases = getattr(self, "_fast_fold_aliases", None)
+            if aliases is not None:
+                for alias, live_key in list(aliases.items()):
+                    if live_key == temp_key:
+                        aliases.pop(alias, None)
 
     def _recheck_window(self, pool: str) -> None:
         """Re-run a table's live update once the client has had time to draw it."""
@@ -1422,6 +1449,12 @@ class HudMain(QObject):
         started = self._ff_started.get(hand_id)
         elapsed = "" if started is None else f" +{(time.monotonic() - started) * 1000:.0f}ms"
         log.warning("FF[%s]%s %s %s", hand_id, elapsed, event, detail)
+
+    def _next_fast_fold_request_id(self) -> int:
+        """Return a process-local id for the next asynchronous seat read."""
+        request_id = int(getattr(self, "_ff_request_sequence", 0)) + 1
+        self._ff_request_sequence = request_id
+        return request_id
 
     def _on_winamax_table_update(self, update: Any) -> None:
         """Apply a live Winamax log update. Runs on the GUI thread."""
@@ -1526,14 +1559,17 @@ class HudMain(QObject):
         if worker is None:
             self._ff_trace(update.hand_id, "stats-skipped", "no database worker")
             return
+        request_id = self._next_fast_fold_request_id()
         self._ff_pending_hand[temp_key] = update.hand_id
-        self._ff_trace(update.hand_id, "stats-requested", f"table={temp_key}")
+        self._ff_pending_request[temp_key] = request_id
+        self._ff_trace(update.hand_id, "stats-requested", f"table={temp_key} request={request_id}")
         worker.submit(
             FastFoldStatsRequest(
                 temp_key=temp_key,
                 seat_map=seat_map,
                 hand_id=self._stats_reference_hand(temp_key),
                 num_seats=getattr(hud, "max", 6) or 6,
+                request_id=request_id,
             ),
         )
 
@@ -1541,18 +1577,25 @@ class HudMain(QObject):
         """A hand to take the gametypeId from when reading live player stats.
 
         This table's own last hand, when it has one. A window that has not had a
-        hand imported yet would otherwise get no gametypeId, the stats aggregate
-        would be skipped, and every seat would read "NA" -- so fall back to
-        another window on the same pool, which plays the same game for the same
-        stakes.
+        hand imported yet may use another window from the same pool, which is
+        still narrower than guessing from the newest global Gametypes row.
         """
         hand_id = self._last_processed_hands.get(temp_key)
         if hand_id is not None:
             return hand_id
 
-        base = re.sub(r"\s+\d+$", "", temp_key)
+        aliases = getattr(self, "_fast_fold_aliases", {})
+        for imported_key, live_key in aliases.items():
+            if live_key == temp_key:
+                hand_id = self._last_processed_hands.get(imported_key)
+                if hand_id is not None:
+                    return hand_id
+
+        clean_key = re.sub(r"\s*#\d+$", "", temp_key)
+        base = re.sub(r"\s+\d+$", "", clean_key)
         for other_key, other_hand in self._last_processed_hands.items():
-            if re.sub(r"\s+\d+$", "", other_key) == base:
+            clean_other = re.sub(r"\s*#\d+$", "", other_key)
+            if re.sub(r"\s+\d+$", "", clean_other) == base:
                 return other_hand
         return None
 
@@ -1617,6 +1660,14 @@ class HudMain(QObject):
     def _on_fast_fold_stats(self, result: FastFoldStatsResult) -> None:
         """Apply stats the worker read for a Fast-Fold table. Runs on the GUI thread."""
         hand_id = self._ff_pending_hand.get(result.temp_key, "?")
+        expected_request = getattr(self, "_ff_pending_request", {}).get(result.temp_key)
+        if expected_request is None or result.request_id != expected_request:
+            self._ff_trace(
+                hand_id,
+                "stats-dropped",
+                f"table={result.temp_key} stale_request={result.request_id} expected={expected_request}",
+            )
+            return
         hud = self.hud_dict.get(result.temp_key)
         if hud is None:
             self._ff_trace(hand_id, "stats-dropped", f"table={result.temp_key} has no HUD any more")
@@ -1711,6 +1762,11 @@ class HudMain(QObject):
             hud.is_fast_fold = True
             return True
 
+        resolved_key = self._resolve_fast_fold_key(temp_key) if temp_key else temp_key
+        if resolved_key and resolved_key != temp_key and resolved_key in self.hud_dict:
+            hud.is_fast_fold = True
+            return True
+
         clean_key = re.sub(r"\s*#\d+$", "", temp_key or "")
         hud_table_name = getattr(hud, "table_name", None) or ""
         clean_hud_name = re.sub(r"\s*#\d+$", "", hud_table_name if isinstance(hud_table_name, str) else "")
@@ -1778,6 +1834,9 @@ class HudMain(QObject):
             temp_key = f"{window.table_name} #{window.window_id}"
         else:
             temp_key = window.table_name
+        aliases = getattr(self, "_fast_fold_aliases", None)
+        if aliases is not None:
+            aliases[window.table_name] = temp_key
         if temp_key in self.hud_dict:
             return temp_key, self.hud_dict[temp_key]
 
@@ -2836,7 +2895,7 @@ class HudMain(QObject):
         start. Passing it through prevents OSXTables from performing a second
         window scan that can disagree with the first one while TCC is changing.
         """
-        if not resolved_window and any(k.startswith(f"{temp_key} #") for k, h in self.hud_dict.items() if getattr(h, "is_fast_fold", False)):
+        if not resolved_window and self._resolve_fast_fold_key(temp_key) != temp_key:
             log.info("Skipping legacy HUD creation for %r: live FastFold HUD is already active", temp_key)
             return
 
@@ -3077,6 +3136,7 @@ class HudMain(QObject):
             # Remembered so the background import path keeps the live composition
             # from the very first hand, before any log update has been matched.
             self._fast_fold_tables.add(temp_key)
+            temp_key = self._resolve_fast_fold_key(temp_key)
         log.debug("Generated temp_key: %s for table: %s", temp_key, table_name)
 
         # Idempotency: skip a hand already processed for this table (duplicate

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1188,7 +1188,7 @@ class HudMain(QObject):
         """Resolve an imported human key to its active window HUD key."""
         aliases = getattr(self, "_fast_fold_aliases", {})
         aliased = aliases.get(temp_key)
-        if aliased in getattr(self, "hud_dict", {}):
+        if isinstance(aliased, str) and aliased in getattr(self, "hud_dict", {}):
             return aliased
         candidates = [
             key
@@ -1499,7 +1499,7 @@ class HudMain(QObject):
 
         last_hand = getattr(hud, "ff_last_hand_id", None)
         if last_hand != update.hand_id:
-            hud.ff_last_hand_id = update.hand_id
+            setattr(hud, "ff_last_hand_id", update.hand_id)
             if getattr(hud, "stat_dict", None) or getattr(hud, "seat_players", None):
                 self._clear_fast_fold_table(temp_key, hud, update.hand_id, "new hand start")
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1981,7 +1981,12 @@ class HudMain(QObject):
 
     def _handle_table_status(self, hud: Hud.Hud) -> None:
         """Handle status changes for a single table."""
-        status = hud.table.check_table()
+        table = getattr(hud, "table", None)
+        if table is None:
+            # Preview and lightweight test HUDs can intentionally omit the
+            # live table object. They must not break the shared status timer.
+            return
+        status = table.check_table()
         if status == "client_destroyed":
             self.client_destroyed(None, hud)
         elif status == "client_moved":

--- a/fpdb_3_legacy/database_hud_stats.py
+++ b/fpdb_3_legacy/database_hud_stats.py
@@ -434,16 +434,6 @@ class DatabaseHudStatsMixin:
         if not player_ids:
             return {}
 
-        if gametype_id is None and hasattr(self, "connection") and self.connection:
-            try:
-                c = self.connection.cursor()
-                c.execute("SELECT id FROM Gametypes ORDER BY id DESC LIMIT 1")
-                r = c.fetchone()
-                if r:
-                    gametype_id = r[0]
-            except Exception:
-                pass
-
         if hud_params is None:
             hud_params = dict(_DEFAULT_HUD_PARAMS)
         # Session stats are read from a different query, one that needs hands on

--- a/fpdb_3_legacy/fast_fold_engine.py
+++ b/fpdb_3_legacy/fast_fold_engine.py
@@ -34,6 +34,9 @@ class FastFoldStatsRequest:
 
     num_seats: int = 6
 
+    request_id: int = 0
+    """Monotonic GUI request id used to discard late worker results."""
+
 
 @dataclass(frozen=True)
 class FastFoldStatsResult:
@@ -42,6 +45,9 @@ class FastFoldStatsResult:
     temp_key: str
     seat_map: dict[int, str] = field(default_factory=dict)
     stat_dict: dict[int, dict[str, Any]] = field(default_factory=dict)
+
+    request_id: int = 0
+    """The request id that produced this result."""
 
 FAST_FOLD_TITLE_PATTERNS = (
     re.compile(r"Go\s*Fast", re.IGNORECASE),

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -360,7 +360,16 @@ class WinamaxAXSeatReader:
         if not is_supported():
             return None
 
+        system = platform.system()
         detected = self._find_table_window_detector(table_no, allow_fallback=False)
+        # The detector is the Windows window-resolution contract. The AX tree
+        # reader below imports AppKit/ApplicationServices and must never be
+        # probed on Windows merely because the shared reader supports both OSes.
+        if system == "Windows":
+            return detected
+        if system != "Darwin":
+            return None
+
         accessible = self._find_table_window_ax(table_no)
         if detected is not None:
             if accessible is not None:
@@ -387,7 +396,7 @@ class WinamaxAXSeatReader:
         return accessible
 
     def _find_table_window_detector(self, table_no: str, *, allow_fallback: bool) -> AXTableWindow | None:
-        """Resolve one indexed Winamax window through the shared macOS detector."""
+        """Resolve one indexed Winamax window through the platform detector."""
         try:
             if self._table_detector is None:
                 from fpdb.infrastructure.platform import get_table_detector

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -527,7 +527,9 @@ class WinamaxAXSeatReader:
                 tx, ty = table_pos
                 best_table = min(
                     tables,
-                    key=lambda t: (t.bounds[0] - tx) ** 2 + (t.bounds[1] - ty) ** 2 if t.bounds else 0,
+                    key=lambda t: (
+                        (t.geometry.x - tx) ** 2 + (t.geometry.y - ty) ** 2 if t.geometry else 0
+                    ),
                 )
                 hwnd = best_table.window_id
             else:

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -720,6 +720,13 @@ def test_check_tables_skipped_during_drag(hud_main) -> None:
         Aux_Base.set_drag_active(False)
 
 
+def test_check_tables_ignores_preview_hud_without_live_table(hud_main) -> None:
+    """Preview/lightweight HUDs must not crash the periodic table poll."""
+    hud_main.hud_dict = {"preview": SimpleNamespace()}
+
+    hud_main.check_tables()
+
+
 # Ensures that create_HUD creates a new HUD and adds it to the hud_dict.
 def test_create_hud(hud_main) -> None:
     with (

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -2435,6 +2435,14 @@ def test_stats_reference_hand_falls_back_to_the_same_pool(hud_main) -> None:
     assert hud_main._stats_reference_hand("Marbella 2") is None
 
 
+def test_stats_reference_hand_resolves_a_window_discriminator_alias(hud_main) -> None:
+    """A live window key can reuse the hand imported under its human key."""
+    hud_main._last_processed_hands = {"Casablanca 6": "hand-99"}
+    hud_main._fast_fold_aliases = {"Casablanca 6": "Casablanca 6 #48782"}
+
+    assert hud_main._stats_reference_hand("Casablanca 6 #48782") == "hand-99"
+
+
 def test_live_stats_read_always_ends_its_transaction() -> None:
     """A SELECT opens a transaction on PostgreSQL; leaving it open stalls the importer."""
     from fpdb_3_legacy.fast_fold_engine import FastFoldStatsRequest
@@ -2847,16 +2855,12 @@ def test_a_read_holding_the_hero_beats_a_bigger_one_without(hud_main) -> None:
     assert hud_main._ax_slots(hud, "hand-1", 6) == {0: "Hero", 2: "b", 3: "c"}
 
 
-def test_read_fast_fold_stats_falls_back_to_recent_gametype() -> None:
-    """When a table has no reference hand yet, _read_fast_fold_stats falls back to recent gametype_id."""
+def test_read_fast_fold_stats_does_not_guess_a_gametype() -> None:
+    """A live table without a reference hand must not borrow a global gametype."""
     from fpdb_3_legacy.fast_fold_engine import FastFoldStatsRequest
 
     db = MagicMock()
     db.get_gameinfo_from_hid.return_value = None
-    cursor = MagicMock()
-    cursor.fetchone.return_value = (42,)
-    db.connection.cursor.return_value = cursor
-
     req = FastFoldStatsRequest(
         temp_key="Winamax Escape 1",
         seat_map={3: "Hero"},
@@ -2869,7 +2873,47 @@ def test_read_fast_fold_stats_falls_back_to_recent_gametype() -> None:
         res = HUD_main.HudReadWorker._read_fast_fold_stats(db, req)
 
     assert res.stat_dict[1]["n"] == 100
-    assert get_stats.call_args.kwargs["gametype_id"] == 42
+    assert get_stats.call_args.kwargs["gametype_id"] is None
+    db.connection.cursor.assert_not_called()
+
+
+def test_late_fast_fold_stats_are_dropped(hud_main) -> None:
+    """A result from an older seat read cannot overwrite the current hand."""
+    from fpdb_3_legacy.fast_fold_engine import FastFoldStatsResult
+
+    hud = SimpleNamespace(stat_dict={}, seat_players={})
+    hud_main.hud_dict = {"Escape 1": hud}
+    hud_main._ff_pending_hand["Escape 1"] = "hand-new"
+    hud_main._ff_pending_request["Escape 1"] = 2
+
+    stale = FastFoldStatsResult(
+        temp_key="Escape 1",
+        seat_map={3: "old-player"},
+        stat_dict={1: {"screen_name": "old-player", "seat": 3, "n": 1}},
+        request_id=1,
+    )
+    with patch.object(HUD_main.FastFoldEngine, "apply_seats") as applied:
+        hud_main._on_fast_fold_stats(stale)
+
+    applied.assert_not_called()
+
+
+def test_clearing_a_fast_fold_table_invalidates_inflight_stats(hud_main) -> None:
+    """Clearing a table must also invalidate a worker result already in flight."""
+    from fpdb_3_legacy.fast_fold_engine import FastFoldStatsResult
+
+    hud = SimpleNamespace(stat_dict={1: {"screen_name": "old"}}, seat_players={1: "old"})
+    hud_main.hud_dict = {"Escape 1": hud}
+    hud_main._fast_fold_pending["Escape 1"] = {3: "old"}
+    hud_main._ff_pending_request["Escape 1"] = 7
+
+    hud_main._clear_fast_fold_table("Escape 1", hud, "hand-old", "new hand")
+    stale = FastFoldStatsResult(temp_key="Escape 1", request_id=7)
+
+    with patch.object(HUD_main.FastFoldEngine, "apply_seats") as applied:
+        hud_main._on_fast_fold_stats(stale)
+
+    applied.assert_not_called()
 
 
 def test_an_import_never_repopulates_a_cleared_fast_fold_table(hud_main) -> None:

--- a/test/test_fast_fold_clockwise_mapping_and_cleanup.py
+++ b/test/test_fast_fold_clockwise_mapping_and_cleanup.py
@@ -23,20 +23,20 @@ def test_clockwise_seat_slots_from_positions():
 
     # Bottom-center hero seat
     hero_seat = AXSeat("hero", 500, 500)
-    # Bottom-right seat
-    br_seat = AXSeat("player_br", 700, 450)
-    # Bottom-left seat
-    bl_seat = AXSeat("player_bl", 300, 450)
+    # Lower-left seat is the next clockwise slot in screen coordinates.
+    lower_right = AXSeat("player_br", 700, 450)
+    # Lower-right seat is the previous clockwise slot.
+    lower_left = AXSeat("player_bl", 300, 450)
 
-    seats = [hero_seat, br_seat, bl_seat]
+    seats = [hero_seat, lower_right, lower_left]
     slots = seat_slots_from_positions(seats, centre, max_seats)
 
     # Hero at bottom-center must be slot 0
     assert slots[0] == "hero"
-    # Clockwise bottom-right seat must be slot 1
-    assert slots[1] == "player_br"
-    # Clockwise bottom-left seat must be slot 5
-    assert slots[5] == "player_bl"
+    # Screen coordinates have a downward Y axis: from the bottom, clockwise
+    # advances toward the lower-left position.
+    assert slots[1] == "player_bl"
+    assert slots[5] == "player_br"
 
 
 def test_show_loading_hud_prevents_duplicate_fast_fold_hud():

--- a/test/test_winamax_ax_seats.py
+++ b/test/test_winamax_ax_seats.py
@@ -294,6 +294,22 @@ class TestFindTableWindow:
 
         assert WinamaxAXSeatReader(detector).find_table_window("4") == from_ax
 
+    def test_windows_resolution_never_probes_the_macos_ax_path(self, monkeypatch) -> None:
+        """Windows table resolution must not import or call AppKit code."""
+        monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+        detector = _Detector(quartz=[self._table("Winamax Colorado 4", 901)])
+        reader = WinamaxAXSeatReader(detector)
+        monkeypatch.setattr(
+            reader,
+            "_find_table_window_ax",
+            lambda _table_no: (_ for _ in ()).throw(AssertionError("macOS AX path called on Windows")),
+        )
+
+        window = reader.find_table_window("4")
+
+        assert window == AXTableWindow("Winamax Colorado 4", "", 901)
+        assert detector.calls == [(r"^Winamax\s+.*\s4\s*$", False)]
+
     def test_nothing_is_attempted_off_macos(self, monkeypatch) -> None:
         monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Linux")
         detector = _Detector(quartz=[self._table("Winamax Colorado 4")])
@@ -409,4 +425,3 @@ def test_read_window_matches_title_by_table_number(monkeypatch) -> None:
     slots = reader.read_window("Winamax Casablanca 6 #1234", 6)
     assert 0 in slots
     assert slots[0] == "Hero"
-

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -33,3 +33,26 @@ def test_winamax_ax_seat_reader_finds_window_on_windows():
         assert window.title == "Winamax Colorado 3"
         assert window.window_id == 123456
         assert window.table_name == "Colorado 3"
+
+
+def test_windows_seat_read_selects_the_closest_duplicate_title(monkeypatch):
+    """UIAutomation must read the window paired by geometry, not first match."""
+    from types import SimpleNamespace
+
+    reader = winamax_ax_seats.WinamaxAXSeatReader(
+        table_detector=MagicMock(
+            find_tables=lambda _pattern: [
+                SimpleNamespace(window_id=101, bounds=(0, 0, 800, 600)),
+                SimpleNamespace(window_id=202, bounds=(1200, 0, 800, 600)),
+            ]
+        )
+    )
+    read = MagicMock(return_value={0: "Hero"})
+    monkeypatch.setattr(reader, "_read_window_windows", read)
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "is_ax_available", lambda: True)
+
+    slots = reader.read_window("Winamax Colorado 3", table_pos=(1200, 0))
+
+    assert slots == {0: "Hero"}
+    read.assert_called_once_with(202, 6)

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -15,8 +15,9 @@ def test_is_supported_returns_true_on_windows_and_darwin():
         assert winamax_ax_seats.is_supported() is True
 
 
-def test_winamax_ax_seat_reader_finds_window_on_windows():
+def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
     """Verify that WinamaxAXSeatReader resolves table window on Windows."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     mock_table = TableInfo(
         window_id=123456,
         title="Winamax Colorado 3",

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from fpdb.infrastructure.platform.protocol import TableInfo
+from fpdb.infrastructure.platform.protocol import TableGeometry, TableInfo
 from fpdb_3_legacy import winamax_ax_seats
 
 
@@ -38,13 +38,19 @@ def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
 
 def test_windows_seat_read_selects_the_closest_duplicate_title(monkeypatch):
     """UIAutomation must read the window paired by geometry, not first match."""
-    from types import SimpleNamespace
-
     reader = winamax_ax_seats.WinamaxAXSeatReader(
         table_detector=MagicMock(
             find_tables=lambda _pattern: [
-                SimpleNamespace(window_id=101, bounds=(0, 0, 800, 600)),
-                SimpleNamespace(window_id=202, bounds=(1200, 0, 800, 600)),
+                TableInfo(
+                    window_id=101,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=0, y=0, width=800, height=600),
+                ),
+                TableInfo(
+                    window_id=202,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=1200, y=0, width=800, height=600),
+                ),
             ]
         )
     )


### PR DESCRIPTION
## What changed

- Add monotonic request IDs to FastHUD stats requests and results.
- Drop late worker results after a newer request or table cleanup.
- Preserve explicit table/window aliases when resolving imported hands.
- Remove the global latest-gametype fallback from HUD statistics reads.

## Why

The Windows support changes exposed races where stale asynchronous results or an unrelated gametype could repopulate a macOS FastHUD with incorrect data.

## Validation

- `pytest -q -m qt test/test_HUD_main.py`
- `ruff check` on all modified Python files
