### PR TITLE
fix(validate-migration): make the import checks able to fail

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -14,8 +14,19 @@
 # other Codacy tool keeps analysing them. This mirrors a choice the repository
 # had already made -- pyproject.toml selects ruff rule groups C901, E, F, I,
 # PLR0912, PLR0915, UP and W, deliberately leaving out S (flake8-bandit).
+#
+# The same reasoning covers the migration check scripts. They are test scripts
+# by content -- they assert and report -- but they live in the package
+# directory rather than under test/, so the two globs above never reached them
+# and four added assertions failed the gate on #252. Listed by name rather than
+# with a `fpdb_3_legacy/test_*` glob so that a future production module cannot
+# drift out of analysis by being named after a test.
 engines:
   bandit:
     exclude_paths:
       - "test/**"
       - "tests/**"
+      - "fpdb_3_legacy/validate_migration.py"
+      - "fpdb_3_legacy/test_migration.py"
+      - "fpdb_3_legacy/test_feature_1_1.py"
+      - "fpdb_3_legacy/test_partypoker_fix.py"

--- a/fpdb_3_legacy/test_feature_1_1.py
+++ b/fpdb_3_legacy/test_feature_1_1.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-from __future__ import annotations
+"""Test de la Feature 1.1: Migration Stack Technique Moderne.
 
-"""Test de la Feature 1.1: Migration Stack Technique Moderne"""
+Les vérifications renvoyaient ``True``/``False`` et ``main()`` jetait ce
+résultat : le script annonçait « SUCCÈS: Tous les tests passés » quel que soit
+l'état des dépendances. Un contrôle dont le verdict est ignoré ne contrôle
+rien, d'où la séparation explicite ci-dessous entre requis et optionnel.
+"""
+
+from __future__ import annotations
 
 import sys
 from pathlib import Path
@@ -49,70 +55,54 @@ def test_numpy_2x_array_methods():
     print("✅ Tous les tests NumPy 2.x passés!\n")
 
 
+def test_pyqtgraph():
+    """Test que PyQtGraph, moteur de rendu des graphiques, est utilisable.
+
+    Ajouté parce qu'il ne l'était pas : c'est la bibliothèque qui dessine tous
+    les graphiques depuis #228, et la seule dépendance critique que rien ne
+    vérifiait.
+    """
+    print("Test PyQtGraph...")
+
+    import pyqtgraph as pg
+
+    version = pg.__version__
+    major_minor = tuple(map(int, version.split(".")[:2]))
+
+    assert major_minor >= (0, 13), f"pyqtgraph 0.13+ requis, trouvé {version}"
+    assert hasattr(pg, "PlotWidget"), "pyqtgraph.PlotWidget introuvable"
+    print(f"  ✓ pyqtgraph version: {version}")
+    print("✅ PyQtGraph confirmé!\n")
+
+
 def test_sqlalchemy_2x():
-    """Test que SQLAlchemy 2.x est installé"""
-    print("Test SQLAlchemy 2.x...")
+    """Test que SQLAlchemy, s'il est présent, est en 2.x.
+
+    Dépendance optionnelle : ``Database.py`` la sonde derrière un
+    ``try``/``except`` et n'est déclarée dans aucune section de
+    ``pyproject.toml``. Une absence -- ou une version trop ancienne -- est
+    signalée, jamais fatale.
+
+    Returns:
+        True si utilisable, False sinon. Le verdict est repris par ``main()``.
+    """
+    print("Test SQLAlchemy 2.x (optionnel)...")
 
     try:
         import sqlalchemy
-
-        version = sqlalchemy.__version__
-        major = int(version.split(".")[0])
-
-        assert major >= 2, f"SQLAlchemy 2.0+ requis, trouvé {version}"
-        print(f"  ✓ SQLAlchemy version: {version}")
-        print("✅ SQLAlchemy 2.x confirmé!\n")
-        return True
     except ImportError:
-        print("  ⚠ SQLAlchemy non installé (optionnel)")
+        print("  ⚠ SQLAlchemy non installé (optionnel)\n")
         return False
 
-
-def test_matplotlib_3_10():
-    """Test que matplotlib 3.10+ est installé"""
-    print("Test matplotlib 3.10+...")
-
-    try:
-        import matplotlib
-
-        version = matplotlib.__version__
-        major_minor = tuple(map(int, version.split(".")[:2]))
-
-        assert major_minor >= (3, 10), f"matplotlib 3.10+ requis, trouvé {version}"
-        print(f"  ✓ matplotlib version: {version}")
-        print("✅ matplotlib 3.10+ confirmé!\n")
-        return True
-    except ImportError:
-        print("  ⚠ matplotlib non installé")
+    version = sqlalchemy.__version__
+    major = int(version.split(".")[0])
+    if major < 2:
+        print(f"  ⚠ SQLAlchemy 2.0+ attendu, trouvé {version} (optionnel)\n")
         return False
 
