### PR TITLE
fix(db): stop a schema migration hanging the GUI on the next tab

### DIFF
--- a/fpdb_3_legacy/database_schema.py
+++ b/fpdb_3_legacy/database_schema.py
@@ -42,6 +42,18 @@ GAMETYPE_CATEGORY_WIDTH = 10
 WIDEN_GAMETYPE_CATEGORY_MYSQL = "ALTER TABLE Gametypes MODIFY category VARCHAR(10) NOT NULL"
 WIDEN_GAMETYPE_CATEGORY_SQL = "ALTER TABLE Gametypes ALTER COLUMN category TYPE VARCHAR(10)"
 
+# Reads a column's declared width. MySQL needs the schema pinned because
+# information_schema.columns spans every database on the server; PostgreSQL's
+# is already scoped to the connected one.
+COLUMN_WIDTH_SQL = (
+    "SELECT character_maximum_length FROM information_schema.columns "
+    "WHERE lower(table_name) = %s AND lower(column_name) = %s"
+)
+COLUMN_WIDTH_MYSQL = (
+    "SELECT character_maximum_length FROM information_schema.columns "
+    "WHERE lower(table_name) = %s AND lower(column_name) = %s AND table_schema = DATABASE()"
+)
+
 # Session settings that apply DDL_LOCK_TIMEOUT_MS on each server backend.
 SET_PGSQL_LOCK_TIMEOUT = "SET lock_timeout = 2000"
 RESET_PGSQL_LOCK_TIMEOUT = "SET lock_timeout = DEFAULT"
@@ -1145,14 +1157,11 @@ class DatabaseSchemaMixin:
         callers can treat it as "nothing to widen".
         """
         c = self.get_cursor()
-        query = (
-            "SELECT character_maximum_length FROM information_schema.columns "
-            "WHERE lower(table_name) = %s AND lower(column_name) = %s"
-        )
-        params: tuple[str, ...] = (table.lower(), column.lower())
-        if self.backend == self.MYSQL_INNODB:
-            query += " AND table_schema = DATABASE()"
-        c.execute(query, params)
+        # Two whole statements rather than one built by appending the MySQL
+        # clause: the analyser reads any query assembled from parts as an
+        # injection site, and it is right to, even when every part is a literal.
+        query = COLUMN_WIDTH_MYSQL if self.backend == self.MYSQL_INNODB else COLUMN_WIDTH_SQL
+        c.execute(query, (table.lower(), column.lower()))
         row = c.fetchone()
         return None if row is None else row[0]
 

--- a/fpdb_3_legacy/database_schema.py
+++ b/fpdb_3_legacy/database_schema.py
@@ -11,6 +11,7 @@ are declared below so the coupling is visible.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +23,30 @@ log = get_logger("db")
 
 # Schema version written into Settings by create_tables and checked on connect.
 DB_VERSION = 224
+
+# How long a migration may wait for a table lock before giving up.
+#
+# PostgreSQL and MySQL both wait forever by default, and ``ensure_feature_tables``
+# runs on *every* Database() construction -- which the GUI does once per heavy
+# tab. One tab left idle inside a read transaction on Gametypes is enough to
+# make the next tab's ALTER TABLE wait on it for the life of the process, on the
+# GUI thread, with no timeout and nothing logged: the freeze reported in #249.
+# Migrations are re-attempted on every connection, so losing a race is a delay
+# until the next one, while blocking on it is the application hanging.
+DDL_LOCK_TIMEOUT_MS = 2000
+
+# Width Gametypes.category must have for aof_holdem (10 chars) to fit. The
+# statements are spelled out rather than formatted from the constant: the
+# quality gate rejects SQL built by string interpolation, whatever the input.
+GAMETYPE_CATEGORY_WIDTH = 10
+WIDEN_GAMETYPE_CATEGORY_MYSQL = "ALTER TABLE Gametypes MODIFY category VARCHAR(10) NOT NULL"
+WIDEN_GAMETYPE_CATEGORY_SQL = "ALTER TABLE Gametypes ALTER COLUMN category TYPE VARCHAR(10)"
+
+# Session settings that apply DDL_LOCK_TIMEOUT_MS on each server backend.
+SET_PGSQL_LOCK_TIMEOUT = "SET lock_timeout = 2000"
+RESET_PGSQL_LOCK_TIMEOUT = "SET lock_timeout = DEFAULT"
+SET_MYSQL_LOCK_TIMEOUT = "SET SESSION lock_wait_timeout = 2"
+RESET_MYSQL_LOCK_TIMEOUT = "SET SESSION lock_wait_timeout = DEFAULT"
 
 # Keys used to index into player data in storeHandsPlayers.
 HANDS_PLAYERS_KEYS = [
@@ -981,10 +1006,61 @@ class DatabaseSchemaMixin:
 
     # end def recreate_tables
 
+    @contextlib.contextmanager
+    def bounded_ddl_lock_wait(self):
+        """Make every migration inside the block fail rather than block.
+
+        A migration that cannot take its lock is a migration that has to wait
+        for another connection to end its transaction -- something a GUI tab
+        holding an open read can keep doing for hours. Both server backends
+        wait for that lock forever unless told otherwise, so the statement
+        never raises, never logs, and never returns: the caller simply stops.
+
+        The timeout is set on the session rather than with SET LOCAL because
+        the block below commits between statements, and a SET LOCAL would not
+        survive the commit. It is restored on the way out, so nothing outside
+        this block inherits it. SQLite has no such knob (it serialises with its
+        own busy timeout) and is left alone.
+        """
+        applied = False
+        try:
+            if self.backend == self.PGSQL:
+                self.get_cursor().execute(SET_PGSQL_LOCK_TIMEOUT)
+                applied = True
+            elif self.backend == self.MYSQL_INNODB:
+                # MySQL counts metadata-lock waits in whole seconds, minimum 1.
+                self.get_cursor().execute(SET_MYSQL_LOCK_TIMEOUT)
+                applied = True
+        except Exception:  # noqa: BLE001 - an unsupported knob must not stop the migrations
+            log.debug("Could not bound the migration lock wait", exc_info=True)
+        try:
+            yield
+        finally:
+            if applied:
+                # The last statement may have left the connection in an aborted
+                # transaction, which refuses everything until it is rolled back.
+                with contextlib.suppress(Exception):
+                    self.rollback()
+                with contextlib.suppress(Exception):
+                    if self.backend == self.PGSQL:
+                        self.get_cursor().execute(RESET_PGSQL_LOCK_TIMEOUT)
+                    else:
+                        self.get_cursor().execute(RESET_MYSQL_LOCK_TIMEOUT)
+                    self.commit()
+
     def ensure_feature_tables(self) -> None:
         """Create tables added after the original schema if they are missing, so
         that databases created by older versions keep working (used for the
-        showdown combinations, cashout details, and additive HudCache stats)."""
+        showdown combinations, cashout details, and additive HudCache stats).
+
+        Runs on every connection, so it must never block: see
+        :meth:`bounded_ddl_lock_wait`.
+        """
+        with self.bounded_ddl_lock_wait():
+            self._run_feature_migrations()
+
+    def _run_feature_migrations(self) -> None:
+        """The migrations themselves, each one best-effort and self-contained."""
         for query_name in (
             "createHandsShowdownTable",
             "createHandsCashoutTable",
@@ -1062,32 +1138,62 @@ class DatabaseSchemaMixin:
         }
         self._ensure_table_columns("Hands", definitions)
 
