### PR TITLE
Fix Winamax splash pot parsing

### DIFF
--- a/fpdb_3_legacy/WinamaxToFpdb.py
+++ b/fpdb_3_legacy/WinamaxToFpdb.py
@@ -1233,11 +1233,23 @@ class Winamax(HandHistoryConverter):
             # Winamax does not identify the splash component on collection lines.
             # Allocate it pro rata for split pots; for a single winner this is the
             # exact amount dropped by the room.
-            splash = Decimal(splash_pot) / 100
+            splash_cents = int(splash_pot)
             total_collected = Decimal(total_collected)
+            shares = []
+            allocated_cents = 0
+            for player, amount in hand.collectees.items():
+                exact_cents = Decimal(splash_cents) * amount / total_collected
+                cents = int(exact_cents)
+                shares.append((player, cents, exact_cents - cents))
+                allocated_cents += cents
+
+            # Distribute the leftover cents by largest remainder so persisted
+            # per-player values still add up to the room's splash amount.
+            remainder = splash_cents - allocated_cents
+            shares.sort(key=lambda share: share[2], reverse=True)
             hand.splashWinnings = {
-                player: splash * amount / total_collected
-                for player, amount in hand.collectees.items()
+                player: Decimal(cents + (index < remainder)) / 100
+                for index, (player, cents, _) in enumerate(shares)
             }
 
     def readShownCards(self, hand: Hand) -> None:

--- a/fpdb_3_legacy/WinamaxToFpdb.py
+++ b/fpdb_3_legacy/WinamaxToFpdb.py
@@ -153,11 +153,11 @@ class Winamax(HandHistoryConverter):
     )
     re_mixed = re.compile(r"_(?P<MIXED>10games|8games|horse)_")
     re_hutp = re.compile(
-        r"(?:Hold\-?up|Escape|Splash|Drop)(?:\s+(?:to|pot))*\s*:\s*(?:total\s*)?({LS})?(?P<AMOUNT>[.0-9]+)({LS})?".format(**substitutions),
+        r"Hold\-?up(?:\s+(?:to|pot))*\s*:\s*(?:total\s*)?({LS})?(?P<AMOUNT>[.0-9]+)({LS})?".format(**substitutions),
         re.IGNORECASE | re.MULTILINE | re.VERBOSE,
     )
     re_escape_pot = re.compile(
-        r"(?:Escape|Splash|Drop|Hold\-?up)(?:\s+(?:to|pot))*\s*:\s*(?:total\s*)?({LS})?(?P<AMOUNT>[.0-9]+)({LS})?".format(**substitutions),
+        r"(?:Escape|Splash|Drop)(?:\s+(?:to|pot))*\s*:\s*(?:total\s*)?({LS})?(?P<AMOUNT>[.0-9]+)({LS})?".format(**substitutions),
         re.IGNORECASE | re.MULTILINE | re.VERBOSE,
     )
     # 2010/09/21 03:10:51 UTC
@@ -896,7 +896,7 @@ class Winamax(HandHistoryConverter):
             hand.bombPot = int(Decimal(m.group("AMOUNT")) * 100)
         elif m := self.re_escape_pot.search(hand.handText):
             hand.addSTP(m.group("AMOUNT"))
-            hand.bombPot = int(Decimal(m.group("AMOUNT")) * 100)
+            hand.splashPot = int(Decimal(m.group("AMOUNT")) * 100)
 
     def readHoleCards(self, hand: Hand) -> None:
         """Read and parse hole cards for all players from hand history.
@@ -1226,6 +1226,19 @@ class Winamax(HandHistoryConverter):
         """
         for m in self.re_collect_pot.finditer(hand.handText):
             hand.addCollectPot(player=m.group("PNAME"), pot=m.group("POT"))
