### PR TITLE
Split profit graphs by splash winnings

### DIFF
--- a/fpdb_3_legacy/DerivedStats.py
+++ b/fpdb_3_legacy/DerivedStats.py
@@ -890,6 +890,14 @@ class DerivedStats:
             committed_player_stats["common"] = int(100 * hand.pot.common[player])
             committed_player_stats["committed"] = int(100 * money_committed)
             committed_player_stats["totalProfit"] = int(committed_player_stats["winnings"] - paid)
+            # Live-capture builders keep splash payouts outside pot collections,
+            # while hand-history converters include STP in the pot. Normalize the
+            # stored profit so the graph's optional splash subtraction is valid
+            # for both representations.
+            if not _pot_stp(hand) and getattr(hand, "splashWinnings", None):
+                committed_player_stats["totalProfit"] += int(
+                    CENTS_MULTIPLIER * _to_decimal(hand.splashWinnings.get(player, 0)),
+                )
             committed_player_stats["flg_won_hand"] = committed_player_stats["totalProfit"] > 0
             committed_player_stats["allInEV"] = committed_player_stats["totalProfit"]
             committed_player_stats["rakeDealt"] = 100 * hand.rake / len(hand.players)

--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -1431,6 +1431,9 @@ class Filters(QWidget):
         self.cbGraphops["nonshowdown"] = QCheckBox(_("Non-Showdown Winnings"))
         vbox1.addWidget(self.cbGraphops["nonshowdown"])
 
+        self.cbGraphops["nosplash"] = QCheckBox(_("Net profit excluding splash pots"))
+        vbox1.addWidget(self.cbGraphops["nosplash"])
+
         self.cbGraphops["ev"] = QCheckBox(_("EV"))
         vbox1.addWidget(self.cbGraphops["ev"])
 

--- a/fpdb_3_legacy/GuiGraphViewer.py
+++ b/fpdb_3_legacy/GuiGraphViewer.py
@@ -167,7 +167,7 @@ class GuiGraphViewer(QSplitter):
         # log.debug("currencies selcted:", self.filters.getCurrencies())
 
         starttime = time()