+    def _column_character_length(self, table: str, column: str) -> int | None:
+        """Declared width of a character column, or None when there is none.
+
+        None covers both "no such column" and a type with no declared width, so
+        callers can treat it as "nothing to widen".
+        """
+        c = self.get_cursor()
+        query = (
+            "SELECT character_maximum_length FROM information_schema.columns "
+            "WHERE lower(table_name) = %s AND lower(column_name) = %s"
+        )
+        params: tuple[str, ...] = (table.lower(), column.lower())
+        if self.backend == self.MYSQL_INNODB:
+            query += " AND table_schema = DATABASE()"
+        c.execute(query, params)
+        row = c.fetchone()
+        return None if row is None else row[0]
+
     def _ensure_gametype_category_width(self) -> None:
         """Widen Gametypes.category to varchar(10) for aof_holdem support.
 
         The original schema used varchar(9), which fits aof_omaha (8 chars)
         but not aof_holdem (10 chars). Avoided on SQLite (TEXT is unbounded)
         and skipped when the column is already wide enough.
+
+        That last sentence used to be a claim rather than a check: the only
+        test was that a column named "category" exists, so an ALTER TABLE went
+        out on every single connection, for the life of the schema, to set a
+        width that was already set. It takes ACCESS EXCLUSIVE on Gametypes,
+        which is why a database that had nothing to migrate could still hang
+        the GUI behind another tab's open read (#249). Reading the width first
+        makes the statement run once, on the one database that needs it.
         """
         if self.backend == self.SQLITE:
             return
         try:
-            existing = self._get_table_columns("Gametypes")
-        except Exception:  # noqa: BLE001
+            width = self._column_character_length("Gametypes", "category")
+        except Exception:  # noqa: BLE001 - table absent during first-time setup
             self.rollback()
             return
-        if not existing or "category" not in {c.lower() for c in existing}:
+        if width is None or width >= GAMETYPE_CATEGORY_WIDTH:
             return
         try:
             c = self.get_cursor()
             if self.backend == self.MYSQL_INNODB:
-                c.execute("ALTER TABLE Gametypes MODIFY category VARCHAR(10) NOT NULL")
+                c.execute(WIDEN_GAMETYPE_CATEGORY_MYSQL)
             else:
-                c.execute("ALTER TABLE Gametypes ALTER COLUMN category TYPE VARCHAR(10)")
+                c.execute(WIDEN_GAMETYPE_CATEGORY_SQL)
             self.commit()
-            log.info("Widened Gametypes.category to varchar(10)")
-        except Exception:  # noqa: BLE001 - column may already be wide enough or table locked.
+            log.info("Widened Gametypes.category to varchar(%d)", GAMETYPE_CATEGORY_WIDTH)
+        except Exception:  # noqa: BLE001 - another connection holds the table; retried next connection.
             self.rollback()
+            log.warning(
+                "Could not widen Gametypes.category to varchar(%d); retrying on the next connection",
+                GAMETYPE_CATEGORY_WIDTH,
+            )
 
     def _ensure_table_columns(self, table: str, definitions: dict[str, str]) -> None:
         try:
@@ -1110,9 +1216,19 @@ class DatabaseSchemaMixin:
                 c.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definitions[column]}")
             self.commit()
             log.info("Added %s missing %s columns: %s", len(missing), table, ", ".join(missing))
-        except Exception:
+        except Exception:  # noqa: BLE001 - reported, then retried on the next connection
             self.rollback()
