### PR TITLE
fix(stats): finish the PT4 action enums — float, guard, and persistence

### DIFF
--- a/fpdb_3_legacy/DerivedStats.py
+++ b/fpdb_3_legacy/DerivedStats.py
@@ -1286,8 +1286,8 @@ class DerivedStats:
 
 
         # ---- enum_folded -------------------------------------------------
-        # Chaque joueur est marqué sur SA première rue de fold (pas de break
-        # global : plusieurs joueurs foldent à des rues différentes).
+        # Each player is marked on the street where THEY folded, so there is no
+        # global break: several players fold on different streets.
         fold_streets = (("P", "BLINDSANTES"), ("P", "PREFLOP"), ("F", "FLOP"),
                         ("T", "TURN"), ("R", "RIVER"))
         pending = set(ps_all)

--- a/fpdb_3_legacy/DerivedStats.py
+++ b/fpdb_3_legacy/DerivedStats.py
@@ -1270,11 +1270,19 @@ class DerivedStats:
         acts_by = {st: snapshot.get(st, [])
                    for st in ("PREFLOP", "FLOP", "TURN", "RIVER")}
 
-        def pos_code(name):
+        def pos_code(name: str) -> int | None:
+            """Positional rank: lower means closer to the button, i.e. later.
+
+            ``position`` is an int for seated players (0 = button, growing
+            away from it) and "S"/"B" for the blinds, which act first
+            postflop and therefore rank behind every numbered seat.
+            """
             v = ps_all.get(name, {}).get("position")
-            if v is not None and not isinstance(v, str):
-                v = None
-            return {"S": 9, "B": 8}.get(v, v) if isinstance(v, str) else v
+            if isinstance(v, str):
+                if v in ("S", "B"):
+                    return 9 if v == "S" else 8
+                return int(v) if v.isdigit() else None
+            return v if isinstance(v, int) else None
 
 
         # ---- enum_folded -------------------------------------------------

--- a/fpdb_3_legacy/DerivedStats.py
+++ b/fpdb_3_legacy/DerivedStats.py
@@ -1326,10 +1326,16 @@ class DerivedStats:
         for pos_i, (raw_i, pname, act) in enumerate(preflop_raw):
             ps = ps_all.get(pname)
             if ps is not None and level >= 2 and pname != last_raiser:
-                already = any(p2 == pname and a2 in decision
-                              for p2, _n, a2 in preflop_raw
-                              if prev_raise_pos is not None
-                              and prev_raise_pos < pos_i > p2 > prev_raise_pos)
+                # Keep a player's FIRST answer to the standing raise: anything
+                # they did between that raise and now has already answered it.
+                # Preflop this is close to unreachable -- one decision per raise
+                # level -- but it pins the enum to the first reaction when a
+                # parser emits an extra action for the same level.
+                already = any(
+                    other == pname and a2 in decision
+                    for j, (_raw_j, other, a2) in enumerate(preflop_raw)
+                    if prev_raise_pos is not None and prev_raise_pos < j < pos_i
+                )
                 if not already:
                     resp = resp_of.get(act)
                     if resp is not None and resp in ("F", "C", "R"):

--- a/fpdb_3_legacy/DerivedStats.py
+++ b/fpdb_3_legacy/DerivedStats.py
@@ -387,21 +387,28 @@ def _initRaiseSizing(init: dict[str, Any]) -> None:
     init["val_p_5bet_facing_bp"] = 0
 
 
+# PT4 enum_*_action columns, in the order HandsPlayers stores them. Both
+# database_schema.HANDS_PLAYERS_KEYS and the store_hands_players insert repeat
+# this order; test_action_enum_persistence guards the three against drift.
+ACTION_ENUM_KEYS = (
+    "enum_p_3bet_action", "enum_p_4bet_action", "enum_p_squeeze_action",
+    "enum_f_3bet_action", "enum_f_4bet_action", "enum_f_cbet_action",
+    "enum_f_donk_action", "enum_t_3bet_action", "enum_t_4bet_action",
+    "enum_t_cbet_action", "enum_t_float_action", "enum_t_donk_action",
+    "enum_r_3bet_action", "enum_r_4bet_action", "enum_r_cbet_action",
+    "enum_r_float_action", "enum_r_donk_action",
+    "enum_face_allin", "enum_face_allin_action", "enum_folded",
+)
+
+
 def _initActionEnums(init: dict[str, Any]) -> None:
     """PT4 action enums: response char F/C/R, or N when situation absent.
 
     enum_folded carries the street of the fold (P/F/T/R/N); enum_face_allin
     uses a lowercase street char when folded, uppercase otherwise.
     """
-    for key in ("enum_p_3bet_action", "enum_p_4bet_action", "enum_p_squeeze_action",
-                "enum_f_3bet_action", "enum_f_4bet_action", "enum_f_cbet_action",
-                "enum_f_donk_action", "enum_t_3bet_action", "enum_t_4bet_action",
-                "enum_t_cbet_action", "enum_t_float_action", "enum_t_donk_action",
-                "enum_r_3bet_action", "enum_r_4bet_action", "enum_r_cbet_action",
-                "enum_r_float_action", "enum_r_donk_action",
-                "enum_face_allin", "enum_face_allin_action"):
+    for key in ACTION_ENUM_KEYS:
         init[key] = "N"
-    init["enum_folded"] = "N"
 
 
 def _buildStatsInitializer() -> dict:

--- a/fpdb_3_legacy/database_schema.py
+++ b/fpdb_3_legacy/database_schema.py
@@ -347,7 +347,35 @@ HANDS_PLAYERS_KEYS = [
     # Turn probe bet (DerivedStats._calc_turn_probe).
     "street2ProbeChance",
     "street2ProbeDone",
+    # PT4 action enums (DerivedStats.calcActionEnums). One char per column --
+    # F/C/R for the response, N when the situation never came up -- so they are
+    # CHAR(1) rather than the INT the other stat columns use. The order mirrors
+    # DerivedStats.ACTION_ENUM_KEYS and the store_hands_players insert.
+    "enum_p_3bet_action",
+    "enum_p_4bet_action",
+    "enum_p_squeeze_action",
+    "enum_f_3bet_action",
+    "enum_f_4bet_action",
+    "enum_f_cbet_action",
+    "enum_f_donk_action",
+    "enum_t_3bet_action",
+    "enum_t_4bet_action",
+    "enum_t_cbet_action",
+    "enum_t_float_action",
+    "enum_t_donk_action",
+    "enum_r_3bet_action",
+    "enum_r_4bet_action",
+    "enum_r_cbet_action",
+    "enum_r_float_action",
+    "enum_r_donk_action",
+    "enum_face_allin",
+    "enum_face_allin_action",
+    "enum_folded",
 ]
+
+# The subset of HANDS_PLAYERS_KEYS holding a PT4 action enum. Split out so the
+# migration can give them a char column instead of the INT default.
+ACTION_ENUM_COLUMNS = [key for key in HANDS_PLAYERS_KEYS if key.startswith("enum_")]
 
 # Just like STATS_KEYS, this lets us efficiently add data at the
 # "beginning" later.
@@ -1019,6 +1047,8 @@ class DatabaseSchemaMixin:
     def ensure_handsplayers_columns(self) -> None:
         """Add missing HandsPlayers stat columns for databases created by older code."""
         definitions = {column: "INT DEFAULT 0" for column in HANDS_PLAYERS_KEYS}
+        # The PT4 action enums store a single response char, not a counter.
+        definitions.update({column: "CHAR(1) DEFAULT 'N'" for column in ACTION_ENUM_COLUMNS})
         definitions["handString"] = "TEXT"
         definitions["cashOutFee"] = "INT DEFAULT 0"
         definitions["isCashOut"] = "BOOLEAN DEFAULT 0"

--- a/fpdb_3_legacy/sql_queries_hand_player_persistence.py
+++ b/fpdb_3_legacy/sql_queries_hand_player_persistence.py
@@ -311,7 +311,27 @@ def hand_player_persistence_queries() -> dict[str, str]:
              street2DelayedCBChance,
              street2DelayedCBDone,
              street2ProbeChance,
-             street2ProbeDone
+             street2ProbeDone,
+             enum_p_3bet_action,
+             enum_p_4bet_action,
+             enum_p_squeeze_action,
+             enum_f_3bet_action,
+             enum_f_4bet_action,
+             enum_f_cbet_action,
+             enum_f_donk_action,
+             enum_t_3bet_action,
+             enum_t_4bet_action,
+             enum_t_cbet_action,
+             enum_t_float_action,
+             enum_t_donk_action,
+             enum_r_3bet_action,
+             enum_r_4bet_action,
+             enum_r_cbet_action,
+             enum_r_float_action,
+             enum_r_donk_action,
+             enum_face_allin,
+             enum_face_allin_action,
+             enum_folded
             )
             values (
                  %s, %s, %s, %s, %s,
@@ -372,6 +392,10 @@ def hand_player_persistence_queries() -> dict[str, str]:
             %s, %s, %s, %s,
             %s, %s, %s, %s
             ,
-                 %s)"""
+                 %s,
+                 %s, %s, %s, %s, %s,
+                 %s, %s, %s, %s, %s,
+                 %s, %s, %s, %s, %s,
+                 %s, %s, %s, %s, %s)"""
     return query
 

--- a/fpdb_3_legacy/sql_schema_hand_player.py
+++ b/fpdb_3_legacy/sql_schema_hand_player.py
@@ -331,7 +331,27 @@ def hand_player_schema_queries(db_server: str) -> dict[str, str]:
                                 cnt_r_raise_made_2 INT,
                                 val_r_raise_made_2_bp INT,
                                 cnt_p_5bet_facing INT,