-
-def test_fastapi_pydantic():
-    """Test que FastAPI et Pydantic sont à jour"""
-    print("Test FastAPI et Pydantic...")
-
-    try:
-        import fastapi
-        import pydantic
-
-        fastapi_version = fastapi.__version__
-        pydantic_version = pydantic.__version__
-
-        # FastAPI >= 0.121.1
-        fastapi_parts = tuple(map(int, fastapi_version.split(".")[:3]))
-        assert fastapi_parts >= (0, 121, 1), f"FastAPI 0.121.1+ requis, trouvé {fastapi_version}"
-
-        # Pydantic >= 2.12.1
-        pydantic_major = int(pydantic_version.split(".")[0])
-        assert pydantic_major >= 2, f"Pydantic 2.x requis, trouvé {pydantic_version}"
-
-        print(f"  ✓ FastAPI version: {fastapi_version}")
-        print(f"  ✓ Pydantic version: {pydantic_version}")
-        print("✅ FastAPI et Pydantic à jour!\n")
-        return True
-    except ImportError:
-        print("  ⚠ FastAPI/Pydantic non installés (optionnels)")
-        return False
+    print(f"  ✓ SQLAlchemy version: {version}")
+    print("✅ SQLAlchemy 2.x confirmé!\n")
+    return True
 
 
 def test_code_modifications():
@@ -138,8 +128,11 @@ def test_code_modifications():
     with open(LEGACY_DIR / "GuiSessionViewer.py") as f:
         content = f.read()
 
-    # Ne devrait plus avoir "from numpy import append, cumsum, diff, nonzero"
-    assert "from numpy import append" not in content or "import numpy as np" in content
+    # Ne devrait plus avoir "from numpy import append, cumsum, diff, nonzero".
+    # L'ancienne forme "A not in content or B in content" était satisfaite dès
+    # que le module importait numpy, donc n'interdisait rien.
+    assert "from numpy import append" not in content, "GuiSessionViewer.py: 'from numpy import append' encore présent"
+    assert "import numpy as np" in content, "GuiSessionViewer.py: 'import numpy as np' manquant"
     assert ".cumsum()" in content, "GuiSessionViewer.py: '.cumsum()' manquant"
     assert "np.diff" in content, "GuiSessionViewer.py: 'np.diff' manquant"
 
@@ -165,11 +158,13 @@ def main():
     print()
 
     try:
+        # Requis : une défaillance lève une AssertionError, reprise plus bas.
         test_numpy_2x_array_methods()
-        test_sqlalchemy_2x()
-        test_matplotlib_3_10()
-        test_fastapi_pydantic()
+        test_pyqtgraph()
         test_code_modifications()
+
+        # Optionnel : le verdict est rapporté, pas jeté.
+        sqlalchemy_ok = test_sqlalchemy_2x()
 
         print("=" * 60)
         print("🎉 SUCCÈS: Tous les tests Feature 1.1 passés!")
@@ -178,28 +173,16 @@ def main():
         print("Résumé des versions:")
         print(f"  • NumPy: {np.__version__}")
 
-        try:
+        import pyqtgraph as pg
+
+        print(f"  • pyqtgraph: {pg.__version__}")
+
+        if sqlalchemy_ok:
             import sqlalchemy
 
             print(f"  • SQLAlchemy: {sqlalchemy.__version__}")
-        except ImportError:
-            pass
-
-        try:
-            import matplotlib
-
-            print(f"  • matplotlib: {matplotlib.__version__}")
-        except ImportError:
-            pass
-
-        try:
-            import fastapi
-            import pydantic
-
-            print(f"  • FastAPI: {fastapi.__version__}")
-            print(f"  • Pydantic: {pydantic.__version__}")
-        except ImportError:
-            pass
+        else:
+            print("  • SQLAlchemy: absent ou < 2.x (optionnel, non bloquant)")
 
         return 0
 

--- a/fpdb_3_legacy/test_migration.py
+++ b/fpdb_3_legacy/test_migration.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-
 """Tests de validation pour la migration NumPy 2.x.
 
 Ce module teste les fonctionnalités NumPy critiques utilisées dans FPDB.
+
+Une dépendance optionnelle absente doit provoquer un *skip*, jamais un échec :
+appeler ``self.fail()`` faisait échouer ce script sur une installation
+parfaitement conforme, SQLAlchemy n'étant requis nulle part.
 """
 
+from __future__ import annotations
+
+import importlib.util
 import sys
 import unittest
 from pathlib import Path
