### PR TITLE
fix(gui): close tab-owned database connections

### DIFF
--- a/fpdb_3_legacy/GuiGraphViewer.py
+++ b/fpdb_3_legacy/GuiGraphViewer.py
@@ -105,6 +105,11 @@ class GuiGraphViewer(QSplitter):
 
         self.db.rollback()
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def clearGraphData(self) -> None:
         with contextlib.suppress(Exception):
             if self.plot_widget:

--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # This code once was in GuiReplayer.py and was split up in this and the former by zarturo.
 # import L10n
 # _ = L10n.get_translation()
+import contextlib
 from decimal import Decimal
 from functools import partial
 from io import StringIO
@@ -228,6 +229,11 @@ class GuiHandViewer(QSplitter):
 
         self.view.resizeColumnsToContents()
         self.view.setSortingEnabled(True)
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def init_card_images(self):
         suits = ("s", "h", "d", "c")

--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -233,6 +233,10 @@ class GuiHandViewer(QSplitter):
     def close_owned_database(self) -> None:
         """Release the connection created for this tab."""
         with contextlib.suppress(Exception):
+            if self.replayer is not None:
+                self.replayer.close()
+                self.replayer = None
+        with contextlib.suppress(Exception):
             self.db.disconnect()
 
     def init_card_images(self):

--- a/fpdb_3_legacy/GuiOpponentsReport.py
+++ b/fpdb_3_legacy/GuiOpponentsReport.py
@@ -47,7 +47,6 @@ limits in the filter sidebar to speed it up.
 from __future__ import annotations
 
 import contextlib
-
 from collections.abc import Sequence
 from time import time
 

--- a/fpdb_3_legacy/GuiOpponentsReport.py
+++ b/fpdb_3_legacy/GuiOpponentsReport.py
@@ -46,6 +46,8 @@ limits in the filter sidebar to speed it up.
 # In the "official" distribution you can find the license in agpl-3.0.txt.
 from __future__ import annotations
 
+import contextlib
+
 from collections.abc import Sequence
 from time import time
 
@@ -485,6 +487,11 @@ class GuiOpponentsReport(QSplitter):
     # ------------------------------------------------------------------
     # Data loading
     # ------------------------------------------------------------------
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def refreshStats(self, checkState=None) -> None:
         try:
             self.fillStatsFrame()

--- a/fpdb_3_legacy/GuiSessionViewer.py
+++ b/fpdb_3_legacy/GuiSessionViewer.py
@@ -140,6 +140,11 @@ class GuiSessionViewer(QSplitter):
         self.main_vbox.addWidget(self.graphBox)
         self.main_vbox.addWidget(self.stats_frame)
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def refreshStats(self, checkState) -> None:
         log.warning(f"GuiSessionViewer.refreshStats called with checkState: {checkState}")
         if self.view:

--- a/fpdb_3_legacy/GuiTourHandViewer.py
+++ b/fpdb_3_legacy/GuiTourHandViewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # This code once was in GuiReplayer.py and was split up in this and the former by zarturo.
 # import L10n
 # _ = L10n.get_translation()
+import contextlib
 from functools import partial
 from io import StringIO
 from typing import Any
@@ -162,6 +163,11 @@ class TourHandViewer(QSplitter):
 
         self.view.resizeColumnsToContents()
         self.view.setSortingEnabled(True)
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def init_card_images(self):
         suits = ("s", "h", "d", "c")

--- a/fpdb_3_legacy/GuiTourHandViewer.py
+++ b/fpdb_3_legacy/GuiTourHandViewer.py
@@ -167,6 +167,10 @@ class TourHandViewer(QSplitter):
     def close_owned_database(self) -> None:
         """Release the connection created for this tab."""
         with contextlib.suppress(Exception):
+            if self.replayer is not None:
+                self.replayer.close()
+                self.replayer = None
+        with contextlib.suppress(Exception):
             self.db.disconnect()
 
     def init_card_images(self):

--- a/fpdb_3_legacy/GuiTourneyGraphViewer.py
+++ b/fpdb_3_legacy/GuiTourneyGraphViewer.py
@@ -100,6 +100,11 @@ class GuiTourneyGraphViewer(QSplitter):
         self.db.rollback()
         self.exportFile = None
 
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
+
     def clearGraphData(self) -> None:
         with contextlib.suppress(Exception):
             if self.plot_widget:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1983,6 +1983,11 @@ class fpdb(QMainWindow):
             shutdown = getattr(item, "shutdown_workers", None)
             if callable(shutdown):
                 shutdown()
