### PR TITLE
fix(gui): give the refresh buttons back their argument

### DIFF
--- a/fpdb_3_legacy/Filters.py
+++ b/fpdb_3_legacy/Filters.py
@@ -859,18 +859,22 @@ class Filters(QWidget):
         aborted transaction poisons every later query on that connection until
         it ends.
 
-        Arguments are trimmed to what the callback accepts. Qt hands a clicked
-        slot the button's ``checked`` flag only if the slot has room for it, and
-        PySide decides that by inspecting the callable -- which a wrapper hides.
-        Three of the registered refreshes (both exportGraph, and
-        GuiTourneyPlayerStats.refreshStats) take no argument at all, so
-        forwarding blindly turns their button into a TypeError.
+        The wrapper has to declare the argument and then decide for itself who
+        gets it. PySide reads a slot's own signature to choose what to send,
+        and a wrapper replaces the signature it is standing in for: ``def
+        run(*args)`` counts as taking none, so Qt sends nothing and the nine
+        refreshes that require ``checkState`` get called with no argument at
+        all. Declaring ``checked`` makes Qt send it; forwarding it only to a
+        callback with room for it keeps the three that take none (both
+        exportGraph, and GuiTourneyPlayerStats.refreshStats) working. Between
+        them those two rules reproduce exactly what Qt did before the wrapper
+        existed.
         """
         wanted = _accepted_positional_count(callback)
 
-        def run(*args: Any) -> Any:
+        def run(checked: bool = False) -> Any:
             try:
-                return callback(*args[:wanted])
+                return callback(*(checked,)[:wanted])
             finally:
                 self.end_read_transaction()
 

--- a/test/test_read_transaction_hygiene.py
+++ b/test/test_read_transaction_hygiene.py
@@ -236,12 +236,19 @@ def test_the_wrapper_offers_only_the_arguments_the_callback_takes(callback, expe
     assert filters_module._accepted_positional_count(callback) == expected
 
 
-def test_a_callback_taking_nothing_survives_a_clicked_signal() -> None:
+def test_a_callback_taking_nothing_is_called_with_nothing() -> None:
+    """Calling the wrapper here says nothing about what Qt sends it.
+
+    That question is answered by clicking a real button, in
+    tests/qt/test_filter_button_arguments.py. Assuming the answer instead of
+    clicking is how ``def run(*args)`` shipped and broke every Refresh button:
+    Qt reads the wrapper's signature, and a wrapper taking ``*args`` counts as
+    taking none.
+    """
     host = RecordingFilters()
     ran: list[bool] = []
 
-    wrapped = host._releasing_read_locks(lambda: ran.append(True))
-    wrapped(False)  # what QPushButton.clicked delivers
+    host._releasing_read_locks(lambda: ran.append(True))(False)
 
     assert ran == [True]
     assert host.rollbacks == 1

--- a/tests/qt/test_filter_button_arguments.py
+++ b/tests/qt/test_filter_button_arguments.py
@@ -1,0 +1,100 @@
+"""What a real button click delivers to a real refresh callback.
+
+The wrapper that ends a tab's read transaction (#271) stands between
+``QPushButton.clicked`` and every tab's refresh, and PySide decides what to
+send a slot by reading that slot's own signature. A wrapper therefore replaces
+the signature it is standing in for, and gets to choose what the callback sees.
+
+Getting that wrong broke all six tabs at once: ``def run(*args)`` counts as
+taking no argument, so Qt sent nothing and the nine refreshes that require
+``checkState`` were called with none -- "Refresh Stats does nothing" on every
+tab. The unit tests around the wrapper did not catch it because they called
+the wrapper directly, supplying the argument Qt was not supplying. Only a real
+click can answer this question, so these tests click.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from PySide6.QtWidgets import QPushButton
+
+from fpdb_3_legacy.Filters import Filters
+
+pytestmark = pytest.mark.qt
+
+
+class RecordingFilters:
+    """The wrapper under test, on a host reduced to what it touches."""
+
+    _releasing_read_locks = Filters._releasing_read_locks
+
+    def __init__(self) -> None:
+        self.rollbacks = 0
+
+    def end_read_transaction(self) -> None:
+        self.rollbacks += 1
+
+
+def clicked_with(qtbot, callback: Any) -> RecordingFilters:
+    """Connect ``callback`` the way Filters does, then click the button."""
+    host = RecordingFilters()
+    button = QPushButton()
+    qtbot.addWidget(button)
+    button.clicked.connect(host._releasing_read_locks(callback))
+    button.click()
+    return host
+
+
+def test_a_refresh_needing_the_flag_is_given_it(qtbot) -> None:
+    """Nine of the twelve registered refreshes declare ``checkState``."""
+    seen: list[Any] = []
+
+    host = clicked_with(qtbot, lambda check_state: seen.append(check_state))
+
+    assert len(seen) == 1, "the refresh was never called with its argument"
+    assert host.rollbacks == 1
+
+
+def test_a_refresh_taking_nothing_is_given_nothing(qtbot) -> None:
+    """Both exportGraph methods and GuiTourneyPlayerStats.refreshStats."""
+    calls: list[bool] = []
+
+    host = clicked_with(qtbot, lambda: calls.append(True))
+
+    assert calls == [True]
+    assert host.rollbacks == 1
+
+
+def test_a_refresh_with_a_second_optional_argument_still_runs(qtbot) -> None:
+    """``GuiGraphViewer.generateGraph(widget, data=None)`` shape."""
+    seen: list[tuple[Any, ...]] = []
+
+    def refresh(widget, data=None) -> None:
+        seen.append((widget, data))
+
+    host = clicked_with(qtbot, refresh)
+
+    assert len(seen) == 1
+    assert seen[0][1] is None
+    assert host.rollbacks == 1
+
+
+def test_a_failing_refresh_still_ends_the_transaction(qtbot) -> None:
+    """The failed refresh is the one that leaves a transaction behind.
+
+    On PostgreSQL it is left aborted, and every later query on that connection
+    fails until something ends it.
+    """
+    host = RecordingFilters()
+
+    def explode(_check_state) -> None:
+        msg = "the query blew up"
+        raise RuntimeError(msg)
+
+    wrapped = host._releasing_read_locks(explode)
+    with pytest.raises(RuntimeError):
+        wrapped(False)
+
+    assert host.rollbacks == 1