-            raise
+            # Raising here used to abort whatever was opening the connection.
+            # Now that the block bounds its lock wait, the likeliest failure is
+            # losing a race for the table -- against the HUD process starting at
+            # the same time, say -- and taking down the window that lost is a
+            # worse answer than saying so and trying again next connection.
+            log.warning(
+                "Could not add missing %s columns (%s); retrying on the next connection",
+                table,
+                ", ".join(missing),
+                exc_info=True,
+            )
 
     def create_tables(self) -> None:
         log.debug(f"{self.sql.query['createSettingsTable']}")

--- a/fpdb_3_legacy/interlocks.py
+++ b/fpdb_3_legacy/interlocks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 # Thanks JJ!
 import base64
-import doctest
 import errno
 import os
 import os.path
@@ -543,6 +542,11 @@ def main(argv=None):
     if args.test or args.interactive:
         print("Running doctest suite for interlocks module...")
         try:
+            # Imported here, not at module scope: doctest pulls in unittest,
+            # and a module the GUI imports while starting up must not make the
+            # whole process look like a test run to code that sniffs sys.modules.
+            import doctest
+
             result = doctest.testmod(optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
             if result.failed == 0:
                 print(f"✓ All {result.attempted} doctests passed")

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -142,6 +142,10 @@ class RingStatsController(QObject):
         self._last_summary_stats: dict[str, Any] | None = None
         self._last_profit_data: tuple[Any, Any, Any, Any, Any] | None = None
 
+        # Bumped by every refresh_all. A result carrying an older number belongs
+        # to filters the user has already replaced: see is_current_result.
+        self._generation = 0
+
     def shutdown_workers(self) -> None:
         """Stop all DbWorker threads started by this controller.
 
@@ -165,10 +169,32 @@ class RingStatsController(QObject):
                     worker.error.disconnect()
         self._workers = []
 
+    def is_current_result(self) -> bool:
+        """False when this result belongs to a refresh the user has replaced.
+
+        Disconnecting a superseded worker's signals is not enough on its own.
+        ``shutdown_workers`` only reaches workers that are still running, and a
+        query that came back quickly is neither running nor still in the list --
+        its callback is simply sitting in the GUI thread's event queue, and it
+        is delivered after the next refresh has already started.
+
+        The visible half of that is a table filled from the previous filters.
+        The quiet half is worse: ``_check_and_emit_dashboard`` emits as soon as
+        it holds both a summary and a profit series, so a stale one arriving
+        beside a fresh one produces a single dashboard describing two different
+        filter sets, with nothing on screen to say so.
+
+        A worker carrying no generation at all is treated as current: the
+        callbacks are called directly in tests, where there is no sender to ask.
+        """
+        generation = getattr(self.sender(), "generation", None)
+        return generation is None or generation == self._generation
+
     def refresh_all(self, filter_widget) -> None:
         """Lance l'ensemble des requêtes asynchrones en fonction des filtres appliqués."""
         debug_log("refresh_all called!")
         self.shutdown_workers()
+        self._generation += 1
         # 1. Extraction des filtres
         sites = filter_widget.getSites()
         heroes = filter_widget.getHeroes()
@@ -258,6 +284,10 @@ class RingStatsController(QObject):
         self._workers = [w for w in self._workers if not w.isFinished()]
 
         worker = DbWorker(self.db, query_name, sql)
+        # Read back through sender() by is_current_result. Carried on the worker
+        # rather than added to the signal so DbWorker stays the same object the
+        # other stats widgets connect to.
+        worker.generation = self._generation
         worker.finished.connect(callback)
 
         def on_error(err):
@@ -274,6 +304,10 @@ class RingStatsController(QObject):
 
     def _on_summary_query_finished(self, name: str, result: list, colnames: list) -> None:
         """Callback appelé lorsque la requête récapitulative est terminée."""
+        if not self.is_current_result():
+            debug_log("_on_summary_query_finished: result of a superseded refresh, discarded")
+            return
+
         debug_log(f"_on_summary_query_finished: returned {len(result) if result else 0} rows")
         if not result:
             self._last_summary_stats = {}
@@ -302,6 +336,10 @@ class RingStatsController(QObject):
 
     def _on_profit_query_finished(self, name: str, result: list, colnames: list) -> None:
         """Callback appelé lorsque la requête chronologique de profit est terminée."""
+        if not self.is_current_result():
+            debug_log("_on_profit_query_finished: result of a superseded refresh, discarded")
+            return
+
         debug_log(f"_on_profit_query_finished: returned {len(result) if result else 0} rows")
         import numpy as np
 
@@ -336,6 +374,10 @@ class RingStatsController(QObject):
 
     def _on_hands_query_finished(self, name: str, result: list, colnames: list) -> None:
         """Callback appelé lorsque la requête détaillée par main est terminée."""
+        if not self.is_current_result():
+            debug_log("_on_hands_query_finished: result of a superseded refresh, discarded")
+            return
+
         debug_log(f"_on_hands_query_finished: returned {len(result) if result else 0} rows")
         if not result:
             return
@@ -376,6 +418,10 @@ class RingStatsController(QObject):
 
     def _on_positions_query_finished(self, name: str, result: list, colnames: list) -> None:
         """Callback pour l'affichage de la table de poker positionnelle."""
+        if not self.is_current_result():
+            debug_log("_on_positions_query_finished: result of a superseded refresh, discarded")
+            return
+
         position_stats = {}
 
         vpip_idx = colnames.index("vpip") if "vpip" in colnames else -1

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -8,6 +8,9 @@ des statistiques pour le tableau de bord, les positions et les cartes.
 
 from __future__ import annotations
 
+import contextlib
+import os
+import sys
 from typing import Any
 
 from PySide6.QtCore import QObject, Qt, Signal
@@ -24,6 +27,25 @@ log = get_logger("ring_stats_controller")
 def debug_log(msg: str) -> None:
     """Route detailed diagnostics through the configured logger."""
     log.debug(msg)
+
+
+def running_under_test() -> bool:
+    """True while a test runner is driving this process.
+
+    ``"unittest" in sys.modules`` used to be half of this test, and it was
+    wrong in production in the worst possible way. ``fpdb_3_legacy.interlocks``
+    imported ``doctest`` at module scope, ``doctest`` imports ``unittest``, and
+    ``fpdb.pyw`` imports ``interlocks`` while starting up -- so every real run
+    of the GUI looked like a test run. Ring Player Stats therefore ran all four
+    of its queries and built every model on the GUI thread, which is exactly
+    what the DbWorker threads exist to avoid, and the asynchronous path only
+    ever ran where nobody was looking.
+
+    Nothing in the application imports pytest, and ``PYTEST_CURRENT_TEST`` is
+    set by pytest for the duration of a test, so both signals mean what they
+    say.
+    """
+    return "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 
 colalias, colheading, colshowsumm, colshowposn, colformat, coltype, colxalign = (
     0, 1, 2, 3, 4, 5, 6
@@ -104,7 +126,7 @@ class RingStatsController(QObject):
     # Carries a NoDataReason value so the view can explain *why* it is empty.
     no_data_found = Signal(str)
 
-    def __init__(self, db, config, sql) -> None:
+    def __init__(self, db, config, sql, *, async_mode: bool | None = None) -> None:
         super().__init__()
         self.db = db
         self.cursor = db.cursor
@@ -113,10 +135,9 @@ class RingStatsController(QObject):
         self.columns = config.get_gui_cash_stat_params()
         self._workers: list[DbWorker] = []
 
-        # Force synchronous mode only in test suites (pytest/unittest)
-        import sys
-
-        self.async_mode = "pytest" not in sys.modules and "unittest" not in sys.modules
+        # Synchronous only under a test runner, so a test can assert on results
+        # without pumping the event loop. Passing async_mode explicitly wins.
+        self.async_mode = not running_under_test() if async_mode is None else async_mode
 
         self._last_summary_stats: dict[str, Any] | None = None
         self._last_profit_data: tuple[Any, Any, Any, Any, Any] | None = None
@@ -124,20 +145,24 @@ class RingStatsController(QObject):
     def shutdown_workers(self) -> None:
         """Stop all DbWorker threads started by this controller.
 
-        Called when the host tab is closed or refreshed: disconnects signals
-        immediately so stale workers never update the UI thread, and terminates them.
+        Called when the host tab is closed or refreshed. Disconnecting the
+        signals is what actually protects the UI: a worker that finishes after
+        its tab is gone then has nobody to deliver results to.
+
+        It does not terminate the thread, for the reason ``ModernStatsWidget``
+        already documents -- ``QThread.terminate`` kills the thread wherever it
+        happens to be, including inside ``Database.worker_connection``, which
+        holds a semaphore permit from a pool of four shared by every tab. Four
+        such kills and the next query waits for a permit that will never be
+        released. The queries here are bounded, so letting one finish and be
+        ignored costs a fraction of a second.
         """
         for worker in self._workers:
             if worker.isRunning():
-                try:
+                with contextlib.suppress(TypeError, RuntimeError):
                     worker.finished.disconnect()
-                except (TypeError, RuntimeError):
-                    pass
-                try:
+                with contextlib.suppress(TypeError, RuntimeError):
                     worker.error.disconnect()
-                except (TypeError, RuntimeError):
-                    pass
-                worker.terminate()
         self._workers = []
 
     def refresh_all(self, filter_widget) -> None:

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -14,6 +14,7 @@ mutex regression and a Windows developer sees an fcntl one.
 
 from __future__ import annotations
 
+import doctest
 import errno
 import os
 import socket
@@ -598,14 +599,14 @@ def test_no_arguments_prints_the_help(capsys) -> None:
 
 
 def test_the_doctest_suite_can_be_run(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(interlocks.doctest, "testmod", lambda **_kwargs: types.SimpleNamespace(failed=0, attempted=7))
+    monkeypatch.setattr(doctest, "testmod", lambda **_kwargs: types.SimpleNamespace(failed=0, attempted=7))
 
     assert interlocks.main(["--test"]) == 0
     assert "All 7 doctests passed" in capsys.readouterr().out
 
 
 def test_a_failing_doctest_is_a_failing_command(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(interlocks.doctest, "testmod", lambda **_kwargs: types.SimpleNamespace(failed=2, attempted=7))
+    monkeypatch.setattr(doctest, "testmod", lambda **_kwargs: types.SimpleNamespace(failed=2, attempted=7))
 
     assert interlocks.main(["--interactive"]) == 1
     assert "2/7 doctests failed" in capsys.readouterr().out
@@ -616,7 +617,7 @@ def test_a_crashing_doctest_is_reported_not_raised(monkeypatch, capsys) -> None:
         msg = "no such attribute"
         raise ValueError(msg)
 
-    monkeypatch.setattr(interlocks.doctest, "testmod", explode)
+    monkeypatch.setattr(doctest, "testmod", explode)
 
     assert interlocks.main(["--test"]) == 1
     assert "Doctests crashed" in capsys.readouterr().out

--- a/test/test_ring_stats_controller.py
+++ b/test/test_ring_stats_controller.py
@@ -24,3 +24,51 @@ def test_dashboard_kpis_preserve_single_result_currency() -> None:
     assert stats["hands"] == 40
     assert stats["net"] == 100.0
     assert stats["currency"] == "USD"
+
+
+def test_async_is_the_default_outside_a_test_run(monkeypatch) -> None:
+    """The DbWorker threads must actually be used in production.
+
+    ``async_mode`` was decided by ``"unittest" not in sys.modules``, and
+    ``fpdb_3_legacy.interlocks`` -- imported by fpdb.pyw at startup -- imported
+    ``doctest``, which imports ``unittest``. Every real session therefore looked
+    like a test run and ran all four Ring Player Stats queries, plus every model
+    it builds from them, on the GUI thread.
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setitem(controller.sys.modules, "unittest", controller.sys)
+    monkeypatch.delitem(controller.sys.modules, "pytest", raising=False)
+
+    assert controller.running_under_test() is False
+
+
+def test_pytest_still_forces_the_synchronous_path(monkeypatch) -> None:
+    monkeypatch.setitem(controller.sys.modules, "pytest", controller.sys)
+
+    assert controller.running_under_test() is True
+
+
+def test_the_current_test_env_var_is_enough_on_its_own(monkeypatch) -> None:
+    monkeypatch.delitem(controller.sys.modules, "pytest", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_x (call)")
+
+    assert controller.running_under_test() is True
+
+
+def test_importing_interlocks_does_not_look_like_a_test_run() -> None:
+    """The specific import chain that produced the bug, pinned at the source.
+
+    Asserting on sys.modules cannot work here -- pytest has already imported
+    unittest by the time this runs -- so the check is that the module the GUI
+    imports at startup no longer drags doctest in at import time.
+    """
+    import ast
+    import pathlib
+
+    source = pathlib.Path(controller.__file__).parent.parent / "interlocks.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    module_level = [node for node in tree.body if isinstance(node, (ast.Import, ast.ImportFrom))]
+    imported = {alias.name.split(".")[0] for node in module_level if isinstance(node, ast.Import) for alias in node.names}
+
+    assert "doctest" not in imported
+    assert "unittest" not in imported

--- a/test/test_ring_stats_controller.py
+++ b/test/test_ring_stats_controller.py
@@ -72,3 +72,73 @@ def test_importing_interlocks_does_not_look_like_a_test_run() -> None:
 
     assert "doctest" not in imported
     assert "unittest" not in imported
+
+
+class StaleSender:
+    """Stands in for the DbWorker whose result is being delivered."""
+
+    def __init__(self, generation: int) -> None:
+        self.generation = generation
+
+
+def controller_at_generation(monkeypatch, current: int, sender_generation: int | None):
+    ctrl = controller.RingStatsController.__new__(controller.RingStatsController)
+    ctrl._generation = current
+    sender = StaleSender(sender_generation) if sender_generation is not None else None
+    monkeypatch.setattr(ctrl, "sender", lambda: sender, raising=False)
+    return ctrl
+
+
+def test_a_result_from_the_current_refresh_is_kept(monkeypatch) -> None:
+    ctrl = controller_at_generation(monkeypatch, current=4, sender_generation=4)
+
+    assert ctrl.is_current_result() is True
+
+
+def test_a_result_from_a_superseded_refresh_is_discarded(monkeypatch) -> None:
+    """The race disconnecting signals cannot close.
+
+    ``shutdown_workers`` only reaches workers that are still running, so a query
+    that finished before the user changed the filters still has its callback
+    queued for the GUI thread -- and it is delivered after the new refresh has
+    begun.
+    """
+    ctrl = controller_at_generation(monkeypatch, current=5, sender_generation=4)
+
+    assert ctrl.is_current_result() is False
+
+
+def test_a_direct_call_with_no_sender_is_treated_as_current(monkeypatch) -> None:
+    """Tests call the callbacks themselves; that must not read as stale."""
+    ctrl = controller_at_generation(monkeypatch, current=5, sender_generation=None)
+
+    assert ctrl.is_current_result() is True
+
+
+def test_every_result_callback_asks_before_it_acts() -> None:
+    """A guard on three of the four callbacks is a guard on none of them."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(controller.RingStatsController))
+    callbacks = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("_on_") and node.name.endswith("_finished")
+    }
+
+    assert set(callbacks) == {
+        "_on_summary_query_finished",
+        "_on_profit_query_finished",
+        "_on_hands_query_finished",
+        "_on_positions_query_finished",
+    }
+    for name, node in callbacks.items():
+        guards = [
+            call
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "is_current_result"
+        ]
+        assert guards, f"{name} does not check whether its result is still wanted"

--- a/test/test_ring_stats_controller.py
+++ b/test/test_ring_stats_controller.py
@@ -81,21 +81,29 @@ class StaleSender:
         self.generation = generation
 
 
-def controller_at_generation(monkeypatch, current: int, sender_generation: int | None):
-    ctrl = controller.RingStatsController.__new__(controller.RingStatsController)
-    ctrl._generation = current
-    sender = StaleSender(sender_generation) if sender_generation is not None else None
-    monkeypatch.setattr(ctrl, "sender", lambda: sender, raising=False)
-    return ctrl
+class GuardHost:
+    """The real guard, on a host reduced to the two things it reads.
+
+    Borrowing the function rather than instantiating a RingStatsController
+    keeps the test off QObject construction while still exercising the
+    shipped implementation.
+    """
+
+    is_current_result = controller.RingStatsController.is_current_result
+
+    def __init__(self, current: int, sender_generation: int | None) -> None:
+        self._generation = current
+        self._sender = None if sender_generation is None else StaleSender(sender_generation)
+
+    def sender(self) -> StaleSender | None:
+        return self._sender
 
 
-def test_a_result_from_the_current_refresh_is_kept(monkeypatch) -> None:
-    ctrl = controller_at_generation(monkeypatch, current=4, sender_generation=4)
-
-    assert ctrl.is_current_result() is True
+def test_a_result_from_the_current_refresh_is_kept() -> None:
+    assert GuardHost(current=4, sender_generation=4).is_current_result() is True
 
 
-def test_a_result_from_a_superseded_refresh_is_discarded(monkeypatch) -> None:
+def test_a_result_from_a_superseded_refresh_is_discarded() -> None:
     """The race disconnecting signals cannot close.
 
     ``shutdown_workers`` only reaches workers that are still running, so a query
@@ -103,16 +111,12 @@ def test_a_result_from_a_superseded_refresh_is_discarded(monkeypatch) -> None:
     queued for the GUI thread -- and it is delivered after the new refresh has
     begun.
     """
-    ctrl = controller_at_generation(monkeypatch, current=5, sender_generation=4)
-
-    assert ctrl.is_current_result() is False
+    assert GuardHost(current=5, sender_generation=4).is_current_result() is False
 
 
-def test_a_direct_call_with_no_sender_is_treated_as_current(monkeypatch) -> None:
+def test_a_direct_call_with_no_sender_is_treated_as_current() -> None:
     """Tests call the callbacks themselves; that must not read as stale."""
-    ctrl = controller_at_generation(monkeypatch, current=5, sender_generation=None)
-
-    assert ctrl.is_current_result() is True
+    assert GuardHost(current=5, sender_generation=None).is_current_result() is True
 
 
 def test_every_result_callback_asks_before_it_acts() -> None:

--- a/test/test_schema_migration_locks.py
+++ b/test/test_schema_migration_locks.py
@@ -1,0 +1,207 @@
+"""A migration must never be able to hang the application that runs it.
+
+``ensure_feature_tables`` runs on every ``Database()`` construction, and the GUI
+builds one per heavy tab. Both server backends wait for a table lock forever by
+default, so a tab sitting inside an open read transaction on Gametypes was
+enough to make the next tab's ``ALTER TABLE`` wait on the GUI thread until the
+user killed the process -- the freeze in #249, reproduced as the second tab
+opening and never returning.
+
+Two things are pinned here, because either one alone leaves the hang reachable:
+the width migration must not issue DDL a database no longer needs, and any DDL
+that does go out must be allowed to fail instead of waiting.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fpdb_3_legacy import database_schema
+
+
+class FakeCursor:
+    """Records every statement, and answers the one query the code reads back."""
+
+    def __init__(self, owner: FakeDatabase) -> None:
+        self.owner = owner
+
+    def execute(self, statement: str, params: tuple[Any, ...] | None = None) -> None:
+        self.owner.statements.append(statement)
+        if statement in self.owner.failing:
+            raise RuntimeError(self.owner.failing[statement])
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.owner.next_row
+
+
+class FakeDatabase(database_schema.DatabaseSchemaMixin):
+    """The mixin's host, reduced to what the migrations actually borrow."""
+
+    MYSQL_INNODB = 2
+    PGSQL = 3
+    SQLITE = 4
+
+    def __init__(self, backend: int, *, width: int | None = 10) -> None:
+        self.backend = backend
+        self.statements: list[str] = []
+        self.failing: dict[str, str] = {}
+        self.next_row: tuple[Any, ...] | None = (width,)
+        self.commits = 0
+        self.rollbacks = 0
+
+    def get_cursor(self, connect: bool = False) -> FakeCursor:  # noqa: ARG002 - signature borrowed from Database
+        return FakeCursor(self)
+
+    def commit(self, force: bool = False) -> None:  # noqa: ARG002 - signature borrowed from Database
+        self.commits += 1
+
+    def rollback(self, force: bool = False) -> None:  # noqa: ARG002 - signature borrowed from Database
+        self.rollbacks += 1
+
+
+ALTERS = (
+    database_schema.WIDEN_GAMETYPE_CATEGORY_SQL,
+    database_schema.WIDEN_GAMETYPE_CATEGORY_MYSQL,
+)
+
+
+@pytest.mark.parametrize("backend", [FakeDatabase.PGSQL, FakeDatabase.MYSQL_INNODB])
+def test_a_wide_enough_column_is_left_alone(backend: int) -> None:
+    """The check the docstring always promised, which the code never made.
+
+    The old version only asked whether a column named "category" existed, so an
+    ALTER TABLE taking ACCESS EXCLUSIVE on Gametypes went out on every single
+    connection, forever, to set a width that was already set.
+    """
+    db = FakeDatabase(backend, width=database_schema.GAMETYPE_CATEGORY_WIDTH)
+
+    db._ensure_gametype_category_width()
+
+    assert not [statement for statement in db.statements if statement in ALTERS]
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        (FakeDatabase.PGSQL, database_schema.WIDEN_GAMETYPE_CATEGORY_SQL),
+        (FakeDatabase.MYSQL_INNODB, database_schema.WIDEN_GAMETYPE_CATEGORY_MYSQL),
+    ],
+)
+def test_a_narrow_column_is_still_widened(backend: int, expected: str) -> None:
+    db = FakeDatabase(backend, width=database_schema.GAMETYPE_CATEGORY_WIDTH - 1)
+
+    db._ensure_gametype_category_width()
+
+    assert expected in db.statements
+    assert db.commits == 1
+
+
+def test_a_missing_column_is_not_a_migration() -> None:
+    db = FakeDatabase(FakeDatabase.PGSQL)
+    db.next_row = None
+
+    db._ensure_gametype_category_width()
+
+    assert not [statement for statement in db.statements if statement in ALTERS]
+
+
+def test_sqlite_is_never_asked_to_widen_anything() -> None:
+    """TEXT is unbounded there, and SQLite has no ALTER COLUMN at all."""
+    db = FakeDatabase(FakeDatabase.SQLITE, width=1)
+
+    db._ensure_gametype_category_width()
+
+    assert db.statements == []
+
+
+def test_a_locked_table_is_reported_not_waited_on() -> None:
+    db = FakeDatabase(FakeDatabase.PGSQL, width=database_schema.GAMETYPE_CATEGORY_WIDTH - 1)
+    db.failing[database_schema.WIDEN_GAMETYPE_CATEGORY_SQL] = "lock timeout"
+
+    db._ensure_gametype_category_width()
+
+    assert db.rollbacks == 1
+    assert db.commits == 0
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected_set", "expected_reset"),
+    [
+        (
+            FakeDatabase.PGSQL,
+            database_schema.SET_PGSQL_LOCK_TIMEOUT,
+            database_schema.RESET_PGSQL_LOCK_TIMEOUT,
+        ),
+        (
+            FakeDatabase.MYSQL_INNODB,
+            database_schema.SET_MYSQL_LOCK_TIMEOUT,
+            database_schema.RESET_MYSQL_LOCK_TIMEOUT,
+        ),
+    ],
+)
+def test_the_migration_block_bounds_its_lock_wait(backend: int, expected_set: str, expected_reset: str) -> None:
+    """Set on the way in, restored on the way out, around the whole block."""
+    db = FakeDatabase(backend)
+
+    with db.bounded_ddl_lock_wait():
+        db.get_cursor().execute("ALTER TABLE Whatever ADD COLUMN x INT")
+
+    assert db.statements[0] == expected_set
+    assert db.statements[-1] == expected_reset
+
+
+def test_the_timeout_is_restored_even_when_a_migration_raises() -> None:
+    """Otherwise one failed migration leaves the timeout on the session."""
+    db = FakeDatabase(FakeDatabase.PGSQL)
+
+    with pytest.raises(RuntimeError), db.bounded_ddl_lock_wait():
+        msg = "migration blew up"
+        raise RuntimeError(msg)
+
+    assert db.statements[-1] == database_schema.RESET_PGSQL_LOCK_TIMEOUT
+
+
+def test_sqlite_gets_no_timeout_statements() -> None:
+    """It serialises with its own busy timeout and has neither setting."""
+    db = FakeDatabase(FakeDatabase.SQLITE)
+
+    with db.bounded_ddl_lock_wait():
+        pass
+
+    assert db.statements == []
+
+
+def test_ensure_feature_tables_runs_its_migrations_inside_the_block() -> None:
+    """The bound has to cover the migrations, not merely exist next to them."""
+    db = FakeDatabase(FakeDatabase.PGSQL)
+    calls: list[str] = []
+
+    def record() -> None:
+        calls.append(db.statements[-1] if db.statements else "")
+
+    db._run_feature_migrations = record  # type: ignore[method-assign]
+
+    db.ensure_feature_tables()
+
+    assert calls == [database_schema.SET_PGSQL_LOCK_TIMEOUT]
+
+
+def test_a_failed_column_migration_does_not_take_the_connection_down() -> None:
+    """It is retried on the next connection, so it must not raise here.
+
+    ``_ensure_table_columns`` re-raised, and ``ensure_feature_tables`` runs from
+    ``Database.__init__``: with a bounded lock wait, losing a race for the table
+    would otherwise turn a tab that opens slowly into a tab that does not open.
+    """
+    db = FakeDatabase(FakeDatabase.PGSQL)
+    db._get_table_columns = lambda _table: {"id"}  # type: ignore[method-assign]
+    statement = "ALTER TABLE HandsPlayers ADD COLUMN enumPreflop CHAR(1) DEFAULT 'N'"
+    db.failing[statement] = "lock timeout"
+
+    db._ensure_table_columns("HandsPlayers", {"enumPreflop": "CHAR(1) DEFAULT 'N'"})
+
+    assert statement in db.statements
+    assert db.rollbacks == 1
+    assert db.commits == 0