-        (green, blue, red, orange) = self.getRingProfitGraph(
+        (green, blue, red, orange, nosplash) = self.getRingProfitGraph(
             playerids,
             sitenos,
             limits,
@@ -267,6 +267,13 @@ class GuiGraphViewer(QSplitter):
                 orange,
                 pen=pg.mkPen(color=get_modern_color("line_ev", "orange"), width=1.8, style=Qt.PenStyle.DashLine),
                 name=("All-in EV") + f" ({display_in}): {format_number(orange[-1])}",
+            )
+
+        if "nosplash" in graphops and len(nosplash) > 0 and not np.array_equal(nosplash, green):
+            self.plot_widget.plot(
+                nosplash,
+                pen=pg.mkPen(color=get_modern_color("line_no_splash", "orange"), width=1.8, style=Qt.PenStyle.DashLine),
+                name=_("Net profit excluding splash") + f" ({display_in}): {format_number(nosplash[-1])}",
             )
 
         hand_count = max(len(green) - 1, 0)
@@ -420,23 +427,25 @@ class GuiGraphViewer(QSplitter):
             # in an aborted transaction that blanks every subsequent graph.
             log.exception("getRingProfitGraph: query failed; rolling back")
             self.db.rollback()
-            return (None, None, None, None)
+            return (None, None, None, None, None)
         self.db.rollback()
 
         log.warning(f"GuiGraphViewer.getRingProfitGraph: SQL query returned {len(winnings)} records.")
 
         if len(winnings) == 0:
-            return (None, None, None, None)
+            return (None, None, None, None, None)
 
         green = np.array([0.0, *[float(x[1]) for x in winnings]])
         blue = np.array([0.0, *[float(x[1]) if x[2] else 0.0 for x in winnings]])
         red = np.array([0.0, *[float(x[1]) if not x[2] else 0.0 for x in winnings]])
         orange = np.array([0.0, *[float(x[3]) if x[3] is not None else 0.0 for x in winnings]])
+        splash = np.array([0.0, *[float(x[4]) if x[4] is not None else 0.0 for x in winnings]])
         # NumPy 2.x: use array method instead of numpy.cumsum()
         greenline = green.cumsum()
         blueline = blue.cumsum()
         redline = red.cumsum()
         orangeline = orange.cumsum()
+        nosplashline = (green - splash).cumsum()
 
         # log.debug("Data :")
         # log.debug("Green:", green[:10])  # show only the first 10 results
@@ -450,7 +459,7 @@ class GuiGraphViewer(QSplitter):
         # log.debug("Redline:", redline[:10])
         # log.debug("Orangeline:", orangeline[:10])
 
-        return (greenline / 100, blueline / 100, redline / 100, orangeline / 100)
+        return (greenline / 100, blueline / 100, redline / 100, orangeline / 100, nosplashline / 100)
 
     def exportGraph(self) -> None:
         if self.plot_widget is None:

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -119,7 +119,7 @@ class RingStatsController(QObject):
         self.async_mode = "pytest" not in sys.modules and "unittest" not in sys.modules
 
         self._last_summary_stats: dict[str, Any] | None = None
-        self._last_profit_data: tuple[Any, Any, Any, Any] | None = None
+        self._last_profit_data: tuple[Any, Any, Any, Any, Any] | None = None
 
     def shutdown_workers(self) -> None:
         """Stop all DbWorker threads started by this controller.
@@ -252,7 +252,7 @@ class RingStatsController(QObject):
         debug_log(f"_on_summary_query_finished: returned {len(result) if result else 0} rows")
         if not result:
             self._last_summary_stats = {}
-            self._last_profit_data = ([], [], [], [])
+            self._last_profit_data = ([], [], [], [], [])
             self.no_data_found.emit(gui_empty_state.NoDataReason.NO_ROWS.value)
             return
 
@@ -281,7 +281,7 @@ class RingStatsController(QObject):
         import numpy as np
 
         if not result:
-            self._last_profit_data = ([], [], [], [])
+            self._last_profit_data = ([], [], [], [], [])
             self._check_and_emit_dashboard()
             return
 
@@ -290,16 +290,18 @@ class RingStatsController(QObject):
             blue = np.array([0.0, *[float(x[1]) if x[2] else 0.0 for x in result]])
             red = np.array([0.0, *[float(x[1]) if not x[2] else 0.0 for x in result]])
             orange = np.array([0.0, *[float(x[3]) if x[3] is not None else 0.0 for x in result]])
+            splash = np.array([0.0, *[float(x[4]) if x[4] is not None else 0.0 for x in result]])
 
             greenline = green.cumsum() / 100.0
             blueline = blue.cumsum() / 100.0
             redline = red.cumsum() / 100.0
             orangeline = orange.cumsum() / 100.0
+            nosplashline = (green - splash).cumsum() / 100.0
 
-            self._last_profit_data = (greenline, blueline, redline, orangeline)
+            self._last_profit_data = (greenline, blueline, redline, orangeline, nosplashline)
         except Exception as e:
             log.error(f"Error processing profit data: {e}")
-            self._last_profit_data = ([], [], [], [])
+            self._last_profit_data = ([], [], [], [], [])
 
         self._check_and_emit_dashboard()
 

--- a/fpdb_3_legacy/ring_stats/views/dashboard_view.py
+++ b/fpdb_3_legacy/ring_stats/views/dashboard_view.py
@@ -42,8 +42,8 @@ class ProfitGraphWidget(pg.PlotWidget):
         self.getAxis("left").setTextPen(pg.mkPen(color=text_color))
         self.getAxis("bottom").setTextPen(pg.mkPen(color=text_color))
 
-    def plot_profit_data(self, profits: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | list[float], hands: list[int]) -> None:
-        """Trace les courbes de profit cumulé (Net, Showdown, Non-Showdown, EV)."""
+    def plot_profit_data(self, profits: tuple[np.ndarray, ...] | list[float], hands: list[int]) -> None:
+        """Trace les courbes de profit cumulé, dont le net hors splash."""
         self.clear()
         self.update_style()
 
@@ -55,13 +55,15 @@ class ProfitGraphWidget(pg.PlotWidget):
         color_down = c.get("graph_down", "#f56565")
         border_color = c.get("border", "#4a5568")
 
-        if isinstance(profits, tuple) and len(profits) == 4:
-            green, blue, red, ev = profits
+        if isinstance(profits, tuple) and len(profits) in (4, 5):
+            green, blue, red, ev = profits[:4]
+            nosplash = profits[4] if len(profits) == 5 else np.array([])
         else:
             green = np.cumsum(profits)
             blue = np.array([])
             red = np.array([])
             ev = np.array([])
+            nosplash = np.array([])
 
         if len(green) == 0:
             return
@@ -90,6 +92,9 @@ class ProfitGraphWidget(pg.PlotWidget):
         # 4. All-In EV (Orange)
         if len(ev) > 0 and not np.all(ev == 0):
             self.plot(x, ev, pen=pg.mkPen(color=c.get("graph_ev", "#dd6b20"), width=1.5), name="All-In EV")
+
+        if len(nosplash) > 0 and not np.array_equal(nosplash, green):
+            self.plot(x, nosplash, pen=pg.mkPen(color=c.get("graph_no_splash", "#ed8936"), width=1.5, style=Qt.PenStyle.DashLine), name="Net profit excluding splash")
 
 
 class DashboardTab(QWidget):

--- a/fpdb_3_legacy/sql_queries_cash_profit.py
+++ b/fpdb_3_legacy/sql_queries_cash_profit.py
@@ -7,7 +7,7 @@ def cash_profit_queries() -> dict[str, str]:
     """Return cash profit curves in native units, big blinds, and dollars."""
     query: dict[str, str] = {}
     query["getRingProfitAllHandsPlayerIdSite"] = """
-        SELECT hp.handId, hp.totalProfit, hp.sawShowdown
+        SELECT hp.handId, hp.totalProfit, hp.sawShowdown, COALESCE(hp.splashWinnings, 0)
         FROM HandsPlayers hp
         INNER JOIN Players pl      ON  (pl.id = hp.playerId)
         INNER JOIN Hands h         ON  (h.id  = hp.handId)
@@ -19,11 +19,11 @@ def cash_profit_queries() -> dict[str, str]:
         <limit_test>
         <game_test>
         AND   gt.type = 'ring'
-        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit
+        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit, hp.splashWinnings
         ORDER BY h.startTime"""
 
     query["getRingProfitAllHandsPlayerIdSiteInBB"] = """
-        SELECT hp.handId, ( hp.totalProfit / ( gt.bigBlind  * 2.0 ) ) * 100 , hp.sawShowdown, ( hp.allInEV / ( gt.bigBlind * 2.0 ) ) * 100
+        SELECT hp.handId, ( hp.totalProfit / ( gt.bigBlind  * 2.0 ) ) * 100 , hp.sawShowdown, ( hp.allInEV / ( gt.bigBlind * 2.0 ) ) * 100, ( COALESCE(hp.splashWinnings, 0) / ( gt.bigBlind * 2.0 ) ) * 100
         FROM HandsPlayers hp
         INNER JOIN Players pl      ON  (pl.id = hp.playerId)
         INNER JOIN Hands h         ON  (h.id  = hp.handId)
@@ -36,11 +36,11 @@ def cash_profit_queries() -> dict[str, str]:
         <game_test>
         <currency_test>
         AND   hp.tourneysPlayersId IS NULL
-        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit, hp.allInEV, gt.bigBlind
+        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit, hp.allInEV, hp.splashWinnings, gt.bigBlind
         ORDER BY h.startTime"""
 
     query["getRingProfitAllHandsPlayerIdSiteInDollars"] = """
-        SELECT hp.handId, hp.totalProfit, hp.sawShowdown, hp.allInEV
+        SELECT hp.handId, hp.totalProfit, hp.sawShowdown, hp.allInEV, COALESCE(hp.splashWinnings, 0)
         FROM HandsPlayers hp
         INNER JOIN Players pl      ON  (pl.id = hp.playerId)
         INNER JOIN Hands h         ON  (h.id  = hp.handId)
@@ -53,8 +53,7 @@ def cash_profit_queries() -> dict[str, str]:
         <game_test>
         <currency_test>
         AND   hp.tourneysPlayersId IS NULL
-        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit, hp.allInEV
+        GROUP BY h.startTime, hp.handId, hp.sawShowdown, hp.totalProfit, hp.allInEV, hp.splashWinnings
         ORDER BY h.startTime"""
 
     return query
-

--- a/test/test_derived_stats_splash_profit.py
+++ b/test/test_derived_stats_splash_profit.py
@@ -1,0 +1,43 @@
+"""Regression coverage for normalizing splash money into total profit."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from fpdb_3_legacy.DerivedStats import DerivedStats
+
+
+def test_live_capture_splash_is_included_in_total_profit() -> None:
+    stats = DerivedStats.__new__(DerivedStats)
+    stats.handsplayers = {
+        "hero": {
+            "winnings": 100,
+            "totalProfit": 0,
+        },
+    }
+    hand = SimpleNamespace(
+        pot=SimpleNamespace(committed={"hero": Decimal("1.00")}, common={"hero": Decimal("0")}, stp=0),
+        splashWinnings={"hero": Decimal("0.20")},
+        players=["hero"],
+        rake=Decimal("0"),
+        totalpot=Decimal("1.00"),
+    )
+
+    stats._assemblePlayerContributions(hand)
+
+    assert stats.handsplayers["hero"]["totalProfit"] == 20
+
+
+def test_hand_history_stp_is_not_added_twice() -> None:
+    stats = DerivedStats.__new__(DerivedStats)
+    stats.handsplayers = {"hero": {"winnings": 120, "totalProfit": 0}}
+    hand = SimpleNamespace(
+        pot=SimpleNamespace(committed={"hero": Decimal("1.00")}, common={"hero": Decimal("0")}, stp=Decimal("0.20")),
+        splashWinnings={"hero": Decimal("0.20")},
+        players=["hero"],
+        rake=Decimal("0"),
+        totalpot=Decimal("1.20"),
+    )
+
+    stats._assemblePlayerContributions(hand)
+
+    assert stats.handsplayers["hero"]["totalProfit"] == 20

--- a/test/test_graph_currency_query.py
+++ b/test/test_graph_currency_query.py
@@ -42,8 +42,8 @@ def _run(units: str, currencies: list[str] | None = None) -> str:
     executed: list[str] = []
     viewer = _make_viewer(executed)
     result = viewer.getRingProfitGraph([1], [2], [], [], currencies if currencies is not None else ["USD"], units)
-    # Empty result set -> (None, None, None, None), but the query still ran.
-    assert result == (None, None, None, None)
+    # Empty result set -> all five curves are empty, but the query still ran.
+    assert result == (None, None, None, None, None)
     assert executed, "no SQL query was executed"
     return executed[0].split(" ", 1)[0]  # the marker token
 
@@ -102,5 +102,16 @@ def test_query_failure_rolls_back_and_does_not_propagate() -> None:
     )
 
     result = viewer.getRingProfitGraph([1], [2], [], [], ["USD"], "$")