@@ -116,11 +121,23 @@ class TestNumPyMigration(unittest.TestCase):
         print(f"✅ var() : {variance}")
 
     def test_deprecated_functions_removed(self):
-        """Vérifie que les fonctions dépréciées ne sont plus importées."""
-        # Ces fonctions ne doivent PAS être dans le namespace après import
+        """Vérifie que les modules migrés n'importent plus max/min/sum de NumPy.
 
-        # On ne devrait pas pouvoir importer max, min, sum directement
-        # (mais elles peuvent encore exister dans numpy. namespace)
+        La version précédente de ce test n'affirmait rien : elle affichait un
+        ``✅`` sans rien vérifier. Sa prémisse était de surcroît fausse -- NumPy
+        2.x exporte toujours ``max``/``min``/``sum``. L'invariant réel de la
+        migration porte sur le code de FPDB, qui doit utiliser les méthodes de
+        tableau, et c'est lui qui est vérifié ici.
+        """
+        legacy_dir = Path(__file__).resolve().parent
+        for module in ("GuiGraphViewer.py", "GuiSessionViewer.py"):
+            content = (legacy_dir / module).read_text(encoding="utf-8")
+            for name in ("max", "min", "sum"):
+                self.assertNotIn(
+                    f"from numpy import {name}",
+                    content,
+                    f"{module} importe encore numpy.{name} au lieu de la méthode de tableau",
+                )
         print("✅ Imports dépréciés non utilisés")
 
     def test_realistic_session_calculation(self):
@@ -169,86 +186,34 @@ class TestNumPyMigration(unittest.TestCase):
         print(f"✅ GraphViewer : Green={greenline[-1]:.2f}, Blue={blueline[-1]:.2f}, Red={redline[-1]:.2f}")
 
 
+HAS_SQLALCHEMY = importlib.util.find_spec("sqlalchemy") is not None
+
+
+@unittest.skipUnless(HAS_SQLALCHEMY, "SQLAlchemy est une dépendance optionnelle (cf. Database.py)")
 class TestSQLAlchemyCompatibility(unittest.TestCase):
-    """Tests de compatibilité SQLAlchemy 2.0."""
+    """Tests de compatibilité SQLAlchemy 2.0.
+
+    ``Database.py`` sonde SQLAlchemy derrière un ``try``/``except`` et bascule
+    sur ``use_sqlalchemy = False`` s'il manque ; il n'est déclaré dans aucune
+    section de ``pyproject.toml``. Son absence est donc normale et se traduit
+    par un skip, là où la version précédente appelait ``self.fail()`` et
+    faisait échouer le script sur une installation saine.
+    """
 
     def test_sqlalchemy_version(self):
-        """Vérifie que SQLAlchemy 2.0+ est installé."""
-        try:
-            import sqlalchemy
+        """Vérifie que SQLAlchemy, s'il est présent, est en 2.x."""
+        import sqlalchemy
 
-            version = sqlalchemy.__version__
-            major_version = int(version.split(".")[0])
-            self.assertGreaterEqual(major_version, 2, f"SQLAlchemy 2.x requis, version actuelle : {version}")
-            print(f"✅ SQLAlchemy version : {version}")
-        except ImportError:
-            self.fail("SQLAlchemy n'est pas installé")
+        version = sqlalchemy.__version__
+        major_version = int(version.split(".")[0])
+        self.assertGreaterEqual(major_version, 2, f"SQLAlchemy 2.x requis, version actuelle : {version}")
+        print(f"✅ SQLAlchemy version : {version}")
 
     def test_sqlalchemy_pool_import(self):
         """Vérifie que sqlalchemy.pool peut être importé."""
-        try:
-            from sqlalchemy import pool  # noqa: F401 -- import compatibility test
+        from sqlalchemy import pool  # noqa: F401 -- import compatibility test
 
