### PR TITLE
fix(hud): stop reporting an untestable lock as a HUD that is already running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,10 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system -e ".[test]"
+      - name: Install the Windows platform bindings
+        if: runner.os == 'Windows'
+        run: |
+          uv pip install --system pywin32==306
       - name: Run tests (no GUI)
         env:
           QT_QPA_PLATFORM: offscreen

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -37,7 +37,11 @@ from PySide6.QtWidgets import (
 from fpdb_3_legacy import Configuration, Importer
 from fpdb_3_legacy.hud_diagnostics import session_id
 from fpdb_3_legacy.i18n import gettext as _
-from fpdb_3_legacy.interlocks import HUD_ALREADY_RUNNING_EXIT_CODE, read_lock_owner
+from fpdb_3_legacy.interlocks import (
+    HUD_ALREADY_RUNNING_EXIT_CODE,
+    HUD_LOCK_UNDETERMINED_EXIT_CODE,
+    read_lock_owner,
+)
 from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.subprocess_launch import hud_main_command
 
@@ -835,6 +839,15 @@ class GuiAutoImport(QWidget):
                 "The HUD did not start: another FPDB HUD is already running and owns the "
                 f"single-HUD lock ({owner}). Two HUDs draw two sets of stat blocks over every "
                 "table. Quit the other one, then start Auto Import again."
+            )
+        elif return_code == HUD_LOCK_UNDETERMINED_EXIT_CODE:
+            # Deliberately not "another HUD is running": the HUD reached this
+            # exit because it could not find out. Sending the player off to
+            # quit a HUD they do not have is what #259 was about.
+            msg = (
+                "The HUD did not start: the single-HUD lock could not be tested, so whether "
+                "another FPDB HUD is running is unknown. See HUD-log.txt for the underlying "
+                "error. If no other HUD is running, retrying usually succeeds."
             )
         else:
             msg = f"HUD_main exited during startup with code {return_code}"

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -67,6 +67,8 @@ from fpdb_3_legacy.HudStatsPersistence import get_hud_stats_persistence
 from fpdb_3_legacy.interlocks import (
     HUD_ALREADY_RUNNING_EXIT_CODE,
     HUD_INSTANCE_LOCK_NAME,
+    HUD_LOCK_UNDETERMINED_EXIT_CODE,
+    LockUndeterminedError,
     SingleInstanceError,
     acquire_hud_instance_lock,
     read_lock_owner,
@@ -3954,6 +3956,19 @@ if __name__ == "__main__":
 
     try:
         hud_instance_lock = acquire_hud_instance_lock(format_identity(identity))
+    except LockUndeterminedError as exc:
+        # Not a refusal: the lock mechanism never answered. Saying "another HUD
+        # owns the lock" here would be a guess, and the one time it was wrong
+        # the user had no HUD to quit and no way to tell (#259).
+        log.error(
+            "HUD startup aborted: the single-HUD lock %s could not be tested (%s). This process "
+            "(pid=%s session=%s) is exiting. Whether another HUD is running is unknown.",
+            HUD_INSTANCE_LOCK_NAME,
+            exc,
+            identity["pid"],
+            identity["session"],
+        )
+        raise SystemExit(HUD_LOCK_UNDETERMINED_EXIT_CODE) from None
     except SingleInstanceError:
         # Naming the owner matters: two HUDs draw two sets of stat blocks over
         # every table, and without this the second one dies silently and the

--- a/fpdb_3_legacy/interlocks.py
+++ b/fpdb_3_legacy/interlocks.py
@@ -56,6 +56,23 @@ class SingleInstanceError(RuntimeError):
     """Thrown when you try to acquire an InterProcessLock and another version of the process is already running."""
 
 
+class LockUndeterminedError(SingleInstanceError):
+    """Thrown when the lock could not be tested at all.
+
+    Distinct from its parent because the two say different things. A
+    ``SingleInstanceError`` means the mechanism answered and the answer was
+    "taken"; this one means the mechanism never answered, so whether another
+    HUD is running is simply unknown. The socket lock cannot tell those apart
+    on its own -- a bind failing with ENETDOWN is not evidence of a second HUD
+    -- and reporting both as "the HUD is already running" sent users hunting
+    for a process that did not exist (#259).
+
+    A subclass so that every caller written against ``SingleInstanceError``
+    keeps refusing to start, which is still the safe answer when the lock is
+    untestable. Only the diagnostics change.
+    """
+
+
 HUD_INSTANCE_LOCK_NAME = "fpdb_hud_instance"
 """Name of the machine-wide lock that admits exactly one HUD process."""
 
@@ -66,6 +83,15 @@ Distinct from a crash so the GUI can tell the user what actually happened.
 "HUD_main exited during startup with code 1" sent an investigation into two
 HUDs drawing over every table down several wrong paths, because nothing
 anywhere said that a second HUD had been refused.
+"""
+
+HUD_LOCK_UNDETERMINED_EXIT_CODE = 4
+"""Exit status a HUD uses when it could not test the instance lock at all.
+
+Separate from HUD_ALREADY_RUNNING_EXIT_CODE because the advice differs. That
+one means "quit your other HUD"; this one means the lock mechanism itself
+failed, and quitting a HUD the user does not have will not help. Telling them
+otherwise is the bug behind #259.
 """
 
 
@@ -111,7 +137,11 @@ def acquire_hud_instance_lock(source: str, name: str = HUD_INSTANCE_LOCK_NAME) -
     """
     lock = InterProcessLock(name=name)
     if not lock.acquire(source):
-        raise SingleInstanceError("The FPDB HUD process is already running")
+        # Carry the mechanism's own account of the refusal. Without it every
+        # refusal reads "already running", including the ones where the lock
+        # merely could not be tested, and the user has nothing to go on.
+        detail = f" ({lock.last_error})" if lock.last_error else ""
+        raise SingleInstanceError(f"The FPDB HUD process is already running{detail}")
     return lock
 
 
@@ -122,6 +152,11 @@ class InterProcessLockBase:
             name = sys.argv[0]
         self.name = name
         self.heldBy = None
+        #: Why the last acquire() was refused, in the words of the mechanism
+        #: that refused it. acquire() reports refusal as a bare False, which
+        #: throws that away; the caller needs it to tell a held lock from an
+        #: untestable one.
+        self.last_error: str | None = None
 
     def getHashedName(self):
         log.debug(f"Original name: {self.name}")  # debug
@@ -163,6 +198,7 @@ class InterProcessLockBase:
         if self._has_lock:  # make sure 2nd acquire in the same process fails
             log.warning(f"Lock already held by: {self.heldBy}")
             return False
+        self.last_error = None
         while not self._has_lock:
             try:
                 self.acquire_impl(wait)
@@ -170,7 +206,14 @@ class InterProcessLockBase:
                 self.heldBy = source
                 self._record_owner(source)
                 log.debug("Lock acquired successfully")
-            except SingleInstanceError:
+            except LockUndeterminedError as exc:
+                # Waiting cannot help here: nothing was ever tested, so there
+                # is nothing to wait for. Retrying every retry_time seconds
+                # would spin on a broken environment until the user gave up.
+                self.last_error = str(exc)
+                raise
+            except SingleInstanceError as exc:
+                self.last_error = str(exc)
                 if not wait:
                     log.debug("Failed to acquire lock without waiting")
                     return False
@@ -306,6 +349,15 @@ class InterProcessLockSocket(InterProcessLockBase):
 
     def acquire_impl(self, wait) -> None:
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Windows lets a second process bind a port somebody already holds if
+        # that process asks for SO_REUSEADDR, so a successful bind there does
+        # not by itself mean the port was free. SO_EXCLUSIVEADDRUSE is what
+        # makes the bind mean what this lock needs it to mean. It exists only
+        # on Windows, which is also the only platform that needs it -- the
+        # other two mechanisms are chosen everywhere else.
+        exclusive = getattr(socket, "SO_EXCLUSIVEADDRUSE", None)
+        if exclusive is not None:
+            self.socket.setsockopt(socket.SOL_SOCKET, exclusive, 1)
         try:
             self.socket.bind(("127.0.0.1", self.portno))
         except OSError as exc:
@@ -321,7 +373,7 @@ class InterProcessLockSocket(InterProcessLockBase):
                 self.portno,
                 exc,
             )
