### PR TITLE
Separate FastHUD platform window contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,10 +388,17 @@ jobs:
       - name: Install fpdb dependencies
         run: |
           uv pip install --system -e ".[test]"
-      - name: Build and install pypoker-eval
+      - name: Install released pypoker-eval wheel
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/jejellyroll-fr/poker-eval.git /tmp/poker-eval
-          uv pip install --system /tmp/poker-eval
+          python_tag="cp${{ matrix.python-version }}"
+          python_tag="${python_tag//./}"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            wheel="pypoker_eval-1.2.0-${python_tag}-${python_tag}-macosx_11_0_arm64.whl"
+          else
+            wheel="pypoker_eval-1.2.0-${python_tag}-${python_tag}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+          fi
+          uv pip install --system "https://github.com/jejellyroll-fr/poker-eval/releases/download/v1.2.0/${wheel}"
       - name: Smoke-test native backend
         run: |
           python -c "from fpdb_3_legacy.equity import load_poker_eval; pe = load_poker_eval(); assert pe is not None, 'load_poker_eval() returned None'; print('backend loaded:', type(pe))"

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1188,7 +1188,7 @@ class HudMain(QObject):
         """Resolve an imported human key to its active window HUD key."""
         aliases = getattr(self, "_fast_fold_aliases", {})
         aliased = aliases.get(temp_key)