-            print("✅ sqlalchemy.pool importé avec succès")
-        except ImportError as e:
-            self.fail(f"Impossible d'importer sqlalchemy.pool : {e}")
-
-
-class TestMatplotlibCompatibility(unittest.TestCase):
-    """Tests de compatibilité matplotlib."""
-
-    def test_matplotlib_version(self):
-        """Vérifie que matplotlib 3.10.7+ est installé."""
-        try:
-            import matplotlib
-
-            version = matplotlib.__version__
-            parts = [int(x) for x in version.split(".")[:3]]
-
-            # Vérifier >= 3.10.7
-            is_compatible = (
-                parts[0] > 3
-                or (parts[0] == 3 and parts[1] > 10)
-                or (parts[0] == 3 and parts[1] == 10 and parts[2] >= 7)
-            )
-
-            self.assertTrue(is_compatible, f"matplotlib 3.10.7+ requis, version actuelle : {version}")
-            print(f"✅ matplotlib version : {version}")
-        except ImportError:
-            self.fail("matplotlib n'est pas installé")
-
-    def test_matplotlib_qt_backend(self):
-        """Vérifie que le backend QtAgg compatible PySide6 peut être importé."""
-        try:
-            from matplotlib.backends.backend_qtagg import FigureCanvas  # noqa: F401 -- import compatibility test
-            from matplotlib.figure import Figure  # noqa: F401 -- import compatibility test
-
-            print("✅ matplotlib QtAgg backend importé")
-        except ImportError as e:
-            self.fail(f"Impossible d'importer backend QtAgg : {e}")
-
-
-class TestMplfinanceCompatibility(unittest.TestCase):
-    """Tests de compatibilité mplfinance."""
-
-    def test_mplfinance_version(self):
-        """Vérifie que mplfinance 0.12.10+ est installé."""
-        try:
-            import mplfinance
-
-            version = mplfinance.__version__
-            print(f"✅ mplfinance version : {version}")
-        except ImportError:
-            self.fail("mplfinance n'est pas installé")
-
-    def test_mplfinance_candlestick(self):
-        """Vérifie que candlestick_ochl peut être importé."""
-        try:
-            from mplfinance.original_flavor import candlestick_ochl  # noqa: F401 -- import compatibility test
-
-            print("✅ mplfinance candlestick_ochl importé")
-        except ImportError as e:
-            self.fail(f"Impossible d'importer candlestick_ochl : {e}")
+        print("✅ sqlalchemy.pool importé avec succès")
 
 
 def run_tests():
@@ -257,11 +222,10 @@ def run_tests():
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
 
-    # Ajouter les tests
+    # Ajouter les tests. matplotlib et mplfinance ne figurent plus ici : aucun
+    # code applicatif ne les importe depuis le passage à PyQtGraph (#228).
     suite.addTests(loader.loadTestsFromTestCase(TestNumPyMigration))
     suite.addTests(loader.loadTestsFromTestCase(TestSQLAlchemyCompatibility))
-    suite.addTests(loader.loadTestsFromTestCase(TestMatplotlibCompatibility))
-    suite.addTests(loader.loadTestsFromTestCase(TestMplfinanceCompatibility))
 
     # Exécuter
     runner = unittest.TextTestRunner(verbosity=2)

--- a/fpdb_3_legacy/validate_migration.py
+++ b/fpdb_3_legacy/validate_migration.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-
 """Script de validation de la migration Python 3.13/3.14 + PySide6.
 
-Ce script vérifie que toutes les bibliothèques sont correctement installées
-avec les versions compatibles Python 3.13/3.14 et PySide6.
+Ce script vérifie que les bibliothèques dont l'application dépend réellement
+sont installées, importables, et dans une version compatible.
+
+Deux règles tirées d'un échec de ce script :
+
+* Une vérification d'import passe par :func:`check_import`, qui exécute une
+  sonde. Les blocs ``try:`` écrits à la main ne contenaient aucun import et
+  affichaient donc ``OK`` quoi qu'il arrive -- y compris pour des paquets
+  absents de l'environnement.
+* Seules les dépendances déclarées dans ``pyproject.toml`` comptent dans le
+  verdict. Vérifier un paquet non déclaré faisait échouer le script sur une
+  installation saine.
 """
 
+from __future__ import annotations
+
 import sys
+from collections.abc import Callable
 from importlib import metadata
 
 VALIDATION_VERSION_ERRORS = (TypeError, ValueError)
@@ -65,62 +76,96 @@ def check_version(package: str, min_version: str, name: str | None = None) -> bo
         return False
 
 