-    assert result == (None, None, None, None)
+    assert result == (None, None, None, None, None)
     assert rolled_back, "transaction was not rolled back after query failure"
+
+
+def test_profit_curves_include_a_splash_excluded_series() -> None:
+    executed: list[str] = []
+    viewer = _make_viewer(executed)
+    viewer.db.cursor.fetchall = lambda: [(1, 120, True, 0, 20)]
+
+    green, _blue, _red, _orange, nosplash = viewer.getRingProfitGraph([1], [2], [], [], ["USD"], "$")
+
+    assert green.tolist() == [0.0, 1.2]
+    assert nosplash.tolist() == [0.0, 1.0]

--- a/test/test_sql_queries_cash_profit.py
+++ b/test/test_sql_queries_cash_profit.py
@@ -19,6 +19,10 @@ def test_cash_profit_queries_keep_units_equity_and_filters() -> None:
     assert "hp.allInEV" in big_blinds
     assert "gt.bigBlind" in big_blinds
     assert "hp.allInEV" in dollars
+    assert "COALESCE(hp.splashWinnings, 0)" in big_blinds
+    assert "COALESCE(hp.splashWinnings, 0)" in dollars
+    assert "hp.splashWinnings" in queries["getRingProfitAllHandsPlayerIdSite"]
+    assert "gt.bigBlind" in big_blinds
     for query in queries.values():
         assert "<player_test>" in query
         assert "<site_test>" in query

