### PR TITLE
fix(db): end the transaction a GUI read opens

### DIFF
--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -812,6 +812,15 @@ class Database(
 
         Limits the number of concurrent connections to avoid hitting
         max_connections on PostgreSQL (and MySQL).
+
+        The connection is always returned to the pool with its transaction
+        ended. Workers only read, but a read still opens a transaction, and one
+        that is never ended does two things: it leaves the connection in ``idle
+        in transaction`` holding read locks for the life of the process --
+        pinning autovacuum off Hands and HandsPlayers, and standing in the way
+        of anything needing a stronger lock (#249, #271) -- and, when the query
+        failed, it hands the next borrower a connection whose transaction is
+        already aborted, so every later query on it fails too.
         """
         self._worker_conn_semaphore.acquire()
         conn = None
@@ -823,9 +832,25 @@ class Database(
 
             yield conn
         finally:
-            if conn is not None:
-                self._worker_conn_pool.put(conn)
+            self._return_worker_connection(conn)
             self._worker_conn_semaphore.release()
+
+    def _return_worker_connection(self, conn) -> None:
+        """Put a worker connection back, with nothing left open on it.
+
+        A connection whose rollback fails is beyond reuse, so it is dropped
+        rather than pooled; the next borrower simply opens a fresh one.
+        """
+        if conn is None:
+            return
+        try:
+            conn.rollback()
+        except Exception:  # noqa: BLE001 - a connection that cannot roll back is not reusable
+            log.debug("Discarding a worker connection that could not be rolled back", exc_info=True)
+            with contextlib.suppress(Exception):
+                conn.close()
+            return
+        self._worker_conn_pool.put(conn)
 
     def _create_new_worker_connection(self):
         """Open a dedicated connection for a background worker thread.

--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -11,7 +11,9 @@ Provides a comprehensive filtering system for poker data analysis with support f
 
 from __future__ import annotations
 
+import inspect
 import itertools
+import sys
 import time
 import unicodedata
 from functools import partial
@@ -228,6 +230,30 @@ def resolve_site_icon(site: str) -> QIcon:
     return icon
 
 
+#: Stands in for "as many as you like" when a callback declares ``*args``.
+UNLIMITED_POSITIONAL = sys.maxsize
+
+
+def _accepted_positional_count(callback: Any) -> int:
+    """How many positional arguments ``callback`` can be given.
+
+    A callable whose signature cannot be read is assumed to want none, which is
+    the safe end: an argument too few raises where the callback is defined, an
+    argument too many raises at the button.
+    """
+    try:
+        parameters = inspect.signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return 0
+    count = 0
+    for parameter in parameters:
+        if parameter.kind is parameter.VAR_POSITIONAL:
+            return UNLIMITED_POSITIONAL
+        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD):
+            count += 1
+    return count
+
+
 class Filters(QWidget):
     """Main filtering widget for FPDB data analysis.
 
@@ -426,8 +452,8 @@ class Filters(QWidget):
         if self.display.get("Button1", False) or self.display.get("Button2", False):
             layout.addWidget(self.create_buttons())
 
-        self.db.rollback()
         self.set_default_hero()
+        self.end_read_transaction()
         log.info("[PERF-TIMING] Filters.make_filter built in %.3f s", time.perf_counter() - t0)
 
     def _clear_layout(self, layout: Any) -> None:
@@ -820,9 +846,39 @@ class Filters(QWidget):
         """Register button 1 name."""
         self.Button1.setText(title)
 
+    def _releasing_read_locks(self, callback: Any) -> Any:
+        """Wrap a filter button's callback so it cannot leave a read open.
+
+        Every tab reaches its data through one of these two buttons, so this is
+        the one place that sees them all -- including tabs written later. The
+        alternative was a rollback at the end of each tab's refresh method,
+        which is the same fix repeated seven times and forgotten the eighth.
+
+        The rollback runs even when the callback raises: a refresh that failed
+        is exactly the one leaving a transaction behind, and on PostgreSQL an
+        aborted transaction poisons every later query on that connection until
+        it ends.
+
+        Arguments are trimmed to what the callback accepts. Qt hands a clicked
+        slot the button's ``checked`` flag only if the slot has room for it, and
+        PySide decides that by inspecting the callable -- which a wrapper hides.
+        Three of the registered refreshes (both exportGraph, and
+        GuiTourneyPlayerStats.refreshStats) take no argument at all, so
+        forwarding blindly turns their button into a TypeError.
+        """
+        wanted = _accepted_positional_count(callback)
+
+        def run(*args: Any) -> Any:
+            try:
+                return callback(*args[:wanted])
+            finally:
+                self.end_read_transaction()
+
+        return run
+
     def registerButton1Callback(self, callback: Any) -> None:
         """Register button 1 callback."""
-        self.Button1.clicked.connect(callback)
+        self.Button1.clicked.connect(self._releasing_read_locks(callback))
         self.Button1.setEnabled(True)
         self.callback["button1"] = callback
 
@@ -832,7 +888,7 @@ class Filters(QWidget):
 
     def registerButton2Callback(self, callback: Any) -> None:
         """Register button 2 callback."""
-        self.Button2.clicked.connect(callback)
+        self.Button2.clicked.connect(self._releasing_read_locks(callback))
         self.Button2.setEnabled(True)
         self.callback["button2"] = callback
 
@@ -1709,6 +1765,22 @@ class Filters(QWidget):
         """Set games filter."""
         self.games = games
 
+    def end_read_transaction(self) -> None:
+        """Close the transaction the filter queries opened.
+
+        Every query here is a read, but a read still opens a transaction, and a
+        transaction nobody ends keeps the connection in ``idle in transaction``
+        for as long as the tab exists. One per tab, each holding ACCESS SHARE on
+        Gametypes, Hands, HandsPlayers, Players and Sites: autovacuum stops
+        being able to reclaim dead rows on the two tables that grow, and
+        anything wanting a stronger lock waits behind it -- which is how a
+        schema migration came to hang the GUI in #249.
+
+        ``Database.rollback`` defers while an explicit transaction block is
+        open, so this cannot cut one short.
+        """
+        self.db.rollback()
+
     def update_filters_for_hero(self) -> None:
         """Update all filters when hero selection changes."""
         if self.heroList and self.heroList.count() > 0:
@@ -1721,6 +1793,9 @@ class Filters(QWidget):
                 self.update_positions_for_hero(selected_hero, selected_site)
                 self.update_currencies_for_hero(selected_hero, selected_site)
                 self.update_tourney_filters_for_hero(selected_hero, selected_site)
+        # Reached on every hero change too, not just the first: the six updates
+        # above each run their own queries, so the transaction reopens each time.
+        self.end_read_transaction()
 
     def update_sites_for_hero(self, _hero: str, site: str) -> None:
         """Update sites filter for selected hero and site."""

--- a/fpdb_3_legacy/ring_stats/controller.py
+++ b/fpdb_3_legacy/ring_stats/controller.py
@@ -276,6 +276,12 @@ class RingStatsController(QObject):
         log.warning(f"[PERF] controller sql_profit generation: {t4-t3:.3f}s. Total queries dispatch: {t4-t0:.3f}s")
         self._run_query("profit", sql_profit, self._on_profit_query_finished)
 
+        # The player and site lookups above ran on the tab's own connection, and
+        # a read opens a transaction like anything else. The workers use their
+        # own pooled connections, so ending this one now leaves nothing of this
+        # refresh holding a lock (#271).
+        self.db.rollback()
+
     def _run_query(self, query_name: str, sql: str, callback) -> None:
         """Lance une requête asynchrone à l'aide d'un DbWorker (ou synchrone en test)."""
         debug_log(f"_run_query: name={query_name}, async_mode={self.async_mode}")

--- a/test/test_read_transaction_hygiene.py
+++ b/test/test_read_transaction_hygiene.py
@@ -1,0 +1,256 @@
+"""A GUI read must not leave a transaction open behind it.
+
+Every filter query is a read, but a read still opens a transaction, and one
+that is never ended keeps its connection in ``idle in transaction`` for the
+life of the tab. Measured on the reporter's database before the fix, three
+tabs left three such backends holding ACCESS SHARE on Gametypes, Hands,
+HandsPlayers, Players and Sites (#271).
+
+Two consequences, and the second is how this was found: autovacuum cannot
+reclaim dead rows on the two tables that actually grow while fpdb is running,
+and anything wanting a stronger lock queues behind the read -- which is what
+made a schema migration hang the GUI in #249.
+
+The fixes are at the two places that see every read: the filter buttons every
+tab registers its refresh with, and the pooled connection every DbWorker
+borrows. Both are pinned here, along with the order inside ``make_filter``,
+where the rollback used to sit one call too early.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import queue
+from typing import Any
+
+import pytest
+
+import fpdb_3_legacy
+from fpdb_3_legacy import Filters as filters_module
+from fpdb_3_legacy.Database import Database
+from fpdb_3_legacy.Filters import Filters
+
+FILTERS_SOURCE = pathlib.Path(fpdb_3_legacy.__file__).parent / "Filters.py"
+
+
+def filters_tree() -> ast.Module:
+    return ast.parse(FILTERS_SOURCE.read_text(encoding="utf-8"))
+
+
+def function_named(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    pytest.fail(f"Filters.{name} no longer exists")
+    raise AssertionError  # unreachable, keeps the type checker happy
+
+
+# ---------------------------------------------------------------------------
+# The filter buttons: the one place that sees every tab's refresh
+# ---------------------------------------------------------------------------
+
+
+class RecordingFilters:
+    """The wrapper under test, on a host reduced to what it touches."""
+
+    _releasing_read_locks = Filters._releasing_read_locks
+
+    def __init__(self) -> None:
+        self.rollbacks = 0
+
+    def end_read_transaction(self) -> None:
+        self.rollbacks += 1
+
+
+def test_a_refresh_ends_its_read_transaction() -> None:
+    host = RecordingFilters()
+    calls: list[tuple[Any, ...]] = []
+
+    wrapped = host._releasing_read_locks(lambda *args: calls.append(args))
+    wrapped(None)
+
+    assert calls == [(None,)]
+    assert host.rollbacks == 1
+
+
+def test_a_refresh_that_raises_still_ends_its_read_transaction() -> None:
+    """The failed refresh is the one that leaves a transaction behind.
+
+    On PostgreSQL it is also left *aborted*, which makes every later query on
+    that connection fail until something ends it.
+    """
+    host = RecordingFilters()
+
+    def explode() -> None:
+        msg = "the query blew up"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError):
+        host._releasing_read_locks(explode)()
+
+    assert host.rollbacks == 1
+
+
+def test_the_callback_result_is_passed_through() -> None:
+    host = RecordingFilters()
+
+    assert host._releasing_read_locks(lambda: "graph")() == "graph"
+
+
+@pytest.mark.parametrize("register", ["registerButton1Callback", "registerButton2Callback"])
+def test_both_filter_buttons_connect_through_the_wrapper(register: str) -> None:
+    """Connecting the raw callback again would reopen the leak for every tab."""
+    node = function_named(filters_tree(), register)
+
+    connects = [
+        call
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "connect"
+    ]
+
+    assert connects, f"{register} no longer connects anything"
+    for connect in connects:
+        argument = connect.args[0]
+        assert isinstance(argument, ast.Call), f"{register} connects a bare callback"
+        assert isinstance(argument.func, ast.Attribute)
+        assert argument.func.attr == "_releasing_read_locks"
+
+
+def test_the_sidebar_ends_its_transaction_after_the_last_query() -> None:
+    """``set_default_hero`` runs six more queries, so it must come first.
+
+    The rollback was there all along -- on the line above ``set_default_hero``,
+    which is to say before the queries that actually left the transaction open.
+    """
+    body = function_named(filters_tree(), "make_filter").body
+    order = [
+        index
+        for index, statement in enumerate(body)
+        if isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Call)
+        and isinstance(statement.value.func, ast.Attribute)
+        and statement.value.func.attr in {"set_default_hero", "end_read_transaction"}
+    ]
+
+    assert len(order) == 2
+    first, second = (body[index].value.func.attr for index in order)  # type: ignore[union-attr]
+    assert (first, second) == ("set_default_hero", "end_read_transaction")
+
+
+def test_changing_hero_ends_its_transaction_too() -> None:
+    """It reruns all six update_*_for_hero queries on every change."""
+    node = function_named(filters_tree(), "update_filters_for_hero")
+
+    assert [
+        call
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "end_read_transaction"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The worker pool: shared by every tab, and kept for the life of the process
+# ---------------------------------------------------------------------------
+
+
+class FakeConnection:
+    def __init__(self, *, rollback_fails: bool = False) -> None:
+        self.rollback_fails = rollback_fails
+        self.rollbacks = 0
+        self.closed = False
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+        if self.rollback_fails:
+            msg = "connection is gone"
+            raise RuntimeError(msg)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class PoolHost:
+    """``Database``'s return path, with a pool of its own."""
+
+    _return_worker_connection = Database._return_worker_connection
+
+    def __init__(self) -> None:
+        self._worker_conn_pool: queue.Queue[Any] = queue.Queue()
+
+    def pooled(self) -> list[Any]:
+        return list(self._worker_conn_pool.queue)
+
+
+def test_a_worker_connection_is_rolled_back_before_it_is_pooled() -> None:
+    """Otherwise it idles in a transaction until fpdb exits, holding locks."""
+    host = PoolHost()
+    conn = FakeConnection()
+
+    host._return_worker_connection(conn)
+
+    assert conn.rollbacks == 1
+    assert host.pooled() == [conn]
+
+
+def test_a_connection_that_cannot_roll_back_is_dropped_not_pooled() -> None:
+    """Pooling it hands the next borrower a connection that fails every query."""
+    host = PoolHost()
+    conn = FakeConnection(rollback_fails=True)
+
+    host._return_worker_connection(conn)
+
+    assert conn.closed is True
+    assert host.pooled() == []
+
+
+def test_no_connection_is_not_an_error() -> None:
+    """SQLite ``:memory:`` yields None and falls back to the shared connection."""
+    host = PoolHost()
+
+    host._return_worker_connection(None)
+
+    assert host.pooled() == []
+
+
+@pytest.mark.parametrize(
+    ("callback", "expected"),
+    [
+        (lambda: None, 0),
+        (lambda _checked: None, 1),
+        (lambda _checked=None: None, 1),
+    ],
+)
+def test_the_wrapper_offers_only_the_arguments_the_callback_takes(callback, expected: int) -> None:
+    """Qt sends a clicked slot the checked flag only if it has room for it.
+
+    PySide works that out by inspecting the callable, which a wrapper hides.
+    Both ``exportGraph`` methods and ``GuiTourneyPlayerStats.refreshStats``
+    take no argument, so forwarding blindly makes their button raise
+    TypeError instead of running.
+    """
+    assert filters_module._accepted_positional_count(callback) == expected
+
+
+def test_a_callback_taking_nothing_survives_a_clicked_signal() -> None:
+    host = RecordingFilters()
+    ran: list[bool] = []
+
+    wrapped = host._releasing_read_locks(lambda: ran.append(True))
+    wrapped(False)  # what QPushButton.clicked delivers
+
+    assert ran == [True]
+    assert host.rollbacks == 1
+
+
+def test_a_callback_taking_the_flag_still_receives_it() -> None:
+    host = RecordingFilters()
+    seen: list[Any] = []
+
+    host._releasing_read_locks(lambda checked: seen.append(checked))(True)
+
+    assert seen == [True]


### PR DESCRIPTION
Closes #271. Split out of #249, where this was the other half of the freeze.

## The problem

Every filter query is a read, but a read still opens a transaction, and one nobody ends keeps its connection in `idle in transaction` for the life of the tab.

Measured on the reporter's database, opening three tabs:

```
before any tab              (nothing)
after Graphs                idle=1
after Ring Player Stats     idle=1, idle in transaction=1
after Hand Viewer           idle=1, idle in transaction=2

tables locked: gametypes, hands, handsplayers, players, sites
```

And after actually refreshing a tab it was worse — the four pooled `DbWorker` connections were left the same way, adding `handsactions`, `handscashout` and `handsshowdown`:

```
after a Ring Player Stats refresh   idle in transaction=5
```

Autovacuum therefore could not reclaim dead rows on the two tables that actually grow while fpdb runs, and anything wanting a stronger lock queued behind the read — which is how a schema migration came to hang the GUI in #249.

## The fix

At the two places that see every read, rather than at each of the seven tabs — that being the same fix repeated seven times and forgotten the eighth:

- **`Filters`** wraps the two buttons every tab registers its refresh with, so the transaction ends when the refresh returns. It ends it when the refresh *raises* too, which is precisely the case that otherwise leaves an aborted transaction poisoning every later query on that connection.
- **`Database`** returns a worker connection to the pool rolled back, and drops one whose rollback fails instead of handing the next borrower a connection that cannot run anything. That pool is class-level and shared by every tab for the life of the process, so a poisoned entry stayed poisoned.

Two smaller ones where reads sit outside those paths:

- `make_filter` had its rollback one line too early — above `set_default_hero`, and therefore above the six `update_*_for_hero` queries that reopen the transaction. Those rerun on every hero change, so `update_filters_for_hero` ends its own too.
- `ring_stats.refresh_all` resolves player and site ids on the tab's own connection before dispatching to the workers.

## One trap worth flagging

The wrapper trims what it forwards to what the callback accepts. Qt hands a clicked slot the button's `checked` flag only when the slot has room for it, and PySide decides that by inspecting the callable — which a wrapper hides. Three of the registered refreshes take no argument at all (`GuiGraphViewer.exportGraph`, `GuiTourneyGraphViewer.exportGraph`, `GuiTourneyPlayerStats.refreshStats`), so forwarding blindly would turn their button into a `TypeError`. Caught by checking the arity of all twelve registered callbacks; verified by clicking the Tourney Player Stats button, which is one of the three.

## Verification

Clicking the real Refresh buttons on Graphs, Ring Player Stats, Hand Viewer and Session Viewer:

| | before | after |
|---|---|---|
| after four tabs built | 3 idle-in-transaction, 5 tables locked | all idle, no locks |
| after all four refreshed | idle-in-transaction, 8 tables locked | all idle, no locks |

`test/test_read_transaction_hygiene.py` pins both choke points, the argument trimming, the `make_filter` ordering, and that a connection failing its rollback is dropped rather than pooled.

Full suite: 8213 passed, 16 skipped; 711 `qt` tests passed; ruff, mypy and bandit clean on the changed lines.
