### PR TITLE
fix(perf): time the tab's lazy import apart from its construction

### DIFF
--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -256,13 +256,24 @@ class fpdb(QMainWindow):
         # No timing line here: it duplicated the profiler's "add_tab" phase and
         # was logged at INFO, below the log file's floor.
 
-    def open_tab(self, name, build, *, allow_multiple: bool = True):
+    def open_tab(self, name, build, *, allow_multiple: bool = True, module: str | None = None):
         """Build a page, show it as a tab, and time the whole thing.
 
         Every tab goes through here so that all of them are measured, not the
-        three that happened to carry a hand-written profiler block. ``build``
-        is called inside the timed "construct" phase and returns the page; it
-        performs its own lazy imports, which are timed with it.
+        three that happened to carry a hand-written profiler block.
+
+        ``module`` is the module a lazily imported page comes from. It is
+        imported here, inside its own "import" phase, and handed to ``build``
+        -- which is why ``build`` takes an argument for those tabs and none for
+        the tabs whose module is already imported at startup. Importing inside
+        ``build`` instead would fold the two costs into one figure, and telling
+        them apart is the open question of #249: on a PyOxidizer bundle the
+        first use of a tab resolves its module out of the embedded blob (over a
+        translocated read-only mount, when the .app was left in Downloads),
+        while construction is the widget, its filters and its DB connection.
+        The second open of the same tab reads ``import=0ms``, the module being
+        in ``sys.modules`` by then, so two lines for one tab answer "is the
+        wait the import?" on their own.
 
         Returns the page, or None when ``build`` declined to produce one, or
         when a single-instance tab was already open and was simply shown.
@@ -280,8 +291,13 @@ class fpdb(QMainWindow):
         profiler = TabOpenProfiler(name)
         profiler.watch_ui_stalls()
 
+        imported = None
+        if module is not None:
+            with profiler.phase("import"):
+                imported = import_module(module)
+
         with profiler.phase("construct"):
-            page = build()
+            page = build() if imported is None else build(imported)
 
         if page is None:
             profiler.result()  # stops the stall monitor started above
@@ -1758,17 +1774,16 @@ class fpdb(QMainWindow):
     # end def tab_import_imap_summaries
 
     def tab_ring_player_stats(self, widget, data=None) -> None:
-        def build():
-            # Imported lazily: the package pulls in the whole ring-stats view
-            # tree, and most sessions never open this tab. It used to be
-            # described as a Matplotlib font scan, which stopped being true
-            # with the move to PyQtGraph (#228) and sent a later performance
-            # analysis (#249) after a cost that no longer exists.
-            from fpdb_3_legacy import GuiRingPlayerStats
-
-            return GuiRingPlayerStats.GuiRingPlayerStats(self.config, self.sql, self)
-
-        self.open_tab("Ring Player Stats", build)
+        # Imported lazily by open_tab, which times it separately: the package
+        # pulls in the whole ring-stats view tree, and most sessions never open
+        # this tab. The cost used to be described as a Matplotlib font scan,
+        # which stopped being true with the move to PyQtGraph (#228) and sent a
+        # later performance analysis (#249) after a cost that no longer exists.
+        self.open_tab(
+            "Ring Player Stats",
+            lambda module: module.GuiRingPlayerStats(self.config, self.sql, self),
+            module="fpdb_3_legacy.GuiRingPlayerStats",
+        )
 
     def tab_opponents_report(self, widget, data=None) -> None:
         self.open_tab("Opponents Report", lambda: GuiOpponentsReport.GuiOpponentsReport(self.config, self.sql, self))
@@ -1789,13 +1804,11 @@ class fpdb(QMainWindow):
     #     self.add_and_display_tab(ps_tab, "Positional Stats")
 
     def tab_session_stats(self, widget, data=None) -> None:
-        def build():
-            from fpdb_3_legacy import GuiSessionViewer
-
+        def build(module):
             colors = self.get_theme_colors()
-            return GuiSessionViewer.GuiSessionViewer(self.config, self.sql, self, self, colors=colors)
+            return module.GuiSessionViewer(self.config, self.sql, self, self, colors=colors)
 
-        self.open_tab("Session Stats", build)
+        self.open_tab("Session Stats", build, module="fpdb_3_legacy.GuiSessionViewer")
 
     def tab_hand_viewer(self, widget, data=None) -> None:
         self.open_tab("Hand Viewer", lambda: GuiHandViewer.GuiHandViewer(self.config, self.sql, self))
@@ -1808,17 +1821,15 @@ class fpdb(QMainWindow):
         snapshot of the running build, so a second copy would only duplicate the
         first.
         """
