### PR TITLE
Fix ad-hoc macOS release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,7 @@ jobs:
           # This module is intentionally absent from the pre-sign smoke list.
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.winamax_ax_seats
           codesign --verify --deep --strict dist/fpdb.app
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "${{ github.event_name }}" == "release" && "$FPDB_REQUIRE_STABLE_MACOS_SIGNING" == "1" ]]; then
             codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
             codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
             codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -231,6 +231,10 @@ def test_release_and_rc_pyoxidizer_artifacts_require_stable_developer_id() -> No
     # well as final releases, so this is the shared distribution gate.
     assert "release:\n    types: [ published ]" in workflow
     assert "FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && '1' || '0' }}" in pyoxidizer
+    assert (
+        'if [[ "${{ github.event_name }}" == "release" && "$FPDB_REQUIRE_STABLE_MACOS_SIGNING" == "1" ]]; then'
+        in pyoxidizer
+    )
     assert '"Developer ID Application: "*' in pyoxidizer
     assert 'grep -Fqx "Authority=$FPDB_MACOS_SIGNING_IDENTITY"' in pyoxidizer
     assert 'grep -Fqx "TeamIdentifier=$expected_team_id"' in pyoxidizer


### PR DESCRIPTION
## Cause

Le workflow de release accepte une signature macOS ad hoc lorsque `MACOS_SIGNING_IDENTITY` n’est pas configuré, mais exécutait ensuite les validations Team ID réservées à une identité Developer ID. Le build `v3.6.5` échouait donc dans `Assemble PyOxidizer macOS application`.

## Correction

- exécuter les validations Developer ID uniquement lorsque `FPDB_REQUIRE_STABLE_MACOS_SIGNING == 1`
- ajouter un test statique qui verrouille ce garde-fou

## Validation locale

- `test/test_macos_packaging.py`: 21 tests réussis
- Ruff réussi
- `git diff --check` réussi