### PR TITLE
Fix macOS release validation for v3.6.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,7 @@ jobs:
           # This module is intentionally absent from the pre-sign smoke list.
           dist/fpdb.app/Contents/MacOS/fpdb --run-module fpdb_3_legacy.winamax_ax_seats
           codesign --verify --deep --strict dist/fpdb.app
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "${{ github.event_name }}" == "release" && "$FPDB_REQUIRE_STABLE_MACOS_SIGNING" == "1" ]]; then
             codesign -dv --verbose=4 dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-signature.txt"
             codesign -dr - dist/fpdb.app 2> "$RUNNER_TEMP/fpdb-requirement.txt"
             codesign -d --entitlements :- dist/fpdb.app > "$RUNNER_TEMP/fpdb-entitlements.plist" 2>/dev/null

--- a/test/test_macos_packaging.py
+++ b/test/test_macos_packaging.py
@@ -231,6 +231,10 @@ def test_release_and_rc_pyoxidizer_artifacts_require_stable_developer_id() -> No
     # well as final releases, so this is the shared distribution gate.
     assert "release:\n    types: [ published ]" in workflow
     assert "FPDB_REQUIRE_STABLE_MACOS_SIGNING: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && '1' || '0' }}" in pyoxidizer
+    assert (
+        'if [[ "${{ github.event_name }}" == "release" && "$FPDB_REQUIRE_STABLE_MACOS_SIGNING" == "1" ]]; then'
+        in pyoxidizer
+    )
     assert '"Developer ID Application: "*' in pyoxidizer
     assert 'grep -Fqx "Authority=$FPDB_MACOS_SIGNING_IDENTITY"' in pyoxidizer
     assert 'grep -Fqx "TeamIdentifier=$expected_team_id"' in pyoxidizer


### PR DESCRIPTION
## Résumé

- fusionne la correction validée de `development` dans `main`
- permet les releases macOS signées ad hoc lorsque les secrets Developer ID ne sont pas configurés
- conserve les validations Team ID et notarisation lorsque la signature stable est activée
- ajoute un test de non-régression du workflow

## Validation de #243

- 20 checks réussis, 0 échec
- Codacy : 0 issue
- revue Codex : aucun problème majeur
- test macOS packaging local : 21 réussis

Cette PR ne doit être mergée qu’après réussite complète de ses propres checks.