-                                val_p_5bet_facing_bp INT)
+                                val_p_5bet_facing_bp INT,
+                                enum_p_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_p_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_p_squeeze_action CHAR(1) DEFAULT 'N',
+                                enum_f_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_f_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_f_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_f_donk_action CHAR(1) DEFAULT 'N',
+                                enum_t_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_t_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_t_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_t_float_action CHAR(1) DEFAULT 'N',
+                                enum_t_donk_action CHAR(1) DEFAULT 'N',
+                                enum_r_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_r_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_r_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_r_float_action CHAR(1) DEFAULT 'N',
+                                enum_r_donk_action CHAR(1) DEFAULT 'N',
+                                enum_face_allin CHAR(1) DEFAULT 'N',
+                                enum_face_allin_action CHAR(1) DEFAULT 'N',
+                                enum_folded CHAR(1) DEFAULT 'N')
                                 ENGINE=INNODB"""
     elif db_server == "postgresql":
         ddl = """CREATE TABLE HandsPlayers (
@@ -659,7 +679,27 @@ def hand_player_schema_queries(db_server: str) -> dict[str, str]:
                                 cnt_r_raise_made_2 INT,
                                 val_r_raise_made_2_bp INT,
                                 cnt_p_5bet_facing INT,
-                                val_p_5bet_facing_bp INT)"""
+                                val_p_5bet_facing_bp INT,
+                                enum_p_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_p_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_p_squeeze_action CHAR(1) DEFAULT 'N',
+                                enum_f_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_f_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_f_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_f_donk_action CHAR(1) DEFAULT 'N',
+                                enum_t_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_t_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_t_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_t_float_action CHAR(1) DEFAULT 'N',
+                                enum_t_donk_action CHAR(1) DEFAULT 'N',
+                                enum_r_3bet_action CHAR(1) DEFAULT 'N',
+                                enum_r_4bet_action CHAR(1) DEFAULT 'N',
+                                enum_r_cbet_action CHAR(1) DEFAULT 'N',
+                                enum_r_float_action CHAR(1) DEFAULT 'N',
+                                enum_r_donk_action CHAR(1) DEFAULT 'N',
+                                enum_face_allin CHAR(1) DEFAULT 'N',
+                                enum_face_allin_action CHAR(1) DEFAULT 'N',
+                                enum_folded CHAR(1) DEFAULT 'N')"""
     elif db_server == "sqlite":
         ddl = """CREATE TABLE HandsPlayers (
                                 id INTEGER PRIMARY KEY,
@@ -986,7 +1026,27 @@ def hand_player_schema_queries(db_server: str) -> dict[str, str]:
                                   cnt_r_raise_made_2 INT,
                                   val_r_raise_made_2_bp INT,
                                   cnt_p_5bet_facing INT,
-                                  val_p_5bet_facing_bp INT)
+                                  val_p_5bet_facing_bp INT,
+                                  enum_p_3bet_action CHAR(1) DEFAULT 'N',
+                                  enum_p_4bet_action CHAR(1) DEFAULT 'N',
+                                  enum_p_squeeze_action CHAR(1) DEFAULT 'N',
+                                  enum_f_3bet_action CHAR(1) DEFAULT 'N',
+                                  enum_f_4bet_action CHAR(1) DEFAULT 'N',
+                                  enum_f_cbet_action CHAR(1) DEFAULT 'N',
+                                  enum_f_donk_action CHAR(1) DEFAULT 'N',
+                                  enum_t_3bet_action CHAR(1) DEFAULT 'N',
+                                  enum_t_4bet_action CHAR(1) DEFAULT 'N',
+                                  enum_t_cbet_action CHAR(1) DEFAULT 'N',
+                                  enum_t_float_action CHAR(1) DEFAULT 'N',
+                                  enum_t_donk_action CHAR(1) DEFAULT 'N',
+                                  enum_r_3bet_action CHAR(1) DEFAULT 'N',
+                                  enum_r_4bet_action CHAR(1) DEFAULT 'N',
+                                  enum_r_cbet_action CHAR(1) DEFAULT 'N',
+                                  enum_r_float_action CHAR(1) DEFAULT 'N',
+                                  enum_r_donk_action CHAR(1) DEFAULT 'N',
+                                  enum_face_allin CHAR(1) DEFAULT 'N',
+                                  enum_face_allin_action CHAR(1) DEFAULT 'N',
+                                  enum_folded CHAR(1) DEFAULT 'N')
                                 """
     else:
         return {}

--- a/test/test_action_enum_persistence.py
+++ b/test/test_action_enum_persistence.py
@@ -132,8 +132,13 @@ class TestActionEnumSchemaSync:
 class TestActionEnumRoundTrip:
     """A parsed hand must land its enum values in HandsPlayers."""
 
-    def _stored(self, columns: str) -> tuple[dict, dict]:
-        """Insert a parsed hand through the real storeHandsPlayers, then read back."""
+    def _stored(self) -> tuple[dict, dict]:
+        """Insert a parsed hand through the real storeHandsPlayers, then read back.
+
+        Rows come back as name -> column dict. The select names no columns of
+        its own so the query stays a literal: the point is what the insert
+        wrote, and sqlite3.Row already labels it.
+        """
         pdata = _hands_players()
         conn = _sqlite_connection()
 
@@ -147,13 +152,14 @@ class TestActionEnumRoundTrip:
         db.storeHandsPlayers(hid=1, pids=pids, pdata=pdata, doinsert=True)
 
         try:
-            rows = {
-                name: conn.execute(
-                    f"SELECT {columns} FROM HandsPlayers WHERE playerId = ?",
-                    (pids[name],),
+            conn.row_factory = sqlite3.Row
+            rows = {}
+            for name, pid in pids.items():
+                row = conn.execute(
+                    "SELECT * FROM HandsPlayers WHERE playerId = ?",
+                    (pid,),
                 ).fetchone()
-                for name in pdata
-            }
+                rows[name] = dict(row) if row is not None else None
         finally:
             conn.close()
             # db has to outlive the reads: Database.__del__ closes the connection.
@@ -162,22 +168,21 @@ class TestActionEnumRoundTrip:
         return pdata, rows
 
     def test_enum_values_survive_the_insert(self) -> None:
-        pdata, rows = self._stored("enum_t_float_action")
+        pdata, rows = self._stored()
         assert pdata["Floater"]["enum_t_float_action"] == "R", "fixture no longer exercises a float"
         assert rows["Floater"] is not None, "no HandsPlayers row was written"
-        assert rows["Floater"][0] == "R"
+        assert rows["Floater"]["enum_t_float_action"] == "R"
 
     def test_absent_situations_are_stored_as_n(self) -> None:
         """The default must round-trip too, so aggregates can count it."""
-        _pdata, rows = self._stored("enum_t_float_action")
-        assert rows["BBGuy"][0] == "N"
+        _pdata, rows = self._stored()
+        assert rows["BBGuy"]["enum_t_float_action"] == "N"
 
     def test_every_enum_column_is_written(self) -> None:
         """All twenty columns must carry what DerivedStats computed."""
-        columns = ", ".join(ACTION_ENUM_KEYS)
-        pdata, rows = self._stored(columns)
+        pdata, rows = self._stored()
         for name, row in rows.items():
-            stored = dict(zip(ACTION_ENUM_KEYS, row))
+            stored = {key: row[key] for key in ACTION_ENUM_KEYS}
             expected = {key: pdata[name][key] for key in ACTION_ENUM_KEYS}
             assert stored == expected, f"{name} round-tripped wrong"
 

--- a/test/test_action_enum_persistence.py
+++ b/test/test_action_enum_persistence.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""The PT4 action enums must reach HandsPlayers, not just the stats dict.
+
+``DerivedStats.calcActionEnums`` computed twenty ``enum_*`` values that no
+schema, insert or key list mentioned, so every one of them was recomputed on
+each import and thrown away. These tests cover the three places that have to
+agree and the round trip through a real insert.
+"""
+
+import os
+import re
+import sqlite3
+import sys
+from decimal import Decimal
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import fpdb_3_legacy.Database as Database
+import fpdb_3_legacy.SQL as SQL
+from fpdb_3_legacy.Database import adapt_decimal, convert_decimal
+from fpdb_3_legacy.DerivedStats import ACTION_ENUM_KEYS, DerivedStats
+from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
+
+
+class MockConfig:
+    def get_import_parameters(self) -> dict:
+        return {
+            "saveActions": True,
+            "callFpdbHud": False,
+            "cacheSessions": False,
+            "publicDB": False,
+            "importFilters": [],
+            "handCount": 0,
+            "fastFold": False,
+            "ringFilter": True,
+            "tourneyFilter": True,
+        }
+
+    def get_site_id(self, sitename: str) -> int:
+        return 32
+
+
+# The button calls the small blind's flop c-bet and raises the turn barrel:
+# Floater's enum_t_float_action is R, which is not the "N" default and so
+# proves the value itself survives the round trip.
+FLOAT_HAND = """PokerStars Hand #100000000002:  Hold'em No Limit ($0.05/$0.10 USD) - 2024/01/01 12:00:00 ET
+Table 'TestFloat' 6-max Seat #3 is the button
+Seat 1: PFA ($10 in chips)
+Seat 2: BBGuy ($10 in chips)
+Seat 3: Floater ($10 in chips)
+PFA: posts small blind $0.05
+BBGuy: posts big blind $0.10
+*** HOLE CARDS ***
+Dealt to PFA [As Kd]
+Floater: calls $0.10
+PFA: raises $0.30 to $0.40
+BBGuy: folds
+Floater: calls $0.30
+*** FLOP *** [9h Kd 2d]
+PFA: bets $0.50
+Floater: calls $0.50
+*** TURN *** [9h Kd 2d] [7c]
+PFA: bets $1
+Floater: raises $2 to $3
+PFA: folds
+*** SUMMARY ***
+Total pot $3.80 | Rake $0
+Board [9h Kd 2d 7c]
+Seat 1: PFA folded on the Turn
+Seat 3: Floater collected $3.80"""
+
+
+def _hands_players() -> dict:
+    parser = PokerStars(config=MockConfig())
+
+    def mock_read_file() -> bool:
+        parser.obs = FLOAT_HAND
+        parser.index = 0
+        return True
+
+    parser.readFile = mock_read_file
+    hand = parser.processHand(parser.allHandsAsList()[0])
+    stats = DerivedStats()
+    stats.getStats(hand)
+    return stats.getHandsPlayers()
+
+
+def _sqlite_connection() -> sqlite3.Connection:
+    """A connection set up the way Database.connect() sets up the SQLite one."""
+    sqlite3.register_converter("bool", lambda x: bool(int(x)))
+    sqlite3.register_adapter(bool, lambda x: 1 if x else 0)
+    sqlite3.register_converter("decimal", convert_decimal)
+    sqlite3.register_adapter(Decimal, adapt_decimal)
+    conn = sqlite3.connect(":memory:")
+    conn.execute(SQL.Sql(db_server="sqlite").query["createHandsPlayersTable"])
+    return conn
+
+
+def _insert_columns() -> list[str]:
+    query = SQL.Sql(db_server="sqlite").query["store_hands_players"]
+    col_block = re.search(r"\((.*?)\)\s*values", query, re.IGNORECASE | re.DOTALL)
+    return [c.strip() for c in col_block.group(1).split(",") if c.strip()]
+
+
+class TestActionEnumSchemaSync:
+    """ACTION_ENUM_KEYS, HANDS_PLAYERS_KEYS and the insert must list the same columns."""
+
+    def test_every_enum_key_is_a_stored_column(self) -> None:
+        stored = set(Database.HANDS_PLAYERS_KEYS)
+        missing = [key for key in ACTION_ENUM_KEYS if key not in stored]
+        assert not missing, f"enum keys absent from HANDS_PLAYERS_KEYS: {missing}"
+
+    def test_no_stored_enum_column_is_unknown_to_derivedstats(self) -> None:
+        """A column DerivedStats never fills would KeyError in storeHandsPlayers."""
+        stored = [key for key in Database.HANDS_PLAYERS_KEYS if key.startswith("enum_")]
+        unknown = [key for key in stored if key not in ACTION_ENUM_KEYS]
+        assert not unknown, f"columns no calculator produces: {unknown}"
+
+    def test_insert_lists_the_enum_columns_in_key_order(self) -> None:
+        """storeHandsPlayers positions values by HANDS_PLAYERS_KEYS order."""
+        columns = [c for c in _insert_columns() if c.startswith("enum_")]
+        assert columns == list(ACTION_ENUM_KEYS)
+
+    def test_derivedstats_produces_every_enum_key(self) -> None:
+        for player, pdata in _hands_players().items():
+            missing = [key for key in ACTION_ENUM_KEYS if key not in pdata]
+            assert not missing, f"{player} missing {missing}"
+
+
+class TestActionEnumRoundTrip:
+    """A parsed hand must land its enum values in HandsPlayers."""
+
+    def _stored(self, columns: str) -> tuple[dict, dict]:
+        """Insert a parsed hand through the real storeHandsPlayers, then read back."""
+        pdata = _hands_players()
+        conn = _sqlite_connection()
+
+        db = Database.Database.__new__(Database.Database)
+        db.backend = Database.Database.SQLITE
+        db.connection = conn
+        db._in_transaction = 0
+        db.sql = SQL.Sql(db_server="sqlite")
+        db.hpbulk = []
+        pids = {name: i + 1 for i, name in enumerate(pdata)}
+        db.storeHandsPlayers(hid=1, pids=pids, pdata=pdata, doinsert=True)
+
+        try:
+            rows = {
+                name: conn.execute(
+                    f"SELECT {columns} FROM HandsPlayers WHERE playerId = ?",
+                    (pids[name],),
+                ).fetchone()
+                for name in pdata
+            }
+        finally:
+            conn.close()
+            # db has to outlive the reads: Database.__del__ closes the connection.
+            del db
+
+        return pdata, rows
+
+    def test_enum_values_survive_the_insert(self) -> None:
+        pdata, rows = self._stored("enum_t_float_action")
+        assert pdata["Floater"]["enum_t_float_action"] == "R", "fixture no longer exercises a float"
+        assert rows["Floater"] is not None, "no HandsPlayers row was written"
+        assert rows["Floater"][0] == "R"
+
+    def test_absent_situations_are_stored_as_n(self) -> None:
+        """The default must round-trip too, so aggregates can count it."""
+        _pdata, rows = self._stored("enum_t_float_action")
+        assert rows["BBGuy"][0] == "N"
+
+    def test_every_enum_column_is_written(self) -> None:
+        """All twenty columns must carry what DerivedStats computed."""
+        columns = ", ".join(ACTION_ENUM_KEYS)
+        pdata, rows = self._stored(columns)
+        for name, row in rows.items():
+            stored = dict(zip(ACTION_ENUM_KEYS, row))
+            expected = {key: pdata[name][key] for key in ACTION_ENUM_KEYS}
+            assert stored == expected, f"{name} round-tripped wrong"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_derived_stats_action_enums.py
+++ b/tests/test_derived_stats_action_enums.py
@@ -113,6 +113,36 @@ Seat 2: Villain collected €2.00
 Seat 3: ColdCaller folded on the Flop
 """
 
+# Float IP par un joueur non-blind : le bouton call le c-bet flop du PFA
+# (small blind), puis raise la 2e barre turn. pos_code doit comparer une
+# position entiere (bouton = 0) a une position blind ("S") sans les annuler.
+STARS_FLOAT_IP = """PokerStars Hand #261999999977:  Hold'em No Limit (€0.01/€0.02 EUR) - 2026/06/07 18:00:00 CET
+Table 'Float IP' 6-max Seat #3 is the button
+Seat 1: PFA (€2.00 in chips)
+Seat 2: BBGuy (€2.00 in chips)
+Seat 3: Floater (€2.00 in chips)
+PFA: posts small blind €0.01
+BBGuy: posts big blind €0.02
+*** HOLE CARDS ***
+Dealt to PFA [As Kd]
+Floater: calls €0.02
+PFA: raises €0.06 to €0.08
+BBGuy: folds
+Floater: calls €0.06
+*** FLOP *** [9h Kd 2d]
+PFA: bets €0.10
+Floater: calls €0.10
+*** TURN *** [9h Kd 2d] [7c]
+PFA: bets €0.20
+Floater: raises €0.40 to €0.60
+PFA: folds
+*** SUMMARY ***
+Total pot €0.96 | Rake €0.04
+Board [9h Kd 2d 7c]
+Seat 1: PFA folded on the Turn
+Seat 3: Floater collected €0.92
+"""
+
 
 def _build_stats(hand_text: str) -> dict:
     config = LegacyConfiguration.Config()
@@ -143,6 +173,11 @@ def squeeze_fold_stats():
 @pytest.fixture()
 def raise_chain_stats():
     return _build_stats(STARS_RAISE_CHAIN)
+
+
+@pytest.fixture()
+def float_ip_stats():
+    return _build_stats(STARS_FLOAT_IP)
 
 
 # ---------------------------------------------------------------------------
@@ -245,17 +280,13 @@ def test_postflop_chain_does_not_record_donk_for_re_raiser(raise_chain_stats):
 # ---------------------------------------------------------------------------
 
 
-def test_float_records_caller_response_to_second_barrel(stats_by_player):
+def test_float_requires_the_caller_to_be_in_position(stats_by_player):
     """Le float enum suit la semantique Rust validee ~99.4 % vs PT4 live :
-    l'agressor barre deux rues consecutives, l'enum enregistre la reponse
-    du caller a la deuxieme barre. Comportement documente intentionnel."""
-    # Le ThreeBettor barre flop et turn ; Caller call flop et fold turn.
-    # Le Caller fait face a la 2e barre : c'est son enum_t_float_action.
-    # (Dans la main de base, Caller fold au turn sans avoir eu a repondre a
-    # la 2e barre en tant que caller du c-bet flop — il est en check-call
-    # et la 2e action du turn est son propre fold, pas une reponse. Donc
-    # l'enum reste a N ici, ce qui reste coherent avec la definition
-    # "caller IP repond a la deuxieme barre".)
+    l'agresseur barre deux rues consecutives et l'enum enregistre la reponse
+    du caller a la deuxieme barre — mais seulement si ce caller est IP."""
+    # Le ThreeBettor (bouton) barre flop et turn ; Caller (BB) call le flop
+    # puis fold la turn. Le motif de barre est bien la, mais le Caller est
+    # OOP face au bouton : la definition PT4 exclut le float OOP, donc N.
     assert stats_by_player["Caller"]["enum_t_float_action"] == "N"
 
 
@@ -265,3 +296,26 @@ def test_3bet_caller_already_acted_keeps_enum_n(stats_by_player):
     valide contre PT4 ne le recompte pas dans l'enum postflop."""
     # Comportement documente : Caller a repondu au 3-bet (C).
     assert stats_by_player["Caller"]["enum_p_3bet_action"] == "C"
+
+
+# ---------------------------------------------------------------------------
+# Float IP par un joueur non-blind (regression PR #266)
+# ---------------------------------------------------------------------------
+
+
+def test_float_ip_records_the_raise_of_a_non_blind_caller(float_ip_stats):
+    """Le bouton call le c-bet flop puis raise la 2e barre : enum = R.
+
+    Garde-fou contre une comparaison de positions qui ecarterait les
+    positions entieres (bouton = 0) au profit des seules blinds "S"/"B",
+    ce qui rendrait les float enums inertes sur la quasi-totalite des mains.
+    """
+    assert float_ip_stats["Floater"]["position"] == 0
+    assert float_ip_stats["PFA"]["position"] == "S"
+    assert float_ip_stats["Floater"]["enum_t_float_action"] == "R"
+
+
+def test_float_ip_leaves_the_aggressor_at_n(float_ip_stats):
+    """L'agresseur n'est jamais le floater de sa propre barre."""
+    assert float_ip_stats["PFA"]["enum_t_float_action"] == "N"
+    assert float_ip_stats["BBGuy"]["enum_t_float_action"] == "N"

--- a/tests/test_derived_stats_action_enums.py
+++ b/tests/test_derived_stats_action_enums.py
@@ -1,10 +1,10 @@
-"""Tests PT4 enum_*_action pour DerivedStats.calcActionEnums.
+"""PT4 enum_*_action tests for DerivedStats.calcActionEnums.
 
-Couverture des scenarios ajoutes apres la review Codex (PR #266) :
-- Squeeze F / 4-bet (pas seulement call)
-- Final aggressor apres raise postflop
-- Float IP (reference Rust validee ~99.4 % vs PT4 live)
-- 3-bet/4-bet caller preservation (reference Rust validee)
+Scenarios added after the Codex review of PR #266:
+- squeeze F / 4-bet, not only the call
+- final aggressor after a postflop raise
+- IP float (Rust reference, validated ~99.4% against PT4 live)
+- 3-bet/4-bet caller preservation (validated Rust reference)
 """
 
 import os
@@ -57,7 +57,7 @@ Seat 2: Caller folded on the Turn
 Seat 3: ThreeBettor collected €1.81
 """
 
-# Squeeze F : l'open-raisier fold au 3-bet apres un cold-call.
+# Squeeze F: the open-raiser folds to the 3-bet after a cold call.
 STARS_SQUEEZE_FOLD = """PokerStars Hand #261999999990:  Hold'em No Limit (€0.01/€0.02 EUR) - 2026/06/07 18:00:00 CET
 Table 'Squeeze Fold' 6-max Seat #3 is the button
 Seat 1: OpenRaiser (€2.00 in chips)
@@ -84,8 +84,9 @@ Seat 2: ColdCaller folded on the Flop
 Seat 3: Squeezer collected €0.65
 """
 
-# Aggressor chain : PFA c-bet flop, villain raise, PFA call, villain barre turn.
-# La barre turn du villain est un "cbet" du villain (nouveau flop_aggr), pas un donk.
+# Aggressor chain: PFA c-bets the flop, villain raises, PFA calls, villain fires
+# the turn. That turn barrel is the villain's own c-bet as the new flop
+# aggressor, not a donk bet.
 STARS_RAISE_CHAIN = """PokerStars Hand #261999999980:  Hold'em No Limit (€0.01/€0.02 EUR) - 2026/06/07 18:00:00 CET
 Table 'Raise Chain' 6-max Seat #3 is the button
 Seat 1: PFA (€2.00 in chips)
@@ -113,9 +114,9 @@ Seat 2: Villain collected €2.00
 Seat 3: ColdCaller folded on the Flop
 """
 
-# Float IP par un joueur non-blind : le bouton call le c-bet flop du PFA
-# (small blind), puis raise la 2e barre turn. pos_code doit comparer une
-# position entiere (bouton = 0) a une position blind ("S") sans les annuler.
+# IP float by a non-blind player: the button calls the flop c-bet of the PFA
+# (small blind), then raises the turn barrel. pos_code has to compare an integer
+# position (button = 0) against a blind position ("S") without discarding either.
 STARS_FLOAT_IP = """PokerStars Hand #261999999977:  Hold'em No Limit (€0.01/€0.02 EUR) - 2026/06/07 18:00:00 CET
 Table 'Float IP' 6-max Seat #3 is the button
 Seat 1: PFA (€2.00 in chips)
@@ -181,7 +182,7 @@ def float_ip_stats():
 
 
 # ---------------------------------------------------------------------------
-# Tests existants (scenario de base)
+# Base scenario
 # ---------------------------------------------------------------------------
 
 
@@ -228,19 +229,19 @@ def test_all_enums_default_to_n_when_absent(stats_by_player):
 
 
 def test_os_path_guard_removed():
-    """Le fichier ne doit plus contenir de garde auto-ajoutee."""
+    """The file must no longer carry an auto-added guard."""
     path = os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy", "DerivedStats.py")
     src = open(path, encoding="utf-8").read()
     assert "AUTO-ADDED" not in src
 
 
 # ---------------------------------------------------------------------------
-# Fix 1 (Codex P1) : squeeze defense accepte F / C / R
+# Codex P1: squeeze defence accepts F / C / R
 # ---------------------------------------------------------------------------
 
 
 def test_squeeze_open_raiser_folds_is_recorded_as_F(squeeze_fold_stats):
-    """L'open-raisier fold au 3-bet alors qu'il y a un cold caller : squeeze F."""
+    """The open-raiser folds to the 3-bet with a cold caller in: squeeze F."""
     assert squeeze_fold_stats["OpenRaiser"]["enum_p_3bet_action"] == "F"
     assert squeeze_fold_stats["OpenRaiser"]["enum_p_squeeze_action"] == "F"
 
@@ -256,59 +257,68 @@ def test_squeezer_does_not_face_own_3bet(squeeze_fold_stats):
 
 
 # ---------------------------------------------------------------------------
-# Fix 3 (Codex P2) : aggressor chain apres raise postflop
+# Codex P2: aggressor chain after a postflop raise
 # ---------------------------------------------------------------------------
 
 
 def test_postflop_raise_promotes_aggressor(raise_chain_stats):
-    """PFA c-bet flop -> villain raise -> PFA call. Le villain devient le
-    flop_aggr effectif, donc sa barre turn est un c-bet, pas un donk."""
-    # Villain : barre turn apres avoir raise le flop. C'est son c-bet turn.
+    """PFA c-bets the flop -> villain raises -> PFA calls.
+
+    The villain becomes the effective flop aggressor, so the turn barrel is his
+    c-bet rather than a donk bet.
+    """
+    # The villain fires that barrel, so he never faces it himself.
     assert raise_chain_stats["Villain"]["enum_t_cbet_action"] == "N"
-    # PFA fold face a la barre turn : enregistre comme c-bet repondu.
+    # PFA folds to it, which is a c-bet answered.
     assert raise_chain_stats["PFA"]["enum_t_cbet_action"] == "F"
 
 
 def test_postflop_chain_does_not_record_donk_for_re_raiser(raise_chain_stats):
-    """La barre turn du villain n'est pas un donk (c'est sa continuation bet
-    en tant que dernier raiseur du flop)."""
+    """The villain's turn barrel is not a donk bet.
+
+    He was the last player to raise the flop, so it is his continuation bet.
+    """
     assert raise_chain_stats["Villain"]["enum_t_donk_action"] == "N"
 
 
 # ---------------------------------------------------------------------------
-# Documentation des choix de reference (Codex P1 #1 et P2 #4)
+# Reference behaviour kept on purpose (Codex P1 #1 and P2 #4)
 # ---------------------------------------------------------------------------
 
 
 def test_float_requires_the_caller_to_be_in_position(stats_by_player):
-    """Le float enum suit la semantique Rust validee ~99.4 % vs PT4 live :
-    l'agresseur barre deux rues consecutives et l'enum enregistre la reponse
-    du caller a la deuxieme barre — mais seulement si ce caller est IP."""
-    # Le ThreeBettor (bouton) barre flop et turn ; Caller (BB) call le flop
-    # puis fold la turn. Le motif de barre est bien la, mais le Caller est
-    # OOP face au bouton : la definition PT4 exclut le float OOP, donc N.
+    """The float enum follows the Rust semantics validated ~99.4% vs PT4 live.
+
+    The aggressor fires two streets in a row and the enum records the caller's
+    answer to the second barrel -- but only when that caller is in position.
+    """
+    # ThreeBettor (button) barrels flop and turn; Caller (BB) calls the flop
+    # then folds the turn. The barrelling pattern is there, but Caller is out of
+    # position against the button, and PT4 excludes an OOP float, hence N.
     assert stats_by_player["Caller"]["enum_t_float_action"] == "N"
 
 
 def test_3bet_caller_already_acted_keeps_enum_n(stats_by_player):
-    """Le caller qui cold-call entre open et 3-bet est deja documente
-    comme ayant fait face au 3-bet (enum_p_3bet_action). Le Rust
-    valide contre PT4 ne le recompte pas dans l'enum postflop."""
-    # Comportement documente : Caller a repondu au 3-bet (C).
+    """A cold caller between the open and the 3-bet already faced that 3-bet.
+
+    enum_p_3bet_action records it, and the Rust reference validated against PT4
+    does not count it again in the postflop enums.
+    """
+    # Documented behaviour: Caller answered the 3-bet with a call.
     assert stats_by_player["Caller"]["enum_p_3bet_action"] == "C"
 
 
 # ---------------------------------------------------------------------------
-# Float IP par un joueur non-blind (regression PR #266)
+# IP float by a non-blind player (regression from PR #266)
 # ---------------------------------------------------------------------------
 
 
 def test_float_ip_records_the_raise_of_a_non_blind_caller(float_ip_stats):
-    """Le bouton call le c-bet flop puis raise la 2e barre : enum = R.
+    """The button calls the flop c-bet then raises the turn barrel: enum = R.
 
-    Garde-fou contre une comparaison de positions qui ecarterait les
-    positions entieres (bouton = 0) au profit des seules blinds "S"/"B",
-    ce qui rendrait les float enums inertes sur la quasi-totalite des mains.
+    Guards against a position comparison that would drop integer positions
+    (button = 0) and keep only the "S"/"B" blinds, which leaves the float enums
+    inert on virtually every hand.
     """
     assert float_ip_stats["Floater"]["position"] == 0
     assert float_ip_stats["PFA"]["position"] == "S"
@@ -316,6 +326,6 @@ def test_float_ip_records_the_raise_of_a_non_blind_caller(float_ip_stats):
 
 
 def test_float_ip_leaves_the_aggressor_at_n(float_ip_stats):
-    """L'agresseur n'est jamais le floater de sa propre barre."""
+    """The aggressor is never the floater of his own barrel."""
     assert float_ip_stats["PFA"]["enum_t_float_action"] == "N"
     assert float_ip_stats["BBGuy"]["enum_t_float_action"] == "N"


### PR DESCRIPTION
Follow-up to #266, which landed `calcActionEnums` and twenty `enum_*` fields. Three things were missing before the family could be of any use.

## 1. The float enums were inert

The last commit of #266 (`732e2738`, "resolve pre-existing mypy errors") neutered `pos_code`. `position` is an **int** for seated players (0 = button, growing away from it) and `"S"` / `"B"` for the blinds; the guard that was added returned `None` for anything that is not a string:

```python
if v is not None and not isinstance(v, str):
    v = None
return {"S": 9, "B": 8}.get(v, v) if isinstance(v, str) else v
```

`called_cbet_ip()` therefore bailed out as soon as the caller was not a blind.

| field | before | after |
|---|---|---|
| `enum_t_float_action` | 0 non-"N" | 6 |
| `enum_r_float_action` | 0 non-"N" | 1 |

_(over the 71 hands of the PokerStars regression corpus, 384 player rows)_

`pos_code` now returns an int rank for both shapes. The `v.isdigit()` branch also covers a case the original code did not handle: a numeric string position came back as `"3"`, and `"3" < 9` would have raised a `TypeError` in the middle of an import.

Both float tests in #266 assert `"N"`, so nothing caught it. This PR adds a hand where the button calls the small blind's flop c-bet and raises the turn barrel: **the test fails on `ff8b7562`** (`assert 'N' == 'R'`).

## 2. The "already answered" guard could never fire

```python
already = any(p2 == pname and a2 in decision
              for p2, _n, a2 in preflop_raw   # p2 = index, _n = name
              if ... prev_raise_pos < pos_i > p2 > prev_raise_pos)
```

`p2 == pname` compares an int to a string: always `False`. The chained comparison also mixed the raw index space with the `preflop_raw` one. Rewritten over `enumerate(preflop_raw)`.

**No stat moves**: over the corpus the `enum_p_*` counts are identical before and after (50 / 18 / 5 non-"N" rows). Preflop a player gets one decision per raise level, so the guard stays close to unreachable — it simply holds the line it claims to hold.

## 3. None of the twenty fields were persisted anywhere

`storeHandsPlayers` only copies the keys listed in `HANDS_PLAYERS_KEYS`. No schema, no key list and no insert mentioned `enum_*`: every value was recomputed on each import and thrown away. Wired through the four places that carry a HandsPlayers stat:

- `HANDS_PLAYERS_KEYS`, appended at the end so the existing insert positions do not move (the convention already documented there)
- `store_hands_players`: 20 more columns and 20 more placeholders, 325/325
- `createHandsPlayersTable` for MySQL, PostgreSQL and SQLite
- `ensure_handsplayers_columns`, which gives them `CHAR(1) DEFAULT 'N'` instead of the `INT DEFAULT 0` the counters get

They hold one response char, not a counter, so they stay **out of HudCache**: PT4 aggregates them as `sum(if[col = 'R', 1, 0])` over hands, which the additive cache cannot express.

`DB_VERSION` is deliberately left at 224. Bumping it shows "Please recreate tables" to every existing user, and `ensure_handsplayers_columns` exists precisely so that columns appended to the key list can be ALTERed in.

The key order is now stated once, as `DerivedStats.ACTION_ENUM_KEYS`, and `test/test_action_enum_persistence.py` holds the three copies together: no key missing from the insert or the key list, no stored column that `DerivedStats` never fills (which would `KeyError` the import), and a full round trip — the button's `enum_t_float_action` comes back out of SQLite as `R`. **5 of its 7 tests fail without the persistence commit.**

## Comments back in English

The #266 work was commented in French, unlike the rest of `DerivedStats.py` and the test suite. Translated, with no behaviour touched. Two comments also described the code wrongly and are corrected on the way:

- `test_postflop_raise_promotes_aggressor` called the villain's turn barrel "son c-bet turn" right above an assertion that his own `enum_t_cbet_action` is `N` — he fires that barrel, he does not face it.
- `test_float_records_caller_response_to_second_barrel` explained its `N` by the check-call line; the real reason is positional.

## Verification

- full suite `tests/ test/`: **8087 passed**, 16 skipped, 2 failed
  - the 2 failures are the pre-existing iPoker golden snapshots, reproduced identically on `73e75ffe`, before #266
- `ruff check fpdb_3_legacy fpdb test tests tools`: clean
- `mypy` on the four modified modules: No issues found