-            raise SingleInstanceError(
+            raise LockUndeterminedError(
                 f"Could not test the lock on {self.name}: binding port {self.portno} failed ({exc})",
             ) from exc
 

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -376,6 +376,28 @@ def test_check_hud_process_started_clears_terminated_process():
     assert gui.pipe_to_hud is None
 
 
+def test_an_untestable_lock_is_not_reported_as_another_hud():
+    """The player is told what is known, which is that nothing is known (#259).
+
+    Sending them off to quit a HUD they may not have is the failure this
+    branch exists to avoid.
+    """
+    from fpdb_3_legacy.interlocks import HUD_LOCK_UNDETERMINED_EXIT_CODE
+
+    gui = _make_gui(_make_settings(MagicMock()), _make_config())
+    process = MagicMock(pid=1234)
+    process.poll.return_value = HUD_LOCK_UNDETERMINED_EXIT_CODE
+    gui.pipe_to_hud = process
+    gui.addText = MagicMock()
+
+    gui._check_hud_process_started()
+
+    message = gui.addText.call_args.args[0]
+    assert "could not be tested" in message
+    assert "is unknown" in message
+    assert "Quit the other one" not in message
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="exercises the POSIX/source HUD-launch branch")
 def test_launch_hud_uses_module_relative_path(monkeypatch, tmp_path):
     """_launch_hud must find HUD_main.pyw even when sys.path[0]/CWD are unrelated."""