+            # Only tabs that created their own connection implement this hook.
+            # GuiTourneyPlayerStats shares the main window's connection.
+            close_database = getattr(item, "close_owned_database", None)
+            if callable(close_database):
+                close_database()
             item.deleteLater()
 
     def __init__(self) -> None:

--- a/fpdb_3_legacy/ring_stats/__init__.py
+++ b/fpdb_3_legacy/ring_stats/__init__.py
@@ -8,6 +8,7 @@ l'architecture d'onglets asynchrones.
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 from PySide6.QtCore import Qt
@@ -168,6 +169,11 @@ class GuiRingPlayerStats(QSplitter):
         """
         self.controller.shutdown_workers()
         self.stats_tabs.shutdown_workers()
+
+    def close_owned_database(self) -> None:
+        """Release the connection created for this tab."""
+        with contextlib.suppress(Exception):
+            self.db.disconnect()
 
     def handle_no_data_found(self, reason: str = "") -> None:
         """Explique pourquoi l'onglet est vide (filtre incomplet, base vide, ...)."""

--- a/test/test_tab_database_cleanup.py
+++ b/test/test_tab_database_cleanup.py
@@ -1,0 +1,44 @@
+"""Static checks for the explicit GUI-tab database ownership contract."""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+OWNING_TABS = (
+    "GuiGraphViewer.py",
+    "GuiHandViewer.py",
+    "GuiSessionViewer.py",
+    "GuiTourneyGraphViewer.py",
+    "GuiTourHandViewer.py",
+    "GuiOpponentsReport.py",
+    "ring_stats/__init__.py",
+)
+
+
+def _methods(path: Path) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(path.read_text())
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def test_each_owned_tab_exposes_a_disconnect_hook() -> None:
+    for relative_path in OWNING_TABS:
+        methods = _methods(ROOT / "fpdb_3_legacy" / relative_path)
+        hook = methods["close_owned_database"]
+        assert any(
+            isinstance(node, ast.Attribute) and node.attr == "disconnect"
+            for node in ast.walk(hook)
+        ), relative_path
+
+
+def test_main_window_calls_the_ownership_hook_before_deleting_a_tab() -> None:
+    methods = _methods(ROOT / "fpdb_3_legacy" / "fpdb.pyw")
+    close_tab = methods["close_tab"]
+    names = [node.attr for node in ast.walk(close_tab) if isinstance(node, ast.Attribute)]
+    strings = [node.value for node in ast.walk(close_tab) if isinstance(node, ast.Constant)]
+    assert "close_owned_database" in strings
+    assert "deleteLater" in names

--- a/test/test_tab_database_cleanup.py
+++ b/test/test_tab_database_cleanup.py
@@ -3,7 +3,6 @@
 import ast
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[1]
 OWNING_TABS = (
     "GuiGraphViewer.py",
@@ -33,6 +32,18 @@ def test_each_owned_tab_exposes_a_disconnect_hook() -> None:
             isinstance(node, ast.Attribute) and node.attr == "disconnect"
             for node in ast.walk(hook)
         ), relative_path
+
+
+def test_hand_viewers_close_detached_replayers_before_disconnect() -> None:
+    for relative_path in ("GuiHandViewer.py", "GuiTourHandViewer.py"):
+        hook = _methods(ROOT / "fpdb_3_legacy" / relative_path)["close_owned_database"]
+        calls = [
+            node.func.attr
+            for node in ast.walk(hook)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        ]
+        assert "close" in calls, relative_path
+        assert "disconnect" in calls, relative_path
 
 
 def test_main_window_calls_the_ownership_hook_before_deleting_a_tab() -> None:


### PR DESCRIPTION
## Résumé

Addresses lead 6 of #249.

Les onglets lourds créaient leurs propres connexions `Database.Database`, mais `close_tab` supprimait uniquement le widget. Les connexions PostgreSQL s'accumulaient donc pendant la durée de vie du processus.

Cette PR :

- ajoute un hook explicite `close_owned_database()` aux widgets qui possèdent leur connexion ;
- l'appelle depuis `close_tab` après l'arrêt des workers ;
- laisse intacte la connexion partagée de `GuiTourneyPlayerStats` ;
- couvre les sept widgets concernés ;
- ajoute des tests AST indépendants des dépendances runtime.

## Vérification

- `pytest -q test/test_tab_database_cleanup.py test/test_tab_open_reporting.py` — 5 passed
- syntaxe AST validée sur les 9 fichiers concernés
- `git diff --check` propre

Le lead 7 de #249 (comparaison du même build macOS depuis `/Applications` et `~/Downloads`) reste une validation manuelle et n'est pas clôturé par cette PR.