-        def build():
-            from fpdb_3_legacy import GuiVersionInfo
-
-            return GuiVersionInfo.GuiVersionInfo(
+        def build(module):
+            return module.GuiVersionInfo(
                 config=self.config,
                 db=getattr(self, "db", None),
                 version=VERSION,
                 parent=self,
             )
 
-        self.open_tab("Version", build, allow_multiple=False)
+        self.open_tab("Version", build, allow_multiple=False, module="fpdb_3_legacy.GuiVersionInfo")
 
     def tab_main_help(self, widget, data=None) -> None:
         """Displays a tab with the main fpdb help screen.
@@ -1872,34 +1883,29 @@ class fpdb(QMainWindow):
     def tabGraphViewer(self, widget, data=None) -> None:
         """Opens a graph viewer tab."""
 
-        def build():
-            from fpdb_3_legacy import GuiGraphViewer
-
+        def build(module):
             colors = self.get_theme_colors()
-            return GuiGraphViewer.GuiGraphViewer(self.sql, self.config, self, colors=colors)
+            return module.GuiGraphViewer(self.sql, self.config, self, colors=colors)
 
-        self.open_tab("Graphs", build)
+        self.open_tab("Graphs", build, module="fpdb_3_legacy.GuiGraphViewer")
 
     def tabTourneyGraphViewer(self, widget, data=None) -> None:
         """Opens a graph viewer tab."""
 
-        def build():
-            from fpdb_3_legacy import GuiTourneyGraphViewer
-
+        def build(module):
             colors = self.get_theme_colors()
-            return GuiTourneyGraphViewer.GuiTourneyGraphViewer(self.sql, self.config, self, colors=colors)
+            return module.GuiTourneyGraphViewer(self.sql, self.config, self, colors=colors)
 
-        self.open_tab("Tourney Graphs", build)
+        self.open_tab("Tourney Graphs", build, module="fpdb_3_legacy.GuiTourneyGraphViewer")
 
     def tabStatsInfo(self, widget, data=None) -> None:
         """Opens a statistics guide tab."""
 
-        def build():
-            from fpdb_3_legacy import GuiStatsInfo
-
-            return GuiStatsInfo.GuiStatsInfo(self.config, self)
-
-        self.open_tab("Stats Guide", build)
+        self.open_tab(
+            "Stats Guide",
+            lambda module: module.GuiStatsInfo(self.config, self),
+            module="fpdb_3_legacy.GuiStatsInfo",
+        )
 
     # def tabStove(self, widget, data=None):
     #     """opens a tab for poker stove"""

--- a/fpdb_3_legacy/ui_instrumentation.py
+++ b/fpdb_3_legacy/ui_instrumentation.py
@@ -2,10 +2,19 @@
 
 The third tab a user opens is reported as slow, and the SQL behind it is not:
 the queries measured in isolation come back in tenths of a second. That leaves
-the work that a query timer cannot see -- importing Matplotlib and scanning
-the system fonts, building the widget, and the first real paint -- plus the
-only figure that matches what "frozen" means to a user, which is how long the
-Qt event loop went without running.
+the work that a query timer cannot see -- importing the page's module, building
+the widget, and the first real paint -- plus the only figure that matches what
+"frozen" means to a user, which is how long the Qt event loop went without
+running. (This paragraph used to name a Matplotlib font scan. That cost left
+with the PyQtGraph migration in #228, and the sentence outliving it is what
+sent the #249 analysis after a suspect that no longer existed.)
+
+The import is timed on its own because it is the one phase whose cost depends
+on how the application was installed: a PyOxidizer bundle resolves a module
+out of its embedded blob on first use, over a randomized read-only mount when
+macOS has translocated the .app. ``fpdb.open_tab`` performs it, so a tab that
+imports its own page inside ``build`` would hide that figure inside
+``construct=``.
 
 Two instruments, both usable in production and in a test:
 

--- a/test/test_tab_open_reporting.py
+++ b/test/test_tab_open_reporting.py
@@ -16,7 +16,7 @@ import ast
 import logging
 from importlib import import_module
 from pathlib import Path
-from types import SimpleNamespace
+from types import CodeType, FunctionType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -34,16 +34,24 @@ def _load_fpdb_method(name: str):
     method = next(node for node in fpdb_class.body if isinstance(node, ast.FunctionDef) and node.name == name)
     module = ast.Module(body=[method], type_ignores=[])
     ast.fix_missing_locations(module)
+    compiled = compile(module, str(SOURCE), "exec")
+    code = next(item for item in compiled.co_consts if isinstance(item, CodeType) and item.co_name == name)
     namespace = {
         "TabOpenProfiler": TabOpenProfiler,
         "import_module": import_module,
         "log": logging.getLogger("test-open-tab"),
     }
-    # exec rather than FunctionType(code, ...): keyword defaults live on the
-    # function object, not on its code, so a hand-built function would demand
-    # every keyword-only argument at every call site here.
-    exec(compile(module, str(SOURCE), "exec"), namespace)  # noqa: S102 - compiling one method out of fpdb.pyw
-    return namespace[name]
+    function = FunctionType(code, namespace, name)
+    # Keyword defaults live on the function object, not on its code, so a
+    # function built this way demands every keyword-only argument at every call
+    # site. Read them off the same AST rather than restating open_tab's
+    # signature here, which would go stale the next time it grows a keyword.
+    function.__kwdefaults__ = {
+        arg.arg: ast.literal_eval(default)
+        for arg, default in zip(method.args.kwonlyargs, method.args.kw_defaults, strict=True)
+        if default is not None
+    }
+    return function
 
 
 def _tab_methods() -> list[ast.FunctionDef]:

--- a/test/test_tab_open_reporting.py
+++ b/test/test_tab_open_reporting.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 import ast
 import logging
+from importlib import import_module
 from pathlib import Path
-from types import CodeType, FunctionType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -33,10 +34,16 @@ def _load_fpdb_method(name: str):
     method = next(node for node in fpdb_class.body if isinstance(node, ast.FunctionDef) and node.name == name)
     module = ast.Module(body=[method], type_ignores=[])
     ast.fix_missing_locations(module)
-    compiled = compile(module, str(SOURCE), "exec")
-    code = next(item for item in compiled.co_consts if isinstance(item, CodeType) and item.co_name == name)
-    namespace = {"TabOpenProfiler": TabOpenProfiler, "log": logging.getLogger("test-open-tab")}
-    return FunctionType(code, namespace, name)
+    namespace = {
+        "TabOpenProfiler": TabOpenProfiler,
+        "import_module": import_module,
+        "log": logging.getLogger("test-open-tab"),
+    }
+    # exec rather than FunctionType(code, ...): keyword defaults live on the
+    # function object, not on its code, so a hand-built function would demand
+    # every keyword-only argument at every call site here.
+    exec(compile(module, str(SOURCE), "exec"), namespace)  # noqa: S102 - compiling one method out of fpdb.pyw
+    return namespace[name]
 
 
 def _tab_methods() -> list[ast.FunctionDef]:
@@ -66,6 +73,23 @@ def test_every_tab_is_instrumented() -> None:
     ]
 
     assert unmeasured == [], f"ces onglets s'ouvrent sans être mesurés : {unmeasured}"
+
+
+def test_no_tab_imports_its_page_itself() -> None:
+    """A lazy import must go through ``open_tab``, which times it on its own.
+
+    Lead 7 of #249 is whether the wait is the module coming out of the
+    PyOxidizer blob or the widget being built. A tab that imports inside its
+    own ``build`` folds both into ``construct=``, and the line can no longer
+    tell them apart -- which is the shape the original report was captured in.
+    """
+    offenders = [
+        method.name
+        for method in _tab_methods()
+        if any(isinstance(node, (ast.Import, ast.ImportFrom)) for node in ast.walk(method))
+    ]
+
+    assert offenders == [], f"ces onglets importent eux-mêmes, hors de la phase mesurée : {offenders}"
 
 
 def test_no_tab_reports_inline() -> None:
@@ -136,6 +160,63 @@ def test_a_single_instance_tab_is_built_the_first_time(qtbot) -> None:
 
     assert result is page
     window.add_and_display_tab.assert_called_once_with(page, "Version", allow_multiple=False)
+
+
+def _window_showing(page) -> SimpleNamespace:
+    """A stand-in main window whose add_and_display_tab shows the page."""
+    return SimpleNamespace(
+        nb_tab_names=[],
+        threads=[],
+        add_and_display_tab=MagicMock(side_effect=lambda *_args, **_kwargs: page.show()),
+    )
+
+
+@pytest.mark.qt
+def test_the_import_is_timed_apart_from_the_construction(qtbot) -> None:
+    """Lead 7 of #249 needs the two costs separated, not summed.
+
+    The evidence in the report carried ``import=`` and ``construct=`` as
+    distinct figures; folding the lazy import into ``build`` lost that split,
+    and with it the only way to say from a log whether a translocated bundle
+    is paying for resolving the module out of its embedded blob.
+    """
+    open_tab = _load_fpdb_method("open_tab")
+    recorder = _RecordingLogger()
+    open_tab.__globals__["log"] = recorder
+    page = QLabel("contenu")
+    qtbot.addWidget(page)
+    received = []
+
+    def build(module):
+        received.append(module)
+        return page
+
+    result = open_tab(_window_showing(page), "Graphs", build, module="json")
+
+    qtbot.waitUntil(lambda: bool(recorder.lines), timeout=5000)
+
+    assert result is page
+    assert received == [import_module("json")], "le module importé doit être passé à build"
+    line = recorder.lines[0]
+    assert "import=" in line
+    assert line.index("import=") < line.index("construct=")
+
+
+@pytest.mark.qt
+def test_a_tab_without_a_lazy_module_reports_no_import_phase(qtbot) -> None:
+    """Tabs imported at startup pay nothing here, and must not claim a phase."""
+    open_tab = _load_fpdb_method("open_tab")
+    recorder = _RecordingLogger()
+    open_tab.__globals__["log"] = recorder
+    page = QLabel("contenu")
+    qtbot.addWidget(page)
+
+    open_tab(_window_showing(page), "Hand Viewer", lambda: page)
+
+    qtbot.waitUntil(lambda: bool(recorder.lines), timeout=5000)
+
+    assert "import=" not in recorder.lines[0]
+    assert "construct=" in recorder.lines[0]
 
 
 @pytest.mark.qt


### PR DESCRIPTION
## Résumé

Adresse le lead 7 de #249 — côté instrument, pas côté conclusion.

Les leads 1–6 sont livrés (#253, #255, #262). Reste le lead 7 : le bundle macOS tourne App-Translocated, et l'hypothèse est que le premier ouvrage d'un onglet paie la résolution de son module depuis le blob embarqué PyOxidizer, à travers un montage lecture seule aléatoire.

Le log ne peut pas trancher aujourd'hui. Depuis que tous les onglets passent par `open_tab()` (#255), l'import paresseux se fait *dans* `build()` et est donc facturé à `construct=` : l'import et la construction du widget arrivent comme un seul chiffre. La capture d'origine de l'issue, elle, portait bien `import=133ms construct=141ms` séparément.

Cette PR :

- `open_tab(name, build, *, module=...)` importe le module dans une phase `"import"` distincte et le passe à `build()` ;
- les six onglets à import paresseux (Ring Player Stats, Session Stats, Version, Graphs, Tourney Graphs, Stats Guide) passent leur nom de module ;
- les onglets dont le module est déjà importé au démarrage gardent un `build()` sans argument et n'affichent aucune phase `import=` — l'absence signifie « rien à importer », pas « non mesuré » ;
- un test AST interdit à un onglet de faire son propre import, hors de la phase mesurée ;
- le docstring de `ui_instrumentation` perd le scan de polices Matplotlib qu'il accusait encore : c'est la phrase qui avait envoyé l'analyse de #249 sur un coût supprimé par #228.

Nouvelle ligne attendue :

```
[PERF] tab open: tab='Graphs' import=133ms construct=141ms add_tab=9ms first_paint=612ms total=755ms max_stall=430ms
```

## Comment cela tranche le lead 7

Le deuxième ouvrage du même onglet lit `import=0ms` (module déjà dans `sys.modules`) : deux lignes pour un même onglet disent donc, seules, si l'attente est l'import. La comparaison `/Applications` vs `~/Downloads` demandée par le lead 7 devient une comparaison de deux `grep '\[PERF\] tab open'`, sur un chiffre qui ne mélange plus import et construction. L'expérience manuelle elle-même reste à faire et cette PR ne ferme pas #249.

## Vérification

- `pytest test/test_tab_open_reporting.py -m "qt or not qt"` — 15 passed (2 nouveaux tests)
- `pytest test/test_ui_instrumentation.py test/test_tab_database_cleanup.py test/test_fpdb_lazy_default_paths.py test/test_fpdb_version_resolution.py test/test_macos_packaging.py test/test_menu_layout.py test/test_performance_tab_opening.py test/test_tab_opening_ui_responsiveness.py` — tout passe
- les six chemins de module ont été importés et l'attribut de classe vérifié sur chacun
- `ruff check` propre sur les trois fichiers touchés

Note : le helper de test compile désormais la méthode via `exec` plutôt que `FunctionType(code, ...)`, parce que les valeurs par défaut des arguments keyword-only vivent sur l'objet fonction et pas sur son code.