### PR TITLE
Add splash hand filters to Hand Viewer

### DIFF
--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -28,6 +28,7 @@ from PySide6.QtGui import QBrush, QColor, QPainter, QPixmap, QStandardItem, QSta
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
+    QComboBox,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -126,6 +127,7 @@ class GuiHandViewer(QSplitter):
             "Total Pot": 15,
             "Rake": 16,
             "SiteHandNo": 17,
+            "Splash": 18,
         }
         self.view = QTableView()
         self.view.setSelectionBehavior(QTableView.SelectRows)
@@ -157,6 +159,7 @@ class GuiHandViewer(QSplitter):
                 "Total Pot",
                 "Rake",
                 "SiteHandId",
+                "Splash",
             ],
         )
 
@@ -194,7 +197,6 @@ class GuiHandViewer(QSplitter):
         self.flagCashout = QCheckBox("CO$")
         self.flagBombPot = QCheckBox("Bomb")
         self.flagDoubleBoard = QCheckBox("2xB")
-        self.flagSplashPot = QCheckBox("Splash")
         _flag_tips = {
             "AI": "went all-in",
             "SD": "saw showdown",
@@ -202,7 +204,6 @@ class GuiHandViewer(QSplitter):
             "CO$": "EV cashout",
             "Bomb": "bomb pot",
             "2xB": "double board",
-            "Splash": "splash pot",
         }
         for cb in (
             self.flagAllIn,
@@ -211,11 +212,17 @@ class GuiHandViewer(QSplitter):
             self.flagCashout,
             self.flagBombPot,
             self.flagDoubleBoard,
-            self.flagSplashPot,
         ):
             cb.setToolTip(_("Filter: ") + _flag_tips[cb.text()])
             cb.stateChanged.connect(lambda _state: self.loadHands(None))
             self.pagerBox.addWidget(cb)
+        self.flagSplashPot = QComboBox()
+        self.flagSplashPot.addItem(_("All hands"), "all")
+        self.flagSplashPot.addItem(_("Splash pots only"), "only")
+        self.flagSplashPot.addItem(_("Exclude splash pots"), "exclude")
+        self.flagSplashPot.setToolTip(_("Filter: splash pot"))
+        self.flagSplashPot.currentIndexChanged.connect(lambda _index: self.loadHands(None))
+        self.pagerBox.addWidget(self.flagSplashPot)
         self.handsVBox.addLayout(self.pagerBox)
         self._update_pager()
 
@@ -267,8 +274,9 @@ class GuiHandViewer(QSplitter):
             extra.append("h.bombPot > 0")
         if getattr(self, "flagDoubleBoard", None) and self.flagDoubleBoard.isChecked():
             extra.append("(SELECT COUNT(*) FROM Boards b WHERE b.handId = h.id) >= 2")
-        if getattr(self, "flagSplashPot", None) and self.flagSplashPot.isChecked():
-            extra.append("h.splashPot > 0")
+        splash_condition = self._splash_filter_condition()
+        if splash_condition:
+            extra.append(splash_condition)
         if extra:
             q = q + " AND " + " AND ".join(extra)
 
@@ -290,6 +298,17 @@ class GuiHandViewer(QSplitter):
         result = [r[0] for r in c.fetchall()]
         log.info("Load Hands matched %d hand(s) for dates %s..%s", len(result), start, end)
         return result
+
+    def _splash_filter_condition(self) -> str | None:
+        """Return the SQL condition for the selected splash-pot mode."""
+        mode = "all"
+        selector = getattr(self, "flagSplashPot", None)
+        if selector is not None and hasattr(selector, "currentData"):
+            mode = selector.currentData() or "all"
+        return {
+            "only": "h.splashPot > 0",
+            "exclude": "(h.splashPot = 0 OR h.splashPot IS NULL)",
+        }.get(mode)
 
     def rankedhand(self, hand, game):
         ranks = {
@@ -401,6 +420,9 @@ class GuiHandViewer(QSplitter):
         totalpot = hand.totalpot
         rake = hand.rake if hand.rake is not None else Decimal("0.00")
         sitehandid = hand.handid
+        currency = str(hand.gametype.get("currency", "USD"))
+        splash = getattr(hand, "splashPot", 0) or 0
+        splash_won = (getattr(hand, "splashWinnings", {}) or {}).get(hero, 0) or 0
         base = hand.gametype["base"]
         category = hand.gametype.get("category", "")
 
@@ -468,6 +490,7 @@ class GuiHandViewer(QSplitter):
             "Total Pot": format_number(totalpot),
             "Rake": format_number(rake),
             "SiteHandNo": str(sitehandid),
+            "Splash": self._format_splash(splash, splash_won, currency),
         }
 
         ordered = sorted(self.colnum.items(), key=lambda kv: kv[1])
@@ -495,6 +518,11 @@ class GuiHandViewer(QSplitter):
                 try:
                     item.setData(float(values[name]), Qt.ItemDataRole.UserRole)
                 except (TypeError, ValueError):
