### PR TITLE
fix(hud): stop timers during shutdown

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1457,6 +1457,14 @@ class HudMain(QObject):
             return
         self._shutdown_started = True
 
+        # Stop every timer owned by the HUD before the event loop can dispatch
+        # another callback against tables that are already being torn down.
+        for timer_name in ("_cleanup_timer", "check_tables_timer"):
+            timer = getattr(self, timer_name, None)
+            if timer is not None:
+                with contextlib.suppress(RuntimeError):
+                    timer.stop()
+
         # A batch still waiting would fire against a torn-down connection.
         batch_timer = getattr(self, "_hand_batch_timer", None)
         if batch_timer is not None:

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -678,6 +678,9 @@ def test_destroy(hud_main) -> None:
         mock_stop.assert_called_once()
         mock_quit.assert_called_once()
 
+    assert not hud_main._cleanup_timer.isActive()
+    assert not hud_main.check_tables_timer.isActive()
+
 
 # Verifies that check_tables calls the correct methods (client_destroyed, client_moved, client_resized) based on the table's status.
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The CI job fails in `test_third_tab_is_not_slower_than_the_first_two` because a test `HudMain` instance leaves its table-check timer running after the window is closed. The timer then calls `idle_move`/`idle_resize` on mocks and floods the Qt event loop with tracebacks, skewing the third-tab timing.

This PR:
- stops `_cleanup_timer` and `check_tables_timer` in `HudMain.destroy()` ;
- adds shutdown assertions to `test_destroy` to prevent timer leaks.

## Verification

- `QT_QPA_PLATFORM=offscreen pytest -m qt test/test_HUD_main.py test/test_tab_opening_ui_responsiveness.py`
- Result on the merge tree: 161 passed, 1 expected xpass.