+
+        splash_pot = getattr(hand, "splashPot", 0)
+        total_collected = getattr(hand, "totalcollected", 0)
+        if isinstance(splash_pot, (int, Decimal)) and isinstance(total_collected, (int, Decimal)) and splash_pot and total_collected:
+            # Winamax does not identify the splash component on collection lines.
+            # Allocate it pro rata for split pots; for a single winner this is the
+            # exact amount dropped by the room.
+            splash = Decimal(splash_pot) / 100
+            total_collected = Decimal(total_collected)
+            hand.splashWinnings = {
+                player: splash * amount / total_collected
+                for player, amount in hand.collectees.items()
+            }
 
     def readShownCards(self, hand: Hand) -> None:
         """Parses and processes all shown cards in the hand.

--- a/test/test_winamax_complete.py
+++ b/test/test_winamax_complete.py
@@ -247,6 +247,25 @@ class TestWinamaxComplete(unittest.TestCase):
         self.parser.readCollectPot(hand)
         assert hand.splashWinnings == {"Hero": Decimal("0.20")}
 
+    def test_read_collect_pot_preserves_splash_cents_when_split(self) -> None:
+        """Split splash winnings are rounded to cents without losing value."""
+        hand = Mock()
+        hand.handText = "Alice collected 1.00€\nBob collected 1.00€\nCarol collected 1.00€"
+        hand.splashPot = 20
+        hand.totalcollected = Decimal("3.00")
+        hand.collectees = {
+            "Alice": Decimal("1.00"),
+            "Bob": Decimal("1.00"),
+            "Carol": Decimal("1.00"),
+        }
+        hand.players = [[1, "Alice", Decimal("1.00")], [2, "Bob", Decimal("1.00")], [3, "Carol", Decimal("1.00")]]
+        hand.gametype = {"currency": "EUR"}
+        self.parser.compilePlayerRegexs(hand)
+        self.parser.readCollectPot(hand)
+
+        assert sum(hand.splashWinnings.values()) == Decimal("0.20")
+        assert sorted(hand.splashWinnings.values()) == [Decimal("0.06"), Decimal("0.07"), Decimal("0.07")]
+
     def test_read_antes_method(self) -> None:
         """Test readAntes method with stud games."""
         mock_hand = Mock()

--- a/test/test_winamax_complete.py
+++ b/test/test_winamax_complete.py
@@ -218,6 +218,35 @@ class TestWinamaxComplete(unittest.TestCase):
         mock_hand.handText = "Hand with escape pot information"
         self.parser.readSTP(mock_hand)
 
+    def test_read_stp_distinguishes_bomb_and_splash_pots(self) -> None:
+        """Hold-up is a bomb pot; Escape/Splash/Drop are splash pots."""
+        bomb_hand = Mock()
+        bomb_hand.handText = "Hold-up to Pot: total 0.20€"
+        bomb_hand.splashPot = 0
+        self.parser.readSTP(bomb_hand)
+        assert bomb_hand.bombPot == 20
+        assert bomb_hand.splashPot == 0
+
+        splash_hand = Mock()
+        splash_hand.handText = "Escape: total 0.20€"
+        splash_hand.bombPot = 0
+        self.parser.readSTP(splash_hand)
+        assert splash_hand.splashPot == 20
+        assert splash_hand.bombPot == 0
+
+    def test_read_collect_pot_attributes_splash_winnings(self) -> None:
+        """A sole winner receives the full splash amount."""
+        hand = Mock()
+        hand.handText = "Hero collected 1.20€"
+        hand.splashPot = 20
+        hand.totalcollected = Decimal("1.20")
+        hand.collectees = {"Hero": Decimal("1.20")}
+        hand.players = [[1, "Hero", Decimal("1.20")]]
+        hand.gametype = {"currency": "EUR"}
+        self.parser.compilePlayerRegexs(hand)
+        self.parser.readCollectPot(hand)
+        assert hand.splashWinnings == {"Hero": Decimal("0.20")}
+
     def test_read_antes_method(self) -> None:
         """Test readAntes method with stud games."""
         mock_hand = Mock()

--- a/test/test_winamax_isolated.py
+++ b/test/test_winamax_isolated.py
@@ -228,9 +228,11 @@ class TestWinamaxIsolated(unittest.TestCase):
         ]:
             hand = Mock()
             hand.handText = text
+            hand.bombPot = 0
             self.parser.readSTP(hand)
             hand.addSTP.assert_called()
-            assert hand.bombPot in (250, 500, 1000)
+            assert hand.splashPot in (250, 500, 1000)
+            assert hand.bombPot == 0
 
     def test_detect_lottery_tournaments(self) -> None:
         """Test _detect_lottery_tournaments method."""


### PR DESCRIPTION
## Summary

- Separate Winamax `Hold-up` bomb pots from `Escape`/`Splash`/`Drop` splash pots.
- Persist the splash amount in `Hands.splashPot`.
- Attribute collected splash money to winners, including proportional allocation for split pots.
- Add regression coverage for parser routing and splash winnings.

## Validation

- `pytest -q test/test_winamax_complete.py test/test_winamax.py test/test_winamax_isolated.py test/test_winamax_parser.py test/test_winamax_robust.py test/test_winamax_parser_errors.py test/test_winamax_parser_comprehensive.py` (125 passed)
- `ruff check` on changed Python files
- `git diff --check`

Fixes #246
Unblocks #247
Unblocks #248