+                    pass
+            elif name == "Splash":
+                try:
+                    item.setData(float(Decimal(str(splash)) / 100), Qt.ItemDataRole.UserRole)
+                except (TypeError, ValueError, ArithmeticError):
                     pass
             if name in ("Won", "Net"):
                 try:
@@ -554,6 +582,18 @@ class GuiHandViewer(QSplitter):
 
     def _format_position(self, pos) -> str:
         return self._POSITION_NAMES.get(str(pos), str(pos))
+
+    @staticmethod
+    def _format_splash(splash, splash_won, currency: str) -> str:
+        """Format the room drop and, when present, the hero's collected share."""
+        try:
+            drop_text = format_currency(Decimal(str(splash)) / 100, currency)
+            if splash_won:
+                won_text = format_currency(splash_won, currency)
+                return f"{drop_text} ({won_text} won)"
+            return drop_text
+        except (TypeError, ValueError, ArithmeticError):
+            return ""
 
     def _format_datetime(self, hand) -> str:
         st = getattr(hand, "startTime", None)

--- a/test/test_guihandviewer_splash_filter.py
+++ b/test/test_guihandviewer_splash_filter.py
@@ -1,0 +1,28 @@
+"""Tests for Hand Viewer splash-pot filtering and display."""
+
+from unittest.mock import MagicMock
+
+from fpdb_3_legacy.GuiHandViewer import GuiHandViewer
+
+
+def test_splash_filter_conditions_include_legacy_null_rows() -> None:
+    viewer = GuiHandViewer.__new__(GuiHandViewer)
+    selector = MagicMock()
+    viewer.flagSplashPot = selector
+
+    selector.currentData.return_value = "all"
+    assert viewer._splash_filter_condition() is None
+
+    selector.currentData.return_value = "only"
+    assert viewer._splash_filter_condition() == "h.splashPot > 0"
+
+    selector.currentData.return_value = "exclude"
+    assert viewer._splash_filter_condition() == "(h.splashPot = 0 OR h.splashPot IS NULL)"
+
+
+def test_splash_display_contains_drop_and_hero_share() -> None:
+    display = GuiHandViewer._format_splash(20, 0.20, "EUR")
+
+    assert "0.20" in display
+    assert "won" in display
+

--- a/test/test_guihandviewer_splash_filter.py
+++ b/test/test_guihandviewer_splash_filter.py
@@ -11,13 +11,13 @@ def test_splash_filter_conditions_include_legacy_null_rows() -> None:
     viewer = SimpleNamespace(flagSplashPot=selector)
 
     selector.currentData.return_value = "all"
-    assert viewer._splash_filter_condition() is None
+    assert GuiHandViewer._splash_filter_condition(viewer) is None
 
     selector.currentData.return_value = "only"
-    assert viewer._splash_filter_condition() == "h.splashPot > 0"
+    assert GuiHandViewer._splash_filter_condition(viewer) == "h.splashPot > 0"
 
     selector.currentData.return_value = "exclude"
-    assert viewer._splash_filter_condition() == "(h.splashPot = 0 OR h.splashPot IS NULL)"
+    assert GuiHandViewer._splash_filter_condition(viewer) == "(h.splashPot = 0 OR h.splashPot IS NULL)"
 
 
 def test_splash_display_contains_drop_and_hero_share() -> None:

--- a/test/test_guihandviewer_splash_filter.py
+++ b/test/test_guihandviewer_splash_filter.py
@@ -1,14 +1,14 @@
 """Tests for Hand Viewer splash-pot filtering and display."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from fpdb_3_legacy.GuiHandViewer import GuiHandViewer
 
 
 def test_splash_filter_conditions_include_legacy_null_rows() -> None:
-    viewer = GuiHandViewer.__new__(GuiHandViewer)
     selector = MagicMock()
-    viewer.flagSplashPot = selector
+    viewer = SimpleNamespace(flagSplashPot=selector)
 
     selector.currentData.return_value = "all"
     assert viewer._splash_filter_condition() is None
@@ -25,4 +25,3 @@ def test_splash_display_contains_drop_and_hero_share() -> None:
 
     assert "0.20" in display
     assert "won" in display
-


### PR DESCRIPTION
## Summary

- Replace the one-way Splash checkbox with an explicit three-state selector: all hands, splash pots only, or exclude splash pots.
- Keep legacy rows with `NULL` `splashPot` values in the exclude-splash view.
- Add a Splash column showing the room drop and the hero's collected share when available.
- Keep the filter combinable with the existing Hand Viewer flag filters.

## Validation

- `ruff check fpdb_3_legacy/GuiHandViewer.py test/test_guihandviewer_splash_filter.py test/test_guihandviewer_replayer.py`
- Python compilation check passed.
- The targeted pytest could not run locally because the environment is missing the `cachetools` dependency required while importing `GuiHandViewer`; the new test is included for CI.

Closes #247
Related to #246
Unblocks #248