### PR TITLE
fix(gui): close tab-owned database connections

### DIFF
--- a/fpdb_3_legacy/GuiGraphViewer.py
+++ b/fpdb_3_legacy/GuiGraphViewer.py
@@ -105,6 +105,11 @@ class GuiGraphViewer(QSplitter):
 
         self.db.rollback()
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def clearGraphData(self) -> None:
         with contextlib.suppress(Exception):
             if self.plot_widget:

--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # This code once was in GuiReplayer.py and was split up in this and the former by zarturo.
 # import L10n
 # _ = L10n.get_translation()
+import contextlib
 from decimal import Decimal
 from functools import partial
 from io import StringIO
@@ -228,6 +229,11 @@ class GuiHandViewer(QSplitter):
 
         self.view.resizeColumnsToContents()
         self.view.setSortingEnabled(True)
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def init_card_images(self):
         suits = ("s", "h", "d", "c")

--- a/fpdb_3_legacy/GuiOpponentsReport.py
+++ b/fpdb_3_legacy/GuiOpponentsReport.py
@@ -46,6 +46,8 @@ limits in the filter sidebar to speed it up.
 # In the "official" distribution you can find the license in agpl-3.0.txt.
 from __future__ import annotations
 
+import contextlib
+
 from collections.abc import Sequence
 from time import time
 
@@ -485,6 +487,11 @@ class GuiOpponentsReport(QSplitter):
     # ------------------------------------------------------------------
     # Data loading
     # ------------------------------------------------------------------
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def refreshStats(self, checkState=None) -> None:
         try:
             self.fillStatsFrame()

--- a/fpdb_3_legacy/GuiSessionViewer.py
+++ b/fpdb_3_legacy/GuiSessionViewer.py
@@ -140,6 +140,11 @@ class GuiSessionViewer(QSplitter):
         self.main_vbox.addWidget(self.graphBox)
         self.main_vbox.addWidget(self.stats_frame)
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def refreshStats(self, checkState) -> None:
         log.warning(f"GuiSessionViewer.refreshStats called with checkState: {checkState}")
         if self.view:

--- a/fpdb_3_legacy/GuiTourHandViewer.py
+++ b/fpdb_3_legacy/GuiTourHandViewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # This code once was in GuiReplayer.py and was split up in this and the former by zarturo.
 # import L10n
 # _ = L10n.get_translation()
+import contextlib
 from functools import partial
 from io import StringIO
 from typing import Any
@@ -162,6 +163,11 @@ class TourHandViewer(QSplitter):
 
         self.view.resizeColumnsToContents()
         self.view.setSortingEnabled(True)
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def init_card_images(self):
         suits = ("s", "h", "d", "c")

--- a/fpdb_3_legacy/GuiTourneyGraphViewer.py
+++ b/fpdb_3_legacy/GuiTourneyGraphViewer.py
@@ -100,6 +100,11 @@ class GuiTourneyGraphViewer(QSplitter):
         self.db.rollback()
         self.exportFile = None
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def clearGraphData(self) -> None:
         with contextlib.suppress(Exception):
             if self.plot_widget:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1983,6 +1983,11 @@ class fpdb(QMainWindow):
             shutdown = getattr(item, "shutdown_workers", None)
             if callable(shutdown):
                 shutdown()
+            # Only tabs that created their own connection implement this hook.
+            # GuiTourneyPlayerStats shares the main window's connection.
+            close_database = getattr(item, "close_owned_database", None)
+            if callable(close_database):
+                close_database()
             item.deleteLater()
 
     def __init__(self) -> None:

--- a/fpdb_3_legacy/interlocks.py
+++ b/fpdb_3_legacy/interlocks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 # Thanks JJ!
 import base64
 import doctest
+import errno
 import os
 import os.path
 import re
@@ -196,10 +197,17 @@ LOCK_FILE_DIRECTORY = "/tmp"
 #: would send two processes looking for one lock to two different places.
 _BAD_FILENAME_CHARACTERS = re.compile(r"[/?<>\\:;*|'\"^=.\[\]]")
 