+def _probe_numpy() -> object:
+    """Importe NumPy et exerce l'API 2.x utilisée par l'application."""
+    import numpy as np
+
+    return np.array([1, 2, 3]).sum()
+
+
+def _probe_pyside6() -> object:
+    """Importe les modules Qt dont dépendent la fenêtre principale et le HUD."""
+    from PySide6 import QtCore, QtWidgets
+
+    return QtCore.qVersion(), QtWidgets.QWidget
+
+
+def _probe_pyqtgraph() -> object:
+    """Importe le moteur de rendu des graphiques (remplace Matplotlib, cf. #228)."""
+    import pyqtgraph as pg
+
+    return pg.PlotWidget
+
+
+def _probe_pandas() -> object:
+    """Importe pandas."""
+    import pandas as pd
+
+    return pd.DataFrame
+
+
+def _probe_aiohttp() -> object:
+    """Importe aiohttp, utilisé par les captures HTTP."""
+    import aiohttp
+
+    return aiohttp.ClientSession
+
+
+def _probe_sqlalchemy() -> object:
+    """Importe SQLAlchemy.
+
+    Optionnel : ``Database.py`` le sonde derrière un ``try``/``except`` et
+    bascule sur ``use_sqlalchemy = False`` s'il manque. Le rapporter comme une
+    erreur ferait échouer une installation parfaitement valide.
+    """
+    import sqlalchemy
+
+    return sqlalchemy.__version__
+
+
+#: Sondes exécutées par :func:`check_imports`, sous la forme
+#: ``(libellé, sonde, optionnel)``. Chaque sonde doit réellement importer :
+#: c'est ce qu'un test de régression vérifie.
+IMPORT_CHECKS: list[tuple[str, Callable[[], object], bool]] = [
+    ("NumPy", _probe_numpy, False),
+    ("PySide6", _probe_pyside6, False),
+    ("pyqtgraph", _probe_pyqtgraph, False),
+    ("pandas", _probe_pandas, False),
+    ("aiohttp", _probe_aiohttp, False),
+    ("SQLAlchemy", _probe_sqlalchemy, True),
+]
+
+
+def check_import(label: str, probe: Callable[[], object], *, optional: bool = False) -> bool:
+    """Exécute une sonde d'import et rapporte son résultat.
+
+    Args:
+        label: Nom affiché
+        probe: Appelable qui effectue l'import à valider
+        optional: Si True, un échec est signalé sans invalider la migration
+
+    Returns:
+        True si l'import a réussi, ou s'il a échoué mais que la dépendance est
+        optionnelle.
+    """
+    try:
+        probe()
+    except VALIDATION_IMPORT_ERRORS as e:
+        if optional:
+            print(f"⚠️  {label:20s} OPTIONAL: {e}")
+            return True
+        print(f"❌ {label:20s} FAILED: {e}")
+        return False
+    print(f"✅ {label:20s} OK")
+    return True
+
+
 def check_imports() -> bool:
     """Vérifie que les imports critiques fonctionnent."""
     print("\n=== Vérification des Imports ===\n")
 
-    imports_ok = True
-
-    # NumPy
-    try:
-        print("✅ NumPy imports       OK (max/min/sum removed as expected)")
-
-        # Test que max/min/sum ne sont plus importés directement
-        try:
-            from numpy import max, min, sum  # noqa: F401 -- import compatibility test
-
-            print("⚠️  NumPy max/min/sum  STILL AVAILABLE (unexpected, but OK)")
-        except ImportError:
-            print("✅ NumPy max/min/sum  REMOVED (expected in NumPy 2.x)")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"❌ NumPy imports       FAILED: {e}")
-        imports_ok = False
-
-    # SQLAlchemy
-    try:
-        print("✅ SQLAlchemy pool     OK")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"❌ SQLAlchemy pool     FAILED: {e}")
-        imports_ok = False
-
-    # matplotlib
-    try:
-        print("✅ matplotlib QtAgg    OK")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"❌ matplotlib QtAgg    FAILED: {e}")
-        imports_ok = False
-
-    # mplfinance
-    try:
-        print("✅ mplfinance          OK")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"❌ mplfinance          FAILED: {e}")
-        imports_ok = False
-
-    # PySide6
-    try:
-        print("✅ PySide6             OK")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"❌ PySide6             FAILED: {e}")
-        imports_ok = False
-
-    # FastAPI (optionnel)
-    try:
-        print("✅ FastAPI/Pydantic    OK")
-    except VALIDATION_IMPORT_ERRORS as e:
-        print(f"⚠️  FastAPI/Pydantic    OPTIONAL: {e}")
-
-    return imports_ok
+    results = [check_import(label, probe, optional=optional) for label, probe, optional in IMPORT_CHECKS]
+    return all(results)
 
 
 def check_numpy_functionality() -> bool:
@@ -182,23 +227,14 @@ def main():
 
     print("=== Vérification des Versions ===\n")
 
-    # Dépendances critiques
+    # Dépendances déclarées dans pyproject.toml. Les minima suivent cette
+    # déclaration : un écart ici ferait échouer une installation conforme.
     all_ok = True
     all_ok &= check_version("numpy", "2.1.0", "NumPy")
-    all_ok &= check_version("sqlalchemy", "2.0.0", "SQLAlchemy")
-    all_ok &= check_version("matplotlib", "3.10.7", "matplotlib")
-    all_ok &= check_version("mplfinance", "0.12.10", "mplfinance")
-
-    # Dépendances moyennes
-    all_ok &= check_version("fastapi", "0.121.1", "FastAPI")
-    all_ok &= check_version("pydantic", "2.12.1", "Pydantic")
+    all_ok &= check_version("PySide6", "6.8.1", "PySide6")
+    all_ok &= check_version("pyqtgraph", "0.13.0", "pyqtgraph")
+    all_ok &= check_version("pandas", "2.2.2", "pandas")
     all_ok &= check_version("aiohttp", "3.13.2", "aiohttp")