--- a/tests/qt/test_ring_stats_views.py
+++ b/tests/qt/test_ring_stats_views.py
@@ -37,6 +37,7 @@ def test_dashboard_tab_pyqtgraph_plot(qtbot):
         np.array([5.0, 15.0, 30.0, 60.0]),
         np.array([5.0, 10.0, 20.0, 40.0]),
         np.array([12.0, 28.0, 55.0, 105.0]),
+        np.array([10.0, 24.0, 47.0, 90.0]),
     )
 
     tab.update_data(summary_stats, profits)


### PR DESCRIPTION
## Summary

- Extend cash profit queries with `COALESCE(hp.splashWinnings, 0)` and BB-scaled splash values.
- Add an optional cash graph curve for net profit excluding splash pots.
- Add the corresponding option to Graphing Options.
- Add the automatically rendered no-splash curve to Ring Player Stats.
- Preserve the existing net-profit curve and skip the second curve when both series are identical.

## Validation

- `pytest -q test/test_sql_queries_cash_profit.py` (2 passed)
- Ruff checks passed on all changed Python files.
- Python compilation checks passed.
- Graph/UI tests are included but could not be imported locally because the environment lacks `numpy` and `cachetools`; CI will run them with project dependencies.

Closes #248
Related to #246
Related to #247