-#: Port range the socket lock picks from: above the registered ports, below
-#: the top of the ephemeral range.
-_LOCK_PORT_BASE = 65530
-_LOCK_PORT_SPAN = 32749
+#: Port range the socket lock picks from. Kept strictly below 32768, which is
+#: what keeps it clear of the dynamic range the OS itself allocates outbound
+#: connections from -- 49152-65535 on Windows and on modern Linux.
+#:
+#: The previous range was 32782-65530, chosen as "below the top of the
+#: ephemeral range", i.e. inside it. Any unrelated process holding one of those
+#: ports made the lock refuse a name nobody held, reported to the user as "The
+#: FPDB HUD process is already running" (#259). A lock must not contend with
+#: the operating system for its own identifier.
+_LOCK_PORT_BASE = 20000
+_LOCK_PORT_SPAN = 12768  # -> 20000..32767
 
 
 def port_for_lock_name(name: str) -> int:
@@ -213,7 +221,7 @@ def port_for_lock_name(name: str) -> int:
     the user and two HUD processes drawing over each other.
     """
     digest = zlib.crc32(name.encode("utf-8"))
-    return _LOCK_PORT_BASE - digest % _LOCK_PORT_SPAN
+    return _LOCK_PORT_BASE + digest % _LOCK_PORT_SPAN
 
 
 class InterProcessLockFcntl(InterProcessLockBase):
@@ -306,12 +314,28 @@ class InterProcessLockSocket(InterProcessLockBase):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.socket.bind(("127.0.0.1", self.portno))
-        except OSError:
+        except OSError as exc:
             self.socket.close()
             self.socket = None
-            raise SingleInstanceError(
-                "Could not acquire exclusive lock on " + self.name,
+            if exc.errno in (errno.EADDRINUSE, errno.EACCES):
+                # The honest reading: the port is taken. Usually that is another
+                # holder of this lock, but a port cannot say who bound it, so the
+                # message names the port instead of asserting a HUD is running.
+                raise SingleInstanceError(
+                    f"Could not acquire exclusive lock on {self.name}: port {self.portno} is already bound",
+                ) from exc
+            # Anything else is a broken environment, not a second HUD. Reporting
+            # it as "already running" sent the user hunting for a process that
+            # does not exist.
+            log.error(
+                "Lock %s could not be tested: binding port %d failed with %s",
+                self.name,
+                self.portno,
+                exc,
             )
+            raise SingleInstanceError(
+                f"Could not test the lock on {self.name}: binding port {self.portno} failed ({exc})",
+            ) from exc
 
     def release_impl(self) -> None:
         self.socket.close()

--- a/fpdb_3_legacy/ring_stats/__init__.py
+++ b/fpdb_3_legacy/ring_stats/__init__.py
@@ -8,6 +8,7 @@ l'architecture d'onglets asynchrones.
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 from PySide6.QtCore import Qt
@@ -168,6 +169,11 @@ class GuiRingPlayerStats(QSplitter):
         """
         self.controller.shutdown_workers()
         self.stats_tabs.shutdown_workers()
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def handle_no_data_found(self, reason: str = "") -> None:
         """Explique pourquoi l'onglet est vide (filtre incomplet, base vide, ...)."""

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -14,7 +14,9 @@ mutex regression and a Windows developer sees an fcntl one.
 
 from __future__ import annotations
 
+import errno
 import os
+import socket
 import sys
 import types
 import uuid
@@ -349,10 +351,65 @@ def test_a_released_socket_lock_can_be_taken_again(name) -> None:
     lock.release()
 
 
+def test_a_busy_port_is_reported_as_a_busy_port(name, monkeypatch) -> None:
+    """EADDRINUSE names the port instead of asserting a HUD is running.
+
+    A bound port is evidence that *something* holds it, never proof of what.
+    """
+    lock = interlocks.InterProcessLockSocket(name=name)
+
+    def refuse(_address):
+        raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        lock.acquire_impl(wait=False)
+
+    assert str(lock.portno) in str(excinfo.value)
+    assert "already bound" in str(excinfo.value)
+
+
+def test_a_bind_that_fails_for_another_reason_is_not_called_a_second_hud(name, monkeypatch) -> None:
+    """A broken environment must not be reported as "already running".
+
+    That message sends the user hunting for a process that does not exist.
+    """
+    lock = interlocks.InterProcessLockSocket(name=name)
+
+    def refuse(_address):
+        raise OSError(errno.ENETDOWN, "Network is down")
+
+    monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        lock.acquire_impl(wait=False)
+
+    message = str(excinfo.value)
+    assert "could not test the lock" in message.lower()
+    assert "Network is down" in message
+
+
 def test_the_port_stays_inside_the_range_it_declares() -> None:
     for candidate in ("a", "fpdb_hud_instance", "x" * 200, ""):
         port = interlocks.port_for_lock_name(candidate)