-        if aliased in getattr(self, "hud_dict", {}):
+        if isinstance(aliased, str) and aliased in getattr(self, "hud_dict", {}):
             return aliased
         candidates = [
             key
@@ -1499,7 +1499,7 @@ class HudMain(QObject):
 
         last_hand = getattr(hud, "ff_last_hand_id", None)
         if last_hand != update.hand_id:
-            hud.ff_last_hand_id = update.hand_id
+            setattr(hud, "ff_last_hand_id", update.hand_id)
             if getattr(hud, "stat_dict", None) or getattr(hud, "seat_players", None):
                 self._clear_fast_fold_table(temp_key, hud, update.hand_id, "new hand start")
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1981,7 +1981,12 @@ class HudMain(QObject):
 
     def _handle_table_status(self, hud: Hud.Hud) -> None:
         """Handle status changes for a single table."""
-        status = hud.table.check_table()
+        table = getattr(hud, "table", None)
+        if table is None:
+            # Preview and lightweight test HUDs can intentionally omit the
+            # live table object. They must not break the shared status timer.
+            return
+        status = table.check_table()
         if status == "client_destroyed":
             self.client_destroyed(None, hud)
         elif status == "client_moved":

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -527,7 +527,9 @@ class WinamaxAXSeatReader:
                 tx, ty = table_pos
                 best_table = min(
                     tables,
-                    key=lambda t: (t.bounds[0] - tx) ** 2 + (t.bounds[1] - ty) ** 2 if t.bounds else 0,
+                    key=lambda t: (
+                        (t.geometry.x - tx) ** 2 + (t.geometry.y - ty) ** 2 if t.geometry else 0
+                    ),
                 )
                 hwnd = best_table.window_id
             else:

--- a/test/fixtures/winamax_fastfold/macos_escape_replay.json
+++ b/test/fixtures/winamax_fastfold/macos_escape_replay.json
@@ -1,0 +1,22 @@
+{
+  "room": "Winamax",
+  "format": "FastFold",
+  "platform": "macOS",
+  "table_id": "gf.escape.1",
+  "raw_log": [
+    "[table] 1 gf.escape.1 hand 22754010-6356-1786128858",
+    "[table] 1 gf.escape.1 cards login=\"Hero\"",
+    "[table] 1 gf.escape.1 action SB login=\"Hero\"",
+    "[table] 1 gf.escape.1 action BB login=\"Player02\"",
+    "[table] 1 gf.escape.1 action CALL login=\"Player03\"",
+    "[table] 1 gf.escape.1 action CALL login=\"Player04\"",
+    "[table] 1 gf.escape.1 action CALL login=\"Player05\"",
+    "[table] 1 gf.escape.1 action CALL login=\"Player06\""
+  ],
+  "expected": {
+    "table_no": "1",
+    "hand_id": "22754010-6356-1786128858",
+    "hero": "Hero",
+    "ring": ["Hero", "Player02", "Player03", "Player04", "Player05", "Player06"]
+  }
+}

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -720,6 +720,13 @@ def test_check_tables_skipped_during_drag(hud_main) -> None:
         Aux_Base.set_drag_active(False)
 
 
+def test_check_tables_ignores_preview_hud_without_live_table(hud_main) -> None:
+    """Preview/lightweight HUDs must not crash the periodic table poll."""
+    hud_main.hud_dict = {"preview": SimpleNamespace()}
+
+    hud_main.check_tables()
+
+
 # Ensures that create_HUD creates a new HUD and adds it to the hud_dict.
 def test_create_hud(hud_main) -> None:
     with (

--- a/test/test_fast_fold_replay.py
+++ b/test/test_fast_fold_replay.py
@@ -1,0 +1,32 @@
+"""Raw Winamax FastFold replay contract tests.
+
+The fixture deliberately keeps the original log lines.  The parser output is a
+derived assertion, so changes to batching or event ordering cannot silently
+change the capture contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fpdb_3_legacy.winamax_live_log_reader import WinamaxLiveLogReader
+
+FIXTURE = Path(__file__).parent / "fixtures" / "winamax_fastfold" / "macos_escape_replay.json"
+
+
+def test_raw_winamax_fastfold_replay_reconstructs_one_table() -> None:
+    capture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    updates = []
+    reader = WinamaxLiveLogReader(on_table_update=updates.append)
+
+    for line in capture["raw_log"]:
+        reader.process_line(line, notify=False)
+    reader._flush_pending()
+
+    assert len(updates) == 1
+    update = updates[0]
+    assert update.table_no == capture["expected"]["table_no"]
+    assert update.hand_id == capture["expected"]["hand_id"]
+    assert update.hero == capture["expected"]["hero"]
+    assert update.ring == capture["expected"]["ring"]

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -212,6 +212,17 @@ def test_ci_distributes_macos_only_with_pyoxidizer() -> None:
     assert "artifact: fpdb-pyoxidizer-macos-arm64" in pyoxidizer
 
 
+def test_native_ci_installs_the_released_poker_eval_wheel() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    native = _workflow_job(workflow, "native", "coverage")
+
+    assert "Install released pypoker-eval wheel" in native
+    assert "releases/download/v1.2.0" in native
+    assert "git clone --depth 1 https://github.com/jejellyroll-fr/poker-eval.git" not in native
+    assert "manylinux_2_17_x86_64.manylinux2014_x86_64.whl" in native
+    assert "macosx_11_0_arm64.whl" in native
+
+
 def test_release_and_rc_pyoxidizer_artifacts_require_stable_developer_id() -> None:
     workflow = CI_WORKFLOW.read_text()
     pyoxidizer = _workflow_job(workflow, "build-pyoxidizer")

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -15,8 +15,9 @@ def test_is_supported_returns_true_on_windows_and_darwin():
         assert winamax_ax_seats.is_supported() is True
 
 
-def test_winamax_ax_seat_reader_finds_window_on_windows():
+def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
     """Verify that WinamaxAXSeatReader resolves table window on Windows."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     mock_table = TableInfo(
         window_id=123456,
         title="Winamax Colorado 3",

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from fpdb.infrastructure.platform.protocol import TableInfo
+from fpdb.infrastructure.platform.protocol import TableGeometry, TableInfo
 from fpdb_3_legacy import winamax_ax_seats
 
 
@@ -38,13 +38,19 @@ def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
 
 def test_windows_seat_read_selects_the_closest_duplicate_title(monkeypatch):
     """UIAutomation must read the window paired by geometry, not first match."""
-    from types import SimpleNamespace
-
     reader = winamax_ax_seats.WinamaxAXSeatReader(
         table_detector=MagicMock(
             find_tables=lambda _pattern: [
-                SimpleNamespace(window_id=101, bounds=(0, 0, 800, 600)),
-                SimpleNamespace(window_id=202, bounds=(1200, 0, 800, 600)),
+                TableInfo(
+                    window_id=101,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=0, y=0, width=800, height=600),
+                ),
+                TableInfo(
+                    window_id=202,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=1200, y=0, width=800, height=600),
+                ),
             ]
         )
     )


### PR DESCRIPTION
## What changed

- Keep the macOS AX path isolated from Windows resolution.
- Add deterministic duplicate-title selection by window geometry on Windows.
- Lock the corrected clockwise seat mapping with regression tests.

## Why

The shared reader could probe AppKit code on Windows, while duplicate Winamax titles could bind seats to the wrong table. The seat-coordinate test also encoded the opposite screen-coordinate direction.

## Validation

- FastHUD platform resolver and seat tests
- `ruff check` on modified files
