### PR TITLE
chore(hooks): reject AI attribution trailers in commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Reject Claude / Anthropic attribution trailers in commit messages.
+#
+# Matches only *attribution* lines (Co-Authored-By trailers, "Generated with"
+# footers, @anthropic.com addresses) plus any "Claude Code" mention -- a commit
+# that merely names Claude in prose, e.g. "Ignore local Claude config", passes.
+#
+# Enable in your clone (once per clone, hooks are not shared by git itself):
+#     git config core.hooksPath .githooks
+#
+# Bypass for a one-off with: git commit --no-verify
+
+msg_file="$1"
+[ -n "$msg_file" ] && [ -f "$msg_file" ] || exit 0
+
+# Drop comment lines and anything below the --verbose scissors line, so the
+# git-supplied template can never trip the check.
+cleaned=$(sed -e '/^# -\{1,\} >8 -\{1,\}$/,$d' -e '/^[[:space:]]*#/d' "$msg_file")
+
+hits=$(printf '%s\n' "$cleaned" | grep -nEi \
+  -e '^[[:space:]]*co-authored-by:.*(claude|anthropic)' \
+  -e '@anthropic\.com' \
+  -e 'generated with[[:space:]]*\[?claude' \
+  -e '(claude code|claude\.com/claude-code)')
+
+[ -z "$hits" ] || {
+  echo "commit-msg: refused -- Claude/Anthropic attribution in the message:" >&2
+  printf '%s\n' "$hits" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Remove those lines, or commit with --no-verify to override." >&2
+  exit 1
+}
+
+exit 0

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -42,6 +42,10 @@ if [ "$prefix" = auto ]; then
     # that choice. Read the character back off the scissors line git generated,
     # and otherwise fall back to the '#' git picks for an empty buffer.
     prefix=$(awk '/^. -+ >8 -+$/ { print substr($0, 1, 1); exit }' "$msg_file")