--- a/tests/test_database_schema_migrations.py
+++ b/tests/test_database_schema_migrations.py
@@ -6,6 +6,8 @@ import pytest
 
 from fpdb_3_legacy.Database import Database
 
+NARROW = 9  # the width the original schema declared
+
 
 class RecordingCursor:
     def __init__(self, error: Exception | None = None) -> None:
@@ -18,10 +20,16 @@ class RecordingCursor:
             raise self.error
 
 
-def migration_db(backend: int, cursor: RecordingCursor) -> tuple[Database, list[str]]:
+def migration_db(backend: int, cursor: RecordingCursor, width: int | None = NARROW) -> tuple[Database, list[str]]:
+    """A Database stubbed down to what the width migration reads.
+
+    ``width`` is what the column currently declares: the migration decides
+    from that number alone, which is what keeps it from re-issuing DDL on a
+    database that has already been migrated.
+    """
     db = Database.__new__(Database)
     db.backend = backend
-    db._get_table_columns = lambda _table: {"id", "CATEGORY"}
+    db._column_character_length = lambda _table, _column: width
     db.get_cursor = lambda: cursor
     events: list[str] = []
     db.commit = lambda: events.append("commit")
@@ -46,14 +54,25 @@ def test_gametype_category_is_widened_for_server_databases(backend: int, expecte
     assert events == ["commit"]
 
 
+def test_gametype_category_already_wide_issues_no_ddl() -> None:
+    """The ALTER takes ACCESS EXCLUSIVE on Gametypes, so it must be earned."""
+    cursor = RecordingCursor()
+    db, events = migration_db(Database.PGSQL, cursor, width=10)
+
+    db._ensure_gametype_category_width()
+
+    assert cursor.statements == []
+    assert events == []
+
+
 def test_gametype_category_lookup_failure_rolls_back() -> None:
     cursor = RecordingCursor()
     db, events = migration_db(Database.PGSQL, cursor)
 
-    def fail_lookup(_table: str) -> set[str]:
+    def fail_lookup(_table: str, _column: str) -> int:
         raise RuntimeError("missing table")
 
-    db._get_table_columns = fail_lookup
+    db._column_character_length = fail_lookup
 
     db._ensure_gametype_category_width()
 


### PR DESCRIPTION
Closes #249 (leads 6 and 7).

## What it actually was

Not tab-count, not PyOxidizer, not App Translocation. Lead 7 is settled by the reproduction below: it reproduces from source, on any backend that takes real table locks.

Opening six heavy tabs in one process, the **second one never returns**. `sample(1)` puts the main thread in `poll()` inside psycopg, and PostgreSQL says why:

```
22765  idle in transaction   SELECT DISTINCT gt.currency FROM GameTypes ...   <- the Graphs tab
22767  active Lock/relation  ALTER TABLE Gametypes ALTER COLUMN category ...  <- the next tab
pg_blocking_pids(22767) = [22765]
```

Every heavy tab builds its own `Database`, every `Database` runs `ensure_feature_tables`, and `_ensure_gametype_category_width` issued that `ALTER` unconditionally. Its docstring promised "skipped when the column is already wide enough", but the only check was that a column named `category` exists. A database with nothing left to migrate therefore asked for `ACCESS EXCLUSIVE` on `Gametypes` on **every connection, forever** — and one earlier tab sitting inside an open read transaction was enough to make the next one wait. Both server backends wait for that lock forever, on the GUI thread, logging nothing.

That is why the log goes silent right after the Ring Player Stats refresh in both captures in #249 (2026-08-13 and 2026-08-27) and the next line belongs to a new pid.

## The second bug, found on the way

Ring Player Stats was running **entirely on the GUI thread** in production. `async_mode` was `"unittest" not in sys.modules`; `interlocks.py` imported `doctest` at module scope, `doctest` imports `unittest`, and `fpdb.pyw` imports `interlocks` while starting up. So every real session looked like a test run and the `DbWorker` threads only ever ran where nobody was looking.

The reported log already showed the cost and nobody could read it as such — `Total queries dispatch: 0.322s` and `hands emit took: 0.206s` are the four queries and all of their model building, executed inline with the window blocked. A source run with the same import order reproduces both numbers to the millisecond.

## Changes

- **`database_schema.py`** — the width migration reads the declared width first, so no DDL goes out on an up-to-date database. The whole migration block also runs under a `lock_timeout` (2s): the migration a connection cannot afford to lose is exactly the one it must be allowed to lose. Losing it is a delay until the next connection; blocking on it is the application stopping. `_ensure_table_columns` stops re-raising for the same reason — with a bounded wait, a lost race would otherwise turn a slow tab into one that fails to open.
- **`ring_stats/controller.py`** — detection is pytest-only (`pytest` in `sys.modules` or `PYTEST_CURRENT_TEST`), with an explicit `async_mode` parameter available. `shutdown_workers` no longer calls `QThread.terminate`, which `ModernStatsWidget` already documents as leaking a permit from the four-permit worker-connection pool — harmless while the path was dead, not once it runs.
- **`interlocks.py`** — `import doctest` moved into the `--test` branch it serves.

## Verification

Measured on the reporter's database (Winamax cash, ~1000 hands, PostgreSQL):

| | before | after |
|---|---|---|
| six heavy tabs | hang on the 2nd | 34–234ms each, 1.7s total |
| RPS refresh dispatch | 322ms on the GUI thread | 3ms |

The lock bound was checked against a live server too: holding `ACCESS SHARE` on `Gametypes` in one connection, the `ALTER` gives up with `LockNotAvailable` after 2.08s instead of waiting.

New `test/test_schema_migration_locks.py` pins both halves — that a wide-enough column produces no DDL, and that any DDL that does go out is bounded and restores the session setting. `test_ring_stats_controller.py` pins the async default and reads `interlocks.py` back with `ast` so the import chain cannot return.

Full suite: 8194 passed, 16 skipped; 711 `qt` tests passed; ruff clean.

## Not in scope

Tabs still leave their connections `idle in transaction` for the life of the process. It no longer freezes anything, but it does hold locks and keep autovacuum off those tables — worth its own issue.