-
-    # PySide6 (LGPL license)
-    check_version("PySide6", "6.8.1", "PySide6")
-
-    # Autres dépendances
-    check_version("pandas", "2.2.0", "pandas")
 
     # Test imports
     imports_ok = check_imports()

--- a/fpdb_3_legacy/validate_migration.py
+++ b/fpdb_3_legacy/validate_migration.py
@@ -139,21 +139,31 @@ IMPORT_CHECKS: list[tuple[str, Callable[[], object], bool]] = [
 def check_import(label: str, probe: Callable[[], object], *, optional: bool = False) -> bool:
     """Exécute une sonde d'import et rapporte son résultat.
 
+    ``optional`` tolerates an *absence*, not a breakage. Only ``ImportError``
+    is forgiven, because that is the only failure the application itself
+    survives: ``Database.py`` guards ``import sqlalchemy`` with
+    ``except ImportError`` alone, so an installed-but-broken package raising
+    ``AttributeError``, ``OSError`` or ``RuntimeError`` aborts startup. Passing
+    the validator in that situation would be a false all-clear.
+
     Args:
         label: Nom affiché
         probe: Appelable qui effectue l'import à valider
-        optional: Si True, un échec est signalé sans invalider la migration
+        optional: Si True, une absence est signalée sans invalider la migration
 
     Returns:
-        True si l'import a réussi, ou s'il a échoué mais que la dépendance est
-        optionnelle.
+        True si l'import a réussi, ou s'il est absent alors que la dépendance
+        est optionnelle.
     """
     try:
         probe()
-    except VALIDATION_IMPORT_ERRORS as e:
+    except ImportError as e:
         if optional:
             print(f"⚠️  {label:20s} OPTIONAL: {e}")
             return True
+        print(f"❌ {label:20s} FAILED: {e}")
+        return False
+    except VALIDATION_IMPORT_ERRORS as e:
         print(f"❌ {label:20s} FAILED: {e}")
         return False
     print(f"✅ {label:20s} OK")

--- a/test/test_validate_migration.py
+++ b/test/test_validate_migration.py
@@ -49,6 +49,21 @@ def test_check_import_tolerates_an_optional_failure() -> None:
     assert validate_migration.check_import("sqlalchemy", missing, optional=True) is True
 
 
+@pytest.mark.parametrize("broken", [AttributeError, OSError, RuntimeError])
+def test_an_optional_dependency_that_is_broken_is_not_tolerated(broken: type[Exception]) -> None:
+    """Optional means "may be absent", not "may be installed and broken".
+
+    ``Database.py`` guards ``import sqlalchemy`` with ``except ImportError``
+    alone, so any other failure from that import aborts application startup.
+    Reporting it as an acceptable absence would be a false all-clear.
+    """
+
+    def installed_but_broken() -> object:
+        raise broken("sqlalchemy is installed but unusable")
+
+    assert validate_migration.check_import("sqlalchemy", installed_but_broken, optional=True) is False
+
+
 def test_check_imports_fails_when_a_required_probe_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """La régression : aucune entrée ne pouvait faire échouer check_imports()."""
 

--- a/test/test_validate_migration.py
+++ b/test/test_validate_migration.py
@@ -1,0 +1,85 @@
+"""Garde-fous sur le validateur de migration.
+
+Le défaut corrigé ici : chaque vérification d'import était un bloc ``try:``
+sans aucun import, qui affichait donc ``OK`` en toute circonstance.
+``check_imports()`` ne pouvait renvoyer ``False`` pour aucune entrée -- il
+annonçait « SQLAlchemy pool OK » deux lignes après « SQLAlchemy NOT
+INSTALLED ». Les tests ci-dessous verrouillent les deux propriétés que cela
+violait : une sonde importe vraiment, et un échec requis se propage.
+"""
+
+from __future__ import annotations
+
+import dis
+
+import pytest
+
+from fpdb_3_legacy import validate_migration
+
+
+def test_every_probe_actually_imports() -> None:
+    """Une sonde sans import est le bug d'origine : elle validerait le vide."""
+    for label, probe, _optional in validate_migration.IMPORT_CHECKS:
+        opnames = {instruction.opname for instruction in dis.get_instructions(probe)}
+        assert "IMPORT_NAME" in opnames, f"la sonde {label!r} n'importe rien"
+
+
+def test_check_import_reports_success() -> None:
+    assert validate_migration.check_import("ok", lambda: object()) is True
+
+
+def test_check_import_reports_a_required_failure() -> None:
+    def missing() -> object:
+        msg = "No module named 'absent'"
+        raise ImportError(msg)
+
+    assert validate_migration.check_import("absent", missing) is False
+
+
+def test_check_import_tolerates_an_optional_failure() -> None:
+    """SQLAlchemy est sondé derrière un try/except dans Database.py.
+
+    Le rapporter comme une erreur ferait échouer une installation conforme.
+    """
+
+    def missing() -> object:
+        msg = "No module named 'sqlalchemy'"
+        raise ImportError(msg)
+
+    assert validate_migration.check_import("sqlalchemy", missing, optional=True) is True
+
+
+def test_check_imports_fails_when_a_required_probe_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """La régression : aucune entrée ne pouvait faire échouer check_imports()."""
+
+    def missing() -> object:
+        msg = "No module named 'absent'"
+        raise ImportError(msg)
+
+    monkeypatch.setattr(validate_migration, "IMPORT_CHECKS", [("absent", missing, False)])
+    assert validate_migration.check_imports() is False
+
+
+def test_check_imports_survives_an_optional_probe_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing() -> object:
+        msg = "No module named 'absent'"
+        raise ImportError(msg)
+
+    monkeypatch.setattr(validate_migration, "IMPORT_CHECKS", [("absent", missing, True)])
+    assert validate_migration.check_imports() is True
+
+
+def test_only_declared_dependencies_are_probed() -> None:
+    """Sonder un paquet non déclaré faisait échouer une installation saine.
+
+    ``sqlalchemy``, ``fastapi`` et ``pydantic`` n'apparaissent nulle part dans
+    ``pyproject.toml`` ; ``matplotlib`` et ``mplfinance`` y figurent encore mais
+    aucun code applicatif ne les importe depuis la migration PyQtGraph (#228).
+    """
+    required = {label for label, _probe, optional in validate_migration.IMPORT_CHECKS if not optional}
+    assert "SQLAlchemy" not in required
+    assert not {"FastAPI", "Pydantic", "matplotlib", "mplfinance"} & required
+
+
+def test_check_version_flags_a_missing_package() -> None:
+    assert validate_migration.check_version("paquet-absent-volontairement", "1.0.0") is False


### PR DESCRIPTION
Closes #256.

Fixes the migration validation scripts whose checks could not fail, reported while triaging #249 and noted in #251.

## The defect

Every check in `check_imports()` was a `try:` block containing **no import at all**:

```python
    # matplotlib
    try:
        print("✅ matplotlib QtAgg    OK")
    except VALIDATION_IMPORT_ERRORS as e:
        print(f"❌ matplotlib QtAgg    FAILED: {e}")
        imports_ok = False
```

The `except` can never fire, so the block prints `OK` unconditionally. This was true of **all six** checks — NumPy's outer block, SQLAlchemy, matplotlib, mplfinance, PySide6 and FastAPI/Pydantic — which means `check_imports()` could not return `False` for any input. It was decorative.

The version checks were wrong in the opposite direction. `sqlalchemy`, `fastapi` and `pydantic` are declared nowhere in `pyproject.toml` and are not installed, yet all three were folded into `all_ok`. So the script **exited 1 on a correctly installed project**.

Run on `development`, against a healthy venv — note lines 2 and 13:

```
❌ SQLAlchemy           NOT INSTALLED
❌ FastAPI              NOT INSTALLED
❌ Pydantic             NOT INSTALLED
...
✅ SQLAlchemy pool     OK          <- the package it just called missing
✅ FastAPI/Pydantic    OK
...
❌ VALIDATION ÉCHOUÉE - Vérifier les erreurs ci-dessus
EXIT=1
```

Failing on a good environment and passing on a bad one, at the same time.

## The fix

Checks now go through `check_import(label, probe)`, which executes a probe callable. A check can no longer be written without doing the work — that is the structural point, and the reason this is not just six added import statements.

The probe set now covers what `pyproject.toml` declares and the application actually imports:

- **numpy, PySide6, pandas, aiohttp** — required, previously unverifiable.
- **pyqtgraph** — required, and **added**: it is the renderer behind every graph since #228, and it was the one dependency nobody validated.
- **SQLAlchemy** — kept as an explicitly *optional* probe, mirroring the `try`/`except` guard in `Database.py:109-115` that sets `use_sqlalchemy`. Reporting it as an error is what broke a conforming install.
- **fastapi, pydantic** — removed. Not declared, not installed, referenced only by the dev script `test_feature_1_1.py`.
- **matplotlib, mplfinance** — removed. No application code has imported either since #228; this is the `validate_migration.py` part of #251's scope, so that issue shrinks accordingly.

Smaller items in the same file:

- `PySide6` and `pandas` version checks were computed but never folded into `all_ok`. They are now — PySide6 being the hardest requirement in the project.
- The pandas minimum said `2.2.0` where `pyproject.toml` declares `2.2.2`.
- The module docstring sat *after* `from __future__ import annotations`, making it a no-op string expression rather than a docstring. Moved to the top.

## Verification

After the change, on the same venv:

```
✅ NumPy / PySide6 / pyqtgraph / pandas / aiohttp   (versions + imports)
⚠️  SQLAlchemy           OPTIONAL: No module named 'sqlalchemy'
✅ VALIDATION RÉUSSIE - Migration compatible
EXIT=0
```

`test/test_validate_migration.py` adds 8 tests. The load-bearing one states the defect directly:

```python
def test_every_probe_actually_imports() -> None:
    for label, probe, _optional in validate_migration.IMPORT_CHECKS:
        opnames = {instruction.opname for instruction in dis.get_instructions(probe)}
        assert "IMPORT_NAME" in opnames, f"la sonde {label!r} n'importe rien"
```

A check that imports nothing validates nothing, so the bytecode of every probe must contain an `IMPORT_NAME`. The rest cover required-vs-optional failure propagation and the "only declared dependencies" rule.

Local: `pytest` 8 passed, `ruff check` clean, `mypy fpdb_3_legacy/validate_migration.py` clean (CI type-checks this file at `.github/workflows/ci.yml:288`).

## Not in scope

This does not touch the matplotlib/mplfinance **dependencies** themselves — that stays with #251. It has no bearing on the macOS tab lag in #249; the validator is a developer script.

---

## Second commit: the same defect in `test_migration.py` and `test_feature_1_1.py`

The two other migration scripts carry complementary versions of it, and each was wrong in the opposite direction.

### `test_migration.py` — failed on a healthy install

`TestSQLAlchemyCompatibility` called `self.fail("SQLAlchemy n'est pas installé")`. But SQLAlchemy is declared in **no** section of `pyproject.toml`, and `Database.py:109-115` probes it behind a `try`/`except` that sets `use_sqlalchemy = False`. Its absence is the normal state, so the script exited non-zero on a conforming environment:

```
Ran 17 tests in 0.753s
FAILED (failures=2)
```

It now skips via `@unittest.skipUnless`. The matplotlib and mplfinance suites are removed — no application code has imported either since #228.

`test_deprecated_functions_removed` asserted nothing whatsoever:

```python
    def test_deprecated_functions_removed(self):
        """Vérifie que les fonctions dépréciées ne sont plus importées."""
        # Ces fonctions ne doivent PAS être dans le namespace après import
        print("✅ Imports dépréciés non utilisés")
```

Its premise was also false — NumPy 2.x still exports `max`/`min`/`sum`. It now checks the invariant the migration actually cares about: that `GuiGraphViewer` and `GuiSessionViewer` use array methods instead of importing those names from NumPy.

After: `13 tests exécutés`, exit 0.

### `test_feature_1_1.py` — passed unconditionally

Its checks returned `True`/`False` and `main()` discarded every one of them:

```python
        test_numpy_2x_array_methods()
        test_sqlalchemy_2x()      # return value dropped
        test_matplotlib_3_10()    # return value dropped
        test_fastapi_pydantic()   # return value dropped
```

So it printed `🎉 SUCCÈS: Tous les tests Feature 1.1 passés!` and exited 0 while reporting two checks as not satisfied. Required and optional checks are now separated: required ones raise, and the optional SQLAlchemy verdict is reported rather than dropped — including the *present but too old* case, which previously raised an `AssertionError` and failed the entire run for an optional package.

Verified that a required failure now propagates:

```
❌ ÉCHEC: pyqtgraph cassé (simulation)
EXIT SIMULE = 1
```

### Both scripts

- **pyqtgraph check added** — same reasoning as the first commit.
- **matplotlib, FastAPI, Pydantic checks removed** — the first is unused since #228, the other two are declared nowhere and installed nowhere.
- A `GuiSessionViewer` assertion written as `assert "A" not in content or "B" in content` was satisfied the moment the module imported numpy, so it forbade nothing. Split into two assertions with messages.
- Both module docstrings sat *after* `from __future__ import annotations`, making them no-op string expressions rather than docstrings.

### Verification

Both scripts exit 0 on this venv; full suite **8033 passed, 16 skipped**; `ruff` clean.

On mypy: `mypy fpdb_3_legacy/test_migration.py` reports one `assertAlmostEqual` inference error locally, but it **pre-exists on `development`** (same error, line 115 there) and does not appear in CI, whose `uv tool install mypy` environment has no numpy — with `ignore_missing_imports`, numpy resolves to `Any` and the inference succeeds. Reproduced with `mypy --no-site-packages`, which matches CI and is clean on all three files. Left untouched as out of scope.

