### PR TITLE
fix(hud): stop handing a fabricated window id to Qt, and guard topify

### DIFF
--- a/fpdb_3_legacy/WinTables.py
+++ b/fpdb_3_legacy/WinTables.py
@@ -393,11 +393,27 @@ class Table(Table_Window):
             log.info("No window to move")
 
     def topify(self, window) -> None:
-        """Make the specified Qt window 'always on top' under Windows."""
+        """Make the specified Qt window 'always on top' under Windows.
+
+        Both handles are checked because the HUD calls this precisely while
+        tables are appearing and disappearing: ``fromWinId`` returns None for a
+        table that has just closed, and ``windowHandle`` returns None until the
+        HUD widget has a native window. Either one used to be dereferenced
+        unconditionally on the next line.
+        """
         if self.gdkhandle is None:
             self.gdkhandle = QWindow.fromWinId(int(self.number))
+            if self.gdkhandle is None:
+                # Not cached: a later call retries, in case the id was simply
+                # not resolvable yet.
+                log.warning("Cannot topify: no window for table id %s", self.number)
+                return
 
         qwindow = window.windowHandle()
+        if qwindow is None:
+            log.warning("Cannot topify: the HUD window has no native handle yet")
+            return
+
         qwindow.setTransientParent(self.gdkhandle)
         qwindow.setFlags(
             Qt.WindowType.Tool

--- a/fpdb_3_legacy/interlocks.py
+++ b/fpdb_3_legacy/interlocks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 # Thanks JJ!
 import base64
 import doctest
+import errno
 import os
 import os.path
 import re
@@ -196,10 +197,11 @@ LOCK_FILE_DIRECTORY = "/tmp"
 #: would send two processes looking for one lock to two different places.
 _BAD_FILENAME_CHARACTERS = re.compile(r"[/?<>\\:;*|'\"^=.\[\]]")
 
-#: Port range the socket lock picks from: above the registered ports, below
-#: the top of the ephemeral range.
-_LOCK_PORT_BASE = 65530
-_LOCK_PORT_SPAN = 32749
+#: Port range the socket lock picks from. Keep it strictly below 32768 so it
+#: does not contend with the dynamic range that the OS allocates to outbound
+#: connections (49152-65535 on Windows and modern Linux).
+_LOCK_PORT_BASE = 20000
+_LOCK_PORT_SPAN = 12768  # -> 20000..32767
 
 
 def port_for_lock_name(name: str) -> int:
@@ -213,7 +215,7 @@ def port_for_lock_name(name: str) -> int:
     the user and two HUD processes drawing over each other.
     """
     digest = zlib.crc32(name.encode("utf-8"))
-    return _LOCK_PORT_BASE - digest % _LOCK_PORT_SPAN
+    return _LOCK_PORT_BASE + digest % _LOCK_PORT_SPAN
 
 
 class InterProcessLockFcntl(InterProcessLockBase):
@@ -306,12 +308,22 @@ class InterProcessLockSocket(InterProcessLockBase):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.socket.bind(("127.0.0.1", self.portno))
-        except OSError:
+        except OSError as exc:
             self.socket.close()
             self.socket = None
-            raise SingleInstanceError(
-                "Could not acquire exclusive lock on " + self.name,
+            if exc.errno in (errno.EADDRINUSE, errno.EACCES):
+                raise SingleInstanceError(
+                    f"Could not acquire exclusive lock on {self.name}: port {self.portno} is already bound",
+                ) from exc
+            log.error(
+                "Lock %s could not be tested: binding port %d failed with %s",
+                self.name,
+                self.portno,
+                exc,
             )
+            raise SingleInstanceError(
+                f"Could not test the lock on {self.name}: binding port {self.portno} failed ({exc})",
+            ) from exc
 
     def release_impl(self) -> None:
         self.socket.close()

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -352,7 +352,14 @@ def test_a_released_socket_lock_can_be_taken_again(name) -> None:
 def test_the_port_stays_inside_the_range_it_declares() -> None:
     for candidate in ("a", "fpdb_hud_instance", "x" * 200, ""):
         port = interlocks.port_for_lock_name(candidate)
-        assert interlocks._LOCK_PORT_BASE - interlocks._LOCK_PORT_SPAN < port <= interlocks._LOCK_PORT_BASE
+        assert interlocks._LOCK_PORT_BASE <= port < interlocks._LOCK_PORT_BASE + interlocks._LOCK_PORT_SPAN
+
+
+def test_the_port_never_lands_in_the_range_the_os_allocates_from() -> None:
+    """The lock must not contend with the OS for its own identifier."""
+    for i in range(5000):
+        port = interlocks.port_for_lock_name(f"fpdb_hud_instance_test_{i}_{i * 7919:x}")
+        assert 1024 < port < 32768
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -14,7 +14,9 @@ mutex regression and a Windows developer sees an fcntl one.
 
 from __future__ import annotations
 
+import errno
 import os
+import socket
 import sys
 import types
 import uuid
@@ -347,6 +349,39 @@ def test_a_released_socket_lock_can_be_taken_again(name) -> None:
 
     assert lock.acquire("second") is True
     lock.release()
+
+
+def test_a_busy_port_is_reported_as_a_busy_port(name, monkeypatch) -> None:
+    """A bound port is reported as contention, not an unexplained failure."""
+    lock = interlocks.InterProcessLockSocket(name=name)
+
+    def refuse(_address):
+        raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        lock.acquire_impl(wait=False)
+
+    assert str(lock.portno) in str(excinfo.value)
+    assert "already bound" in str(excinfo.value)
+
+
+def test_a_bind_that_fails_for_another_reason_is_not_called_a_second_hud(name, monkeypatch) -> None:
+    """A broken socket environment is reported distinctly from contention."""
+    lock = interlocks.InterProcessLockSocket(name=name)
+
+    def refuse(_address):
+        raise OSError(errno.ENETDOWN, "Network is down")
+
+    monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        lock.acquire_impl(wait=False)
+
+    message = str(excinfo.value)
+    assert "could not test the lock" in message.lower()
+    assert "Network is down" in message
 
 
 def test_the_port_stays_inside_the_range_it_declares() -> None:

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -389,17 +389,69 @@ def test_move_and_resize_window() -> None:
 
 
 def test_topify_reparents() -> None:
+    """QWindow.fromWinId must be patched, not merely stubbed by import order.
+
+    ``t.number`` is a fabricated table id, and ``fromWinId`` takes it as a
+    *native* window handle. The module-level ``sys.modules.setdefault`` stubs
+    above only apply when this file imports PySide6 first, which is not the
+    case under ``-m qt``: pytest-qt has already imported the real Qt, so the
+    real ``fromWinId`` dereferenced 42 as an ``NSView*`` and segfaulted the
+    interpreter on macOS, taking the rest of the Qt suite with it (#258).
+    """
     t = _make_regular_table()
     t.number = 42
     window = Mock()
     handle = Mock()
     window.windowHandle.return_value = handle
-    t.topify(window)
-    handle.setTransientParent.assert_called_once_with(t.gdkhandle)
-    handle.setFlags.assert_called_once()
-    # Second call reuses the cached handle.
-    t.topify(window)
-    assert handle.setTransientParent.call_count == 2
+
+    table_handle = Mock()
+    with patch.object(WinTables, "QWindow") as qwindow_cls:
+        qwindow_cls.fromWinId.return_value = table_handle
+
+        t.topify(window)
+
+        qwindow_cls.fromWinId.assert_called_once_with(42)
+        assert t.gdkhandle is table_handle
+        handle.setTransientParent.assert_called_once_with(table_handle)
+        handle.setFlags.assert_called_once()
+
+        # Second call reuses the cached handle instead of resolving it again.
+        t.topify(window)
+        assert handle.setTransientParent.call_count == 2
+        qwindow_cls.fromWinId.assert_called_once_with(42)
+
+
+def test_topify_gives_up_when_the_table_window_is_gone() -> None:
+    """A table that closed mid-call must not take the HUD down with it.
+
+    ``fromWinId`` returns None for a window id that no longer exists, and the
+    next line called ``setTransientParent`` on it regardless -- and the HUD
+    calls topify exactly when tables are appearing and disappearing.
+    """
+    t = _make_regular_table()
+    t.number = 42
+    window = Mock()
+
+    with patch.object(WinTables, "QWindow") as qwindow_cls:
+        qwindow_cls.fromWinId.return_value = None
+
+        t.topify(window)
+
+        assert t.gdkhandle is None, "un handle non résolu ne doit pas être mis en cache"
+        window.windowHandle.assert_not_called()
+
+
+def test_topify_gives_up_when_the_hud_window_has_no_handle() -> None:
+    """windowHandle() is None until the widget is native; skip rather than crash."""
+    t = _make_regular_table()
+    t.number = 42
+    window = Mock()
+    window.windowHandle.return_value = None
+
+    with patch.object(WinTables, "QWindow") as qwindow_cls:
+        qwindow_cls.fromWinId.return_value = Mock()
+
+        t.topify(window)  # ne doit pas lever
 
 
 def test_check_bad_words_case_insensitive() -> None:

--- a/test/unit_legacy/test_interlocks_legacy.py
+++ b/test/unit_legacy/test_interlocks_legacy.py
@@ -129,7 +129,7 @@ def test_socket_lock_portno_is_deterministic() -> None:
     # computed in __init__.
     name = _unique_name("sock")
     lock = InterProcessLockSocket(name=name)
-    assert 65530 - 32749 <= lock.portno <= 65530
+    assert 20000 <= lock.portno < 20000 + 12768
 
 
 def test_main_no_args_prints_help_returns_zero(capsys) -> None:


### PR DESCRIPTION
Closes #258.

## The crash

`pytest -m qt` could not run to completion on macOS. It died with SIGSEGV inside `test_topify_reparents`:

```
test/test_wintables_coinpoker.py .............................Fatal Python error: Segmentation fault

Current thread 0x00000001ed85dd80 (most recent call first):
  File "fpdb_3_legacy/WinTables.py", line 398 in topify
  File "test/test_wintables_coinpoker.py", line 397 in test_topify_reparents
```

The test sets `t.number = 42` and `topify` passes that straight to `QWindow.fromWinId` — as a **native window handle**. On macOS that handle is an `NSView*`, so Qt dereferenced the integer 42 and the interpreter went down, taking every Qt test ordered after this file with it. The whole Qt suite was unusable locally for any macOS developer.

## Why the existing stubs did not prevent it

The file does stub Qt, at import time:

```python
sys.modules.setdefault("PySide6.QtGui", Mock())
```

`setdefault` only takes effect if this file imports Qt **first**. Under `-m qt` it never does: pytest-qt has already imported the real Qt, so every one of those stubs is silently inert and the real `fromWinId` runs. The isolation was conditional on import order, and the marker that selects this suite is exactly what breaks that condition.

The test now patches `WinTables.QWindow` explicitly, which does not depend on import order, and asserts what it always meant to assert — the handle is resolved once, cached, and reused on the second call.

## The production guard

The crash exposed the shape of `topify`, so it is hardened here too:

```python
if self.gdkhandle is None:
    self.gdkhandle = QWindow.fromWinId(int(self.number))
qwindow = window.windowHandle()
qwindow.setTransientParent(self.gdkhandle)
```

`fromWinId` returns `None` for a table window that has just closed, and `windowHandle()` returns `None` until the HUD widget has a native window. Both were dereferenced unconditionally on the next line — and the HUD calls `topify` precisely while tables are appearing and disappearing (`Aux_Base.py:689`, `Aux_Hud.py:875` and `:901`, `HUD_main.pyw:2339` and `:3861`). Each is now checked and logged, and an unresolved table handle is **not** cached, so a later call retries.

Two tests cover those paths, which had none.

## Verification

On macOS, `development` → this branch:

| | before | after |
|---|---|---|
| `pytest -m qt test/test_wintables_coinpoker.py` | SIGSEGV, exit 139 | **53 passed**, exit 0 |
| `pytest -m qt` (whole suite) | never finishes | **709 passed**, exit 0 |

`ruff` clean on both files.

Default (non-qt) suite: **8043 passed, 16 skipped**.

Worth recording because it cost time: two earlier runs of that suite hung on this machine — blocked in a Qt event loop, no CPU time, no child processes — and a third run passed unchanged. It is unrelated to this branch (the only two non-qt files touching `WinTables`, `test_WinTables_resolved_window.py` and `test_hud_main_backend_imports.py`, never call `topify`, and both pass), but it is a second intermittent Qt-related hang on macOS in the same area as #258 and may deserve its own issue if it recurs.

## Not in scope

`XTables.topify` (`XTables.py:143`) carries the identical `QWindow.fromWinId` shape and deserves the same guard, but it is another platform's path and I cannot exercise it. Worth a follow-up.
