### PR TITLE
Run FastHUD contracts across platforms

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1188,7 +1188,7 @@ class HudMain(QObject):
         """Resolve an imported human key to its active window HUD key."""
         aliases = getattr(self, "_fast_fold_aliases", {})
         aliased = aliases.get(temp_key)
-        if aliased in getattr(self, "hud_dict", {}):
+        if isinstance(aliased, str) and aliased in getattr(self, "hud_dict", {}):
             return aliased
         candidates = [
             key
@@ -1499,7 +1499,7 @@ class HudMain(QObject):
 
         last_hand = getattr(hud, "ff_last_hand_id", None)
         if last_hand != update.hand_id:
-            hud.ff_last_hand_id = update.hand_id
+            setattr(hud, "ff_last_hand_id", update.hand_id)
             if getattr(hud, "stat_dict", None) or getattr(hud, "seat_players", None):
                 self._clear_fast_fold_table(temp_key, hud, update.hand_id, "new hand start")
 

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1981,7 +1981,12 @@ class HudMain(QObject):
 
     def _handle_table_status(self, hud: Hud.Hud) -> None:
         """Handle status changes for a single table."""
-        status = hud.table.check_table()
+        table = getattr(hud, "table", None)
+        if table is None:
+            # Preview and lightweight test HUDs can intentionally omit the
+            # live table object. They must not break the shared status timer.
+            return
+        status = table.check_table()
         if status == "client_destroyed":
             self.client_destroyed(None, hud)
         elif status == "client_moved":

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -527,7 +527,9 @@ class WinamaxAXSeatReader:
                 tx, ty = table_pos
                 best_table = min(
                     tables,
-                    key=lambda t: (t.bounds[0] - tx) ** 2 + (t.bounds[1] - ty) ** 2 if t.bounds else 0,
+                    key=lambda t: (
+                        (t.geometry.x - tx) ** 2 + (t.geometry.y - ty) ** 2 if t.geometry else 0
+                    ),
                 )
                 hwnd = best_table.window_id
             else:

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -720,6 +720,13 @@ def test_check_tables_skipped_during_drag(hud_main) -> None:
         Aux_Base.set_drag_active(False)
 
 
+def test_check_tables_ignores_preview_hud_without_live_table(hud_main) -> None:
+    """Preview/lightweight HUDs must not crash the periodic table poll."""
+    hud_main.hud_dict = {"preview": SimpleNamespace()}
+
+    hud_main.check_tables()
+
+
 # Ensures that create_HUD creates a new HUD and adds it to the hud_dict.
 def test_create_hud(hud_main) -> None:
     with (

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -15,8 +15,9 @@ def test_is_supported_returns_true_on_windows_and_darwin():
         assert winamax_ax_seats.is_supported() is True
 
 
-def test_winamax_ax_seat_reader_finds_window_on_windows():
+def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
     """Verify that WinamaxAXSeatReader resolves table window on Windows."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     mock_table = TableInfo(
         window_id=123456,
         title="Winamax Colorado 3",

--- a/test/test_windows_fast_fold_resolver.py
+++ b/test/test_windows_fast_fold_resolver.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from fpdb.infrastructure.platform.protocol import TableInfo
+from fpdb.infrastructure.platform.protocol import TableGeometry, TableInfo
 from fpdb_3_legacy import winamax_ax_seats
 
 
@@ -38,13 +38,19 @@ def test_winamax_ax_seat_reader_finds_window_on_windows(monkeypatch):
 
 def test_windows_seat_read_selects_the_closest_duplicate_title(monkeypatch):
     """UIAutomation must read the window paired by geometry, not first match."""
-    from types import SimpleNamespace
-
     reader = winamax_ax_seats.WinamaxAXSeatReader(
         table_detector=MagicMock(
             find_tables=lambda _pattern: [
-                SimpleNamespace(window_id=101, bounds=(0, 0, 800, 600)),
-                SimpleNamespace(window_id=202, bounds=(1200, 0, 800, 600)),
+                TableInfo(
+                    window_id=101,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=0, y=0, width=800, height=600),
+                ),
+                TableInfo(
+                    window_id=202,
+                    title="Winamax Colorado 3",
+                    geometry=TableGeometry(x=1200, y=0, width=800, height=600),
+                ),
             ]
         )
     )


### PR DESCRIPTION
## What changed

- Run deterministic FastHUD platform contracts on every CI runner.
- Run the Qt HUD regression suite in the same platform-contract job.

## Why

Previously, the relevant Qt and platform behavior was not consistently exercised on macOS and Windows, allowing OS-specific regressions to pass unnoticed.

## Validation

- CI invokes the replay, resolver, seat, engine, and HUD contract suites.
- Local targeted FastHUD and Qt suites are green.