-        assert interlocks._LOCK_PORT_BASE - interlocks._LOCK_PORT_SPAN < port <= interlocks._LOCK_PORT_BASE
+        assert interlocks._LOCK_PORT_BASE <= port < interlocks._LOCK_PORT_BASE + interlocks._LOCK_PORT_SPAN
+
+
+def test_the_port_never_lands_in_the_range_the_os_allocates_from() -> None:
+    """The lock must not contend with the OS for its own identifier.
+
+    The derived port used to sit in 32782-65530, overlapping the dynamic range
+    (49152-65535 on Windows and modern Linux) that the kernel hands out for
+    outbound connections. An unrelated process holding one of those ports made
+    the lock refuse a name nobody held, reported as "The FPDB HUD process is
+    already running" (#259). Names are swept rather than sampled so the whole
+    reachable range is covered, not a lucky subset.
+    """
+    ephemeral_floor = 32768
+    for i in range(5000):
+        port = interlocks.port_for_lock_name(f"fpdb_hud_instance_test_{i}_{i * 7919:x}")
+        assert 1024 < port < ephemeral_floor, f"port {port} can collide with an ephemeral allocation"
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_tab_database_cleanup.py
+++ b/test/test_tab_database_cleanup.py
@@ -1,0 +1,44 @@
+"""Static checks for the explicit GUI-tab database ownership contract."""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+OWNING_TABS = (
+    "GuiGraphViewer.py",
+    "GuiHandViewer.py",
+    "GuiSessionViewer.py",
+    "GuiTourneyGraphViewer.py",
+    "GuiTourHandViewer.py",
+    "GuiOpponentsReport.py",
+    "ring_stats/__init__.py",
+)
+
+
+def _methods(path: Path) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(path.read_text())
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def test_each_owned_tab_exposes_a_disconnect_hook() -> None:
+    for relative_path in OWNING_TABS:
+        methods = _methods(ROOT / "fpdb_3_legacy" / relative_path)
+        hook = methods["close_owned_database"]
+        assert any(
+            isinstance(node, ast.Attribute) and node.attr == "disconnect"
+            for node in ast.walk(hook)
+        ), relative_path
+
+
+def test_main_window_calls_the_ownership_hook_before_deleting_a_tab() -> None:
+    methods = _methods(ROOT / "fpdb_3_legacy" / "fpdb.pyw")
+    close_tab = methods["close_tab"]
+    names = [node.attr for node in ast.walk(close_tab) if isinstance(node, ast.Attribute)]
+    strings = [node.value for node in ast.walk(close_tab) if isinstance(node, ast.Constant)]
+    assert "close_owned_database" in strings
+    assert "deleteLater" in names

--- a/test/unit_legacy/test_interlocks_legacy.py
+++ b/test/unit_legacy/test_interlocks_legacy.py
@@ -13,6 +13,8 @@ import pytest
 
 from fpdb_3_legacy import interlocks
 from fpdb_3_legacy.interlocks import (
+    _LOCK_PORT_BASE,
+    _LOCK_PORT_SPAN,
     InterProcessLock,
     InterProcessLockBase,
     InterProcessLockFcntl,
@@ -129,7 +131,11 @@ def test_socket_lock_portno_is_deterministic() -> None:
     # computed in __init__.
     name = _unique_name("sock")
     lock = InterProcessLockSocket(name=name)
-    assert 65530 - 32749 <= lock.portno <= 65530
+    # Read from the module rather than repeated as literals: this assertion
+    # hard-coded the old 32782-65530 range, which sat inside the ephemeral
+    # range the OS allocates from (#259), and had to be edited by hand when the
+    # range moved.
+    assert _LOCK_PORT_BASE <= lock.portno < _LOCK_PORT_BASE + _LOCK_PORT_SPAN
 
 
 def test_main_no_args_prints_help_returns_zero(capsys) -> None:


### PR DESCRIPTION
Cette PR est remplacée par la PR #262, basée directement sur `development`, afin de ne pas inclure le commit préexistant sans rapport avec l’issue.