### PR DESCRIPTION
Regression from #272, reported against the rebuilt macOS app: **Refresh Stats does nothing on any tab.**

## What broke

#272 put a wrapper between `QPushButton.clicked` and every tab's refresh, so the read transaction gets ended when the refresh returns. PySide reads a slot's *own* signature to decide what to send it — which means a wrapper replaces the signature it is standing in for.

`def run(*args)` counts as taking no argument:

```
def run(*args)             received ()
def run(checked=False)     received (False,)
def run(checked)           received (False,)
def run()                  received ()
```

So Qt sent nothing, and the nine refreshes that require `checkState` were called with none:

```
TypeError: GuiGraphViewer.generateGraph() missing 1 required positional argument: 'widget'
TypeError: GuiHandViewer.loadHands() missing 1 required positional argument: 'checkState'
TypeError: GuiSessionViewer.refreshStats() missing 1 required positional argument: 'checkState'
...
```

Raised inside the slot, where Qt prints it and carries on — which is why the button appeared to do nothing rather than failing visibly.

## The fix

The wrapper declares `checked` so Qt sends it, and forwards it only to a callback with room for it — keeping the three that take none working (`GuiGraphViewer.exportGraph`, `GuiTourneyGraphViewer.exportGraph`, `GuiTourneyPlayerStats.refreshStats`). Between them, those two rules reproduce exactly what Qt did before the wrapper existed.

## Why the tests missed it

This is the part worth keeping. The unit tests around the wrapper called it directly:

```python
wrapped = host._releasing_read_locks(callback)
wrapped(False)          # supplying the argument Qt was not supplying
```

They asserted that the wrapper forwards what it is given. The question at issue is what Qt gives it, and no amount of calling the wrapper by hand can answer that. The verification run had the same hole: it clicked the buttons and checked the connection state afterwards, but a `TypeError` inside a Qt slot never reaches the caller of `.click()`, so "no exception" meant nothing — and I never asserted the refresh had produced any rows.

`tests/qt/test_filter_button_arguments.py` clicks a real `QPushButton`. Against the shipped wrapper it fails:

```
FAILED test_a_refresh_needing_the_flag_is_given_it
FAILED test_a_refresh_with_a_second_optional_argument_still_runs
```

## Verification

Through the real Refresh button, asserting on what each tab produced rather than on the absence of an exception:

| tab | after refresh |
|---|---|
| Graphs | 4 curves |
| Ring Player Stats | summary present, 500 rows, 495 grid cells |
| Hand Viewer | 100 rows |
| Session Stats | 25 rows |
| Tourney Graphs | 6 curves |
| Tourney Viewer | 83 rows |

The zero-argument button (Tourney Player Stats) clicks without raising. Transaction hygiene from #272 is unchanged — every backend still ends up `idle` with no locks held.

Full suite: 8213 passed, 16 skipped; 715 `qt` tests passed; ruff and mypy clean.