--- a/test/test_hud_single_renderer_regression.py
+++ b/test/test_hud_single_renderer_regression.py
@@ -731,6 +731,30 @@ def test_the_gui_explains_a_refusal_instead_of_reporting_a_code() -> None:
     assert "Quit the other one" in source
 
 
+def test_a_lock_that_could_not_be_tested_is_its_own_exit_status() -> None:
+    """"Quit the other HUD" is bad advice when there may not be another HUD.
+
+    The socket fallback reported an unrelated bind failure as a refusal, so a
+    Windows user with no pywin32 could be told a HUD was running when none was
+    (#259). The verdict and the absence of a verdict now leave by different
+    doors.
+    """
+    from fpdb_3_legacy.interlocks import HUD_ALREADY_RUNNING_EXIT_CODE, HUD_LOCK_UNDETERMINED_EXIT_CODE
+
+    source = (REPO_ROOT_PATH / "fpdb_3_legacy" / "HUD_main.pyw").read_text(encoding="utf-8")
+
+    assert HUD_LOCK_UNDETERMINED_EXIT_CODE not in (0, 1, HUD_ALREADY_RUNNING_EXIT_CODE)
+    assert "raise SystemExit(HUD_LOCK_UNDETERMINED_EXIT_CODE)" in source
+    assert "except LockUndeterminedError" in source
+
+
+def test_the_gui_does_not_blame_a_hud_it_cannot_prove_exists() -> None:
+    source = (REPO_ROOT_PATH / "fpdb_3_legacy" / "GuiAutoImport.py").read_text(encoding="utf-8")
+
+    assert "HUD_LOCK_UNDETERMINED_EXIT_CODE" in source
+    assert "could not be tested" in source
+
+
 def _owner_child_source(lock_name: str, source: str) -> str:
     """A child that takes the socket lock and holds it, whatever the platform."""
     return textwrap.dedent(

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -101,6 +101,92 @@ def test_a_waiting_caller_retries_until_the_lock_is_free(monkeypatch, name) -> N
         lock.release()
 
 
+def test_a_waiting_caller_does_not_retry_a_lock_it_could_not_test(monkeypatch, name) -> None:
+    """Waiting for an untestable lock waits for nothing.
+
+    ``SingleInstanceError`` means "taken", and taken locks get given back, so
+    retrying is sound. ``LockUndeterminedError`` means the mechanism never
+    answered -- a bind failing with ENETDOWN does not become a free port
+    because a second elapsed. Retrying it spins until the user gives up.
+    """
+    lock = interlocks.InterProcessLock(name=name)
+    attempts = {"n": 0}
+
+    def never_answers(_wait):
+        attempts["n"] += 1
+        raise interlocks.LockUndeterminedError("the mechanism is broken")
+
+    monkeypatch.setattr(lock, "acquire_impl", never_answers)
+    monkeypatch.setattr(interlocks.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(interlocks.LockUndeterminedError):
+        lock.acquire("waiting", wait=True, retry_time=0)
+
+    assert attempts["n"] == 1
+
+
+def test_a_refusal_keeps_the_reason_the_mechanism_gave(monkeypatch, name) -> None:
+    """``acquire`` reports refusal as a bare False, which throws the reason away."""
+    lock = interlocks.InterProcessLock(name=name)
+
+    def refuse(_wait):
+        raise interlocks.SingleInstanceError("port 20001 is already bound")
+
+    monkeypatch.setattr(lock, "acquire_impl", refuse)
+
+    assert lock.acquire("refused") is False
+    assert lock.last_error == "port 20001 is already bound"
+
+
+def test_a_later_success_clears_the_previous_reason(name) -> None:
+    lock = interlocks.InterProcessLock(name=name)
+    lock.last_error = "stale"
+
+    assert lock.acquire("first") is True
+    try:
+        assert lock.last_error is None
+    finally:
+        lock.release()
+
+
+def test_the_hud_refusal_names_the_port_rather_than_only_the_verdict(monkeypatch, name) -> None:
+    """The user is shown "already running"; the reason has to travel with it.
+
+    Without this the improved bind messages reach the debug log and nowhere
+    else, and every refusal reads identically whatever caused it (#259).
+    """
+
+    def refuse(_self, _wait):
+        raise interlocks.SingleInstanceError(f"Could not acquire exclusive lock on {name}: port 20001 is already bound")
+
+    monkeypatch.setattr(interlocks.InterProcessLock, "acquire_impl", refuse)
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        interlocks.acquire_hud_instance_lock("pid=2 role='hud'", name=name)
+
+    message = str(excinfo.value)
+    assert "already running" in message
+    assert "port 20001" in message
+
+
+def test_an_untestable_lock_reaches_the_hud_entry_point_as_its_own_error(monkeypatch, name) -> None:
+    """The HUD exits on a different code for it, so the GUI can say something true."""
+
+    def never_answers(_self, _wait):
+        raise interlocks.LockUndeterminedError("binding port 20001 failed (Network is down)")
+
+    monkeypatch.setattr(interlocks.InterProcessLock, "acquire_impl", never_answers)
+
+    with pytest.raises(interlocks.LockUndeterminedError):
+        interlocks.acquire_hud_instance_lock("pid=2 role='hud'", name=name)
+
+
+def test_the_two_refusals_stay_distinguishable() -> None:
+    """A subclass, so old callers keep refusing; distinct, so new ones can tell."""
+    assert issubclass(interlocks.LockUndeterminedError, interlocks.SingleInstanceError)
+    assert interlocks.HUD_LOCK_UNDETERMINED_EXIT_CODE != interlocks.HUD_ALREADY_RUNNING_EXIT_CODE
+
+
 def test_the_same_process_cannot_take_a_lock_twice(name) -> None:
     """Re-entering would let one process believe it is two."""
     lock = interlocks.InterProcessLock(name=name)
@@ -376,12 +462,63 @@ def test_a_bind_that_fails_for_another_reason_is_not_called_a_second_hud(name, m
 
     monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
 
-    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+    with pytest.raises(interlocks.LockUndeterminedError) as excinfo:
         lock.acquire_impl(wait=False)
 
     message = str(excinfo.value)
     assert "could not test the lock" in message.lower()
     assert "Network is down" in message
+
+
+def test_a_busy_port_is_not_reported_as_an_untestable_lock(name, monkeypatch) -> None:
+    """EADDRINUSE is an answer, and the only one the lock can act on."""
+    lock = interlocks.InterProcessLockSocket(name=name)
+
+    def refuse(_address):
+        raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(socket.socket, "bind", lambda self, addr: refuse(addr))
+
+    with pytest.raises(interlocks.SingleInstanceError) as excinfo:
+        lock.acquire_impl(wait=False)
+
+    assert not isinstance(excinfo.value, interlocks.LockUndeterminedError)
+
+
+def test_the_socket_asks_windows_for_a_bind_that_means_something(name, monkeypatch) -> None:
+    """Without SO_EXCLUSIVEADDRUSE a Windows bind is not proof the port was free.
+
+    Another process asking for SO_REUSEADDR can bind a port this lock already
+    holds, which would let a second HUD through the one guard a plain Windows
+    install has. The option exists only on Windows, so it is injected here to
+    be exercised on every runner.
+    """
+    monkeypatch.setattr(socket, "SO_EXCLUSIVEADDRUSE", 4, raising=False)
+    options: list[tuple[int, int, int]] = []
+    real_setsockopt = socket.socket.setsockopt
+
+    def record(self, level, option, value) -> None:
+        options.append((level, option, value))
+        if option != 4:  # the stand-in is not a real option on this platform
+            real_setsockopt(self, level, option, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", record)
+
+    lock = interlocks.InterProcessLockSocket(name=name)
+    lock.acquire_impl(wait=False)
+    try:
+        assert (socket.SOL_SOCKET, 4, 1) in options
+    finally:
+        lock.release_impl()
+
+
+def test_a_platform_without_the_option_still_binds(name, monkeypatch) -> None:
+    """Everywhere but Windows there is no such option, and no need for one."""
+    monkeypatch.delattr(socket, "SO_EXCLUSIVEADDRUSE", raising=False)
+
+    lock = interlocks.InterProcessLockSocket(name=name)
+    assert lock.acquire("only-holder") is True
+    lock.release()
 
 
 def test_the_port_stays_inside_the_range_it_declares() -> None:


### PR DESCRIPTION
Closes #259.

`development` already carries the first half of this issue: the derived port moved out of the ephemeral range (`21f835ff`, `c4724988`, `a05c37e1`). This PR is the rest of it.

## What is still wrong

**Every bind failure is reported as a refusal.** `bind` raising for *any* reason becomes `SingleInstanceError`, which `acquire()` turns into a bare `False`, which the entry point turns into *"The FPDB HUD process is already running"*. Moving the port range narrows how often an unrelated process holds the port; it does not change what happens when one does, and it does nothing at all for a bind that fails for some other reason. A user can still be told to quit a HUD that does not exist, with nothing anywhere to suggest otherwise.

The improved bind messages added with the range never reach that user either. `acquire()` discards them, and `acquire_hud_instance_lock` raises its own generic text, so they land in the debug log and nowhere else.

**CI still does not test what Windows users run.** The Windows job installs `.[test]`; `pywin32` lives in the `windows` extra. `select_lock_class()` therefore falls through to the socket fallback on every run, so the named mutex a normal Windows install actually gets has no coverage — and the fallback is exercised only by accident. The flake on PR #253 landed in exactly that gap.

## What changed

**A verdict and the absence of a verdict now leave by different doors.** `LockUndeterminedError` — a `SingleInstanceError` subclass — carries the case where the mechanism never answered:

| | mechanism said | HUD exits | Auto Import tells the player |
|---|---|---|---|
| `EADDRINUSE` / `EACCES` | the port is taken | 3 | another HUD is running — quit it |
| any other `OSError` | nothing | 4 | the lock could not be tested; whether a HUD is running is unknown |

A subclass, deliberately: every caller written against `SingleInstanceError` keeps refusing to start, which is still the right answer for a lock that cannot be tested. Only the diagnostics change.

Two consequences of the same reasoning:

- `acquire()` no longer retries an undetermined error under `wait=True`. Nothing was tested, so there is nothing to wait for; the loop would have spun on a broken environment until the user gave up.
- A refusal keeps the mechanism's own account in `last_error`, and the entry point appends it — so "already running" now arrives with the port that led to that conclusion.

**`SO_EXCLUSIVEADDRUSE` where it exists.** Windows lets a process asking for `SO_REUSEADDR` bind a port somebody already holds, so a successful bind there was not by itself evidence the port was free — on the one platform where this fallback is the only thing between the user and two HUDs drawing over every table.

**CI installs `pywin32` on the Windows test job**, putting `InterProcessLockWin32` under test. The fallback keeps its coverage: the socket tests construct it directly and run on every runner.

## Tests

- a waiting caller retries a held lock and does not retry an untestable one
- `EADDRINUSE` is a refusal and *not* a `LockUndeterminedError`; `ENETDOWN` is the reverse
- the refusal reason survives `acquire()`'s `False` and reaches the entry point's message, and a later success clears it
- `SO_EXCLUSIVEADDRUSE` is requested when present, and its absence still binds — the option is injected so both branches run on every platform
- the HUD's two exit codes and Auto Import's two messages, asserted against the source, as the existing refusal contract already is

Full non-Qt suite: **8064 passed, 16 skipped**. `ruff` clean on every file touched.

## Not in scope

The issue's fourth suggestion — a file-based lock on Windows, sidestepping ports entirely — would remove this class of problem rather than narrow it, but it changes the lock's on-disk contract and deserves its own change. The socket fallback is now honest about what it knows, which was the reported bug.