+    # Without --verbose there is no scissors line, but git appended its status
+    # template at the end, so the last non-blank line carries the prefix.
+    [ -n "$prefix" ] || prefix=$(awk 'NF { last = $0 }
+        END { c = substr(last, 1, 1); if (index("#;@!$%^&|:", c) > 0) print c }' "$msg_file")
     [ -n "$prefix" ] || prefix='#'
 fi
 
@@ -57,13 +61,17 @@ cleaned=$(awk -v p="$prefix" '
             }
         # Only cut when the tail really is the diff git appended for
         # --verbose; a scissors line in a -F message survives into the commit.
+        # Require the exact shape git emits: the cut line, then its own comment
+        # lines, then the diff. Free-floating patch text below a scissors marker
+        # is not proof that git generated the tail.
         tail_is_diff = 0
-        if (cut > 0)
-            for (i = cut; i <= n; i++)
-                if (line[i] ~ /^diff --git /) {
-                    tail_is_diff = 1
-                    break
-                }
+        if (cut > 0) {
+            j = cut + 1
+            comments = 0
+            while (j <= n && substr(line[j], 1, plen) == p) { j++; comments++ }
+            if (comments >= 1 && j <= n && line[j] ~ /^diff --git /)
+                tail_is_diff = 1
+        }
         last = tail_is_diff ? cut - 1 : n
         for (i = 1; i <= last; i++)
             if (substr(line[i], 1, plen) != p) print line[i]

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,35 +1,87 @@
 #!/bin/sh
 #
-# Reject Claude / Anthropic attribution trailers in commit messages.
+# Reject AI attribution trailers in commit messages.
 #
-# Matches only *attribution* lines (Co-Authored-By trailers, "Generated with"
-# footers, @anthropic.com addresses) plus any "Claude Code" mention -- a commit
-# that merely names Claude in prose, e.g. "Ignore local Claude config", passes.
+# Matches only attribution lines (co-author trailers, "Generated with"
+# footers, Anthropic e-mail addresses) plus any "Claude Code" mention. A
+# commit that merely names Claude in prose, e.g. "Ignore local Claude
+# config", passes.
 #
 # Enable in your clone (once per clone, hooks are not shared by git itself):
 #     git config core.hooksPath .githooks
+# or just: make dev-setup
 #
 # Bypass for a one-off with: git commit --no-verify
 
 msg_file="$1"
 [ -n "$msg_file" ] && [ -f "$msg_file" ] || exit 0
 
-# Drop comment lines and anything below the --verbose scissors line, so the
-# git-supplied template can never trip the check.
-cleaned=$(sed -e '/^# -\{1,\} >8 -\{1,\}$/,$d' -e '/^[[:space:]]*#/d' "$msg_file")
+# This hook runs BEFORE git cleans the message up, so it must remove exactly
+# what git would remove and nothing more:
+#
+#   * Comment lines. Git only treats the prefix as a comment at column 0, and
+#     the prefix is configurable, so honour core.commentString / commentChar.
+#   * The verbose diff that --verbose appends below the scissors line.
+#
+# It must NOT drop a scissors tail in general: `git commit -F` uses
+# cleanup=whitespace and keeps that text in the stored message, so discarding
+# it here would let a trailer through unseen.
+#
+# Known limit: `git commit -F` also keeps comment lines, so a trailer that is
+# commented out in the message file survives into the commit unchecked. Git
+# does not parse a commented line as a trailer, so no co-author attribution
+# results from it -- only the literal text remains.
+
+prefix=$(git config --get core.commentString 2>/dev/null)
+[ -n "$prefix" ] || prefix=$(git config --get core.commentChar 2>/dev/null)
+[ -n "$prefix" ] || prefix='#'
+
+if [ "$prefix" = auto ]; then
+    # Git resolves "auto" against the message as it stood BEFORE its template
+    # was appended, which this hook cannot observe -- so do not try to replay
+    # that choice. Read the character back off the scissors line git generated,
+    # and otherwise fall back to the '#' git picks for an empty buffer.
+    prefix=$(awk '/^. -+ >8 -+$/ { print substr($0, 1, 1); exit }' "$msg_file")
+    [ -n "$prefix" ] || prefix='#'
+fi
+
+cleaned=$(awk -v p="$prefix" '
+    { line[++n] = $0 }
+    END {
+        plen = length(p)
+        cut = 0
+        for (i = 1; i <= n; i++)
+            if (substr(line[i], 1, plen) == p && substr(line[i], plen + 1) ~ /^ -+ >8 -+$/) {
+                cut = i
+                break
+            }
+        # Only cut when the tail really is the diff git appended for
+        # --verbose; a scissors line in a -F message survives into the commit.
+        tail_is_diff = 0
+        if (cut > 0)
+            for (i = cut; i <= n; i++)
+                if (line[i] ~ /^diff --git /) {
+                    tail_is_diff = 1
+                    break
+                }
+        last = tail_is_diff ? cut - 1 : n
+        for (i = 1; i <= last; i++)
+            if (substr(line[i], 1, plen) != p) print line[i]
+    }
+' "$msg_file")
 
 hits=$(printf '%s\n' "$cleaned" | grep -nEi \
-  -e '^[[:space:]]*co-authored-by:.*(claude|anthropic)' \
-  -e '@anthropic\.com' \
-  -e 'generated with[[:space:]]*\[?claude' \
-  -e '(claude code|claude\.com/claude-code)')
+    -e '^[[:space:]]*co-authored-by:.*(claude|anthropic)' \
+    -e '@anthropic\.com' \
+    -e 'generated with[[:space:]]*\[?claude' \
+    -e '(claude code|claude\.com/claude-code)')
 
 [ -z "$hits" ] || {
-  echo "commit-msg: refused -- Claude/Anthropic attribution in the message:" >&2
-  printf '%s\n' "$hits" | sed 's/^/  /' >&2
-  echo "" >&2
-  echo "Remove those lines, or commit with --no-verify to override." >&2
-  exit 1
+    echo "commit-msg: refused -- AI attribution in the message:" >&2
+    printf '%s\n' "$hits" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "Remove those lines, or commit with --no-verify to override." >&2
+    exit 1
 }
 
 exit 0

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -27,10 +27,17 @@ msg_file="$1"
 # cleanup=whitespace and keeps that text in the stored message, so discarding
 # it here would let a trailer through unseen.
 #
-# Known limit: `git commit -F` also keeps comment lines, so a trailer that is
-# commented out in the message file survives into the commit unchecked. Git
-# does not parse a commented line as a trailer, so no co-author attribution
-# results from it -- only the literal text remains.
+# Accepted limits. This hook guards against an accidental trailer, not against
+# someone determined to plant one -- anyone determined already has --no-verify.
+# Both remaining holes need a hand-written `git commit -F` message:
+#
+#   * A commented-out trailer survives, because -F keeps comment lines. Git
+#     does not parse a commented line as a trailer, so nothing is attributed;
+#     only the literal text remains.
+#   * A message reproducing git's own template shape below a scissors marker
+#     is taken for a generated tail and skipped. Closing this for real would
+#     mean checking the stored message instead, in a pre-push hook, since a
+#     commit-msg hook runs before cleanup and is told nothing about its mode.
 
 prefix=$(git config --get core.commentString 2>/dev/null)
 [ -n "$prefix" ] || prefix=$(git config --get core.commentChar 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ clean: ## Clean up generated files
 
 # Development workflow commands
 dev-setup: install-deps ## Set up development environment
+	@git config core.hooksPath .githooks
+	@echo "Git hooks enabled (core.hooksPath -> .githooks)"
 	@echo "Development environment ready!"
 	@echo "Run 'make test' to run tests"
 	@echo "Run 'make lint' to check code style"


### PR DESCRIPTION
## Why

Seventeen commits already in history carry an AI co-author trailer. Nothing
enforced their absence, so new ones could land at any time. This adds a
repository-side guard.

## What

- `.githooks/commit-msg` — refuses co-author trailers, `Generated with`
  footers and Anthropic e-mail addresses in a commit message.
- `make dev-setup` now runs `git config core.hooksPath .githooks`, so a fresh
  clone picks the hook up without a manual step.

Only *attribution* lines are matched. A commit that names Claude in prose,
such as `Ignore local Claude config and vendored pypoker-eval checkout`
(`3de564f`), still passes. Comment lines and everything below the
`git commit --verbose` scissors line are stripped before the check, so git's
own template can never trip the hook.

`git commit --no-verify` remains available for a deliberate one-off.

## Testing

Six cases exercised against the hook, including two real messages from this
repository's history:

| Case | Result |
| --- | --- |
| Clean conventional commit | passes |
| `3de564f` — names Claude in prose | passes |
| `1b2c006` — carries the co-author trailer | blocked |
| `Generated with` footer | blocked |
| Anthropic e-mail in a trailer | blocked |
| Trailer present only inside git's comment template | passes |

End-to-end: a real `git commit` carrying the trailer was rejected through
`core.hooksPath` and `HEAD` did not move. `make -n dev-setup` expands
correctly, and removing `core.hooksPath` then replaying the recipe line
restores it.

## Notes

- `core.hooksPath` is per-clone config, not versioned — existing clones need
  `make dev-setup` (or the `git config` line) once.
- Setting `core.hooksPath` disables `.git/hooks/` entirely. Harmless today
  (only `.sample` files there), but a future `pre-commit` install would need
  pointing at `.githooks/`.
- Branch name is `fix/issues-259` for continuity; this change is unrelated to
  that issue.
