### PR TITLE
fix(ipoker): keep a Twister HUD on the table it was built for

### DIFF
--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -846,6 +846,12 @@ class HudMain(QObject):
             # once; this makes read_stdin idempotent so each hand refreshes the
             # HUD exactly once, without re-running create/update on a duplicate.
             self._last_processed_hands: dict[str, str] = {}
+            # Tables whose window this session found at least once, and tables
+            # already reported as not found. Together they keep "table not found"
+            # an error the first time and a routine note once the table is known
+            # to have existed and closed (see _log_table_not_found).
+            self._tables_attached: set[str] = set()
+            self._tables_not_found: set[str] = set()
             # Winamax log pool -> hud_dict key, learned once a hand from that
             # table has been imported and reused while the table stays open.
             self._winamax_pool_huds: dict[str, str] = {}
@@ -2339,6 +2345,39 @@ class HudMain(QObject):
         elif getattr(table, "type", "") == "tour":
             self._handle_tour_table_switch(hud, table)
 
+    def _log_table_not_found(
+        self,
+        temp_key: str,
+        table_name: str,
+        db_site: str,
+        hud_site: str,
+        tablewindow: Any,
+    ) -> None:
+        """Report a table whose window could not be found, at the right volume.
+
+        A hand reaches the HUD 15 to 30 seconds after it was played, so the last
+        hands of a table that has just been closed -- and every hand of a Sit'n'Go
+        whose file the client only writes once the match is over -- routinely
+        arrive with no window left to attach to. Logged as errors, and once per
+        hand, they buried the case that is a real failure: a table that is open
+        on screen and never gets a HUD. That one still logs an error, once, with
+        the search string it failed on, which is the part that identifies why.
+        """
+        if temp_key in self._tables_attached:
+            report = log.info  # window was found before: the table has since closed
+        elif temp_key in self._tables_not_found:
+            report = log.debug  # already reported once for this table
+        else:
+            report = log.error
+        self._tables_not_found.add(temp_key)
+        report(
+            "HUD create: table name %s not found for db_site=%s hud_site=%s (searched %r), skipping.",
+            table_name,
+            db_site,
+            hud_site,
+            getattr(tablewindow, "search_string", ""),
+        )
+
     def _handle_tour_table_switch(self, hud: Hud.Hud, table: Any) -> None:
         """Kill a tournament HUD whose window has moved on to another table.
 
@@ -3470,12 +3509,7 @@ class HudMain(QObject):
         if tablewindow.number is None:
             if game_type == "tour":
                 table_name = f"{tour_number} {tab_number}"
-            log.error(
-                "HUD create: table name %s not found for db_site=%s hud_site=%s, skipping.",
-                table_name,
-                info.site_name,
-                hud_site_name,
-            )
+            self._log_table_not_found(temp_key, table_name, info.site_name, hud_site_name, tablewindow)
             return
         if tablewindow.number in self.blacklist:
             log.warning(
@@ -3489,6 +3523,7 @@ class HudMain(QObject):
         # One WARNING per HUD creation so the log always records WHICH window
         # was matched: user reports of "table not detected" are impossible to
         # diagnose without the matched hwnd/title (or their absence).
+        self._tables_attached.add(temp_key)
         log.warning(
             "HUD attach: table=%r site=%s hwnd=%s title=%r geometry=(%s,%s %sx%s)",
             temp_key,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -3524,6 +3524,11 @@ class HudMain(QObject):
         # was matched: user reports of "table not detected" are impossible to
         # diagnose without the matched hwnd/title (or their absence).
         self._tables_attached.add(temp_key)
+        # Baseline for _handle_tour_table_switch, taken from the title this HUD
+        # was built on rather than from the first poll up to 800 ms later: a
+        # Twister window handed to the next match in between would otherwise
+        # become the baseline, and the stale HUD would sit there unnoticed.
+        tablewindow.seed_title_table_no()
         log.warning(
             "HUD attach: table=%r site=%s hwnd=%s title=%r geometry=(%s,%s %sx%s)",
             temp_key,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -2336,6 +2336,43 @@ class HudMain(QObject):
             self.client_moved(None, hud)
         elif status == "client_resized":
             self.client_resized(None, hud)
+        elif getattr(table, "type", "") == "tour":
+            self._handle_tour_table_switch(hud, table)
+
+    def _handle_tour_table_switch(self, hud: Hud.Hud, table: Any) -> None:
+        """Kill a tournament HUD whose window has moved on to another table.
+
+        check_table() only watches geometry, so a window that keeps its size and
+        position while its title changes table went unnoticed until a hand of the
+        new table was imported -- 15 to 30 seconds later on a Twister, where the
+        client reuses the same window for the next match of the series. Until
+        then the finished tournament's HUD sat on the new table showing the
+        previous opponents. Killing it here means the worst case is no HUD for a
+        few seconds instead of a wrong one.
+        """
+        try:
+            seen = table.get_table_no()
+        except Exception:
+            log.debug("Table title check failed for %r", getattr(table, "key", "?"), exc_info=True)
+            return
+        if seen is False:
+            return
+        # The number the title carried when the HUD attached is the baseline, so
+        # a site whose title never shows the table id simply never signals here
+        # instead of the HUD being killed on a mismatch it cannot control.
+        baseline = getattr(table, "title_table_no", None)
+        if baseline is None:
+            table.title_table_no = seen
+            return
+        if seen != baseline:
+            log.warning(
+                "HUD dropped: window %s left table %s (title now shows table %s, was %s)",
+                table.number,
+                table.key,
+                seen,
+                baseline,
+            )
+            self.table_is_stale(hud)
 
     def _topify_mac_windows(self) -> None:
         """Bring all HUD windows to the top on macOS."""

--- a/fpdb_3_legacy/TableWindow.py
+++ b/fpdb_3_legacy/TableWindow.py
@@ -115,6 +115,9 @@ class Table_Window:
         self.table: int | None = None
         self.search_string = ""
         self.tableno_re = ""
+        # Table id read from the window title when the HUD attached; HUD_main
+        # compares later reads against it to notice the window switching table.
+        self.title_table_no: int | None = None
         self.width = 0
         self.height = 0
         self.x = 0
@@ -364,6 +367,12 @@ class Table_Window:
         return False  # no change
 
     def has_table_title_changed(self, hud) -> bool:
+        if self.table is not None and self.table == self.tournament:
+            # The hand history carried no table id, so self.table holds the
+            # tournament number as a fallback: it can never equal what the title
+            # shows, and comparing them would report a move on every poll.
+            log.debug("Table id unknown (fell back to the tournament number); skipping title check")
+            return False
         log.debug("before get_table_no()")
         result = self.get_table_no()
         log.debug(f"tb has change nb {result}")

--- a/fpdb_3_legacy/TableWindow.py
+++ b/fpdb_3_legacy/TableWindow.py
@@ -366,6 +366,31 @@ class Table_Window:
             return "client_moved"
         return False  # no change
 
+    def seed_title_table_no(self) -> None:
+        """Record the table the title showed at the moment the HUD attached.
+
+        Read from the title already captured by the window search rather than by
+        asking the window again: a Twister client hands the same window to the
+        next match of the series, and a hand reaches the HUD seconds after it was
+        played, so a switch can fall between the attach and the first status
+        poll. Seeding here means the poll compares against what this HUD was
+        actually built on, instead of adopting the replacement table as its
+        baseline and never noticing.
+        """
+        if not self.tableno_re or not self.title:
+            return
+        try:
+            mo = re.search(self.tableno_re, self.title)
+            if mo is not None:
+                self.title_table_no = int(mo.group(1))
+        except (re.error, IndexError, ValueError):
+            # A site whose pattern does not compile, captures nothing, or
+            # captures something that is not a number simply gets no baseline,
+            # and the poll leaves its HUD alone.
+            log.debug("No table number in %r via %r", self.title, self.tableno_re)
+        else:
+            log.debug("Seeded title table number: %s", self.title_table_no)
+
     def has_table_title_changed(self, hud) -> bool:
         if self.table is not None and self.table == self.tournament:
             # The hand history carried no table id, so self.table holds the

--- a/fpdb_3_legacy/iPoker/base.py
+++ b/fpdb_3_legacy/iPoker/base.py
@@ -1324,8 +1324,15 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
         ``get_table_no`` always returned False and a window that changed table --
         an MTT reseat, or the next match of a Twister series taking over the same
         window -- was never detected.
+
+        Anchored to the end of that segment rather than taking the first long
+        number in it: a table can be named after its tournament as well
+        ("1193390834 Twister, 5867402179"), and reading the tournament number as
+        the table would make has_table_title_changed() call every hand a reseat
+        and kill the HUD on each one. The lookbehind keeps the match from
+        starting mid-number and returning a truncated id.
         """
-        return r"^[^|]*?(\d{6,})"
+        return r"^[^|]*?(?<!\d)(\d{6,})\s*(?:\||$)"
 
     @staticmethod
     def getTableTitleRe(

--- a/fpdb_3_legacy/iPoker/base.py
+++ b/fpdb_3_legacy/iPoker/base.py
@@ -1311,6 +1311,23 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
             log.exception("Error processing tournament summary")
 
     @staticmethod
+    def getTableNoRe(tournament: str | int) -> str:  # noqa: ARG004
+        """Return the regex that reads the table id back out of a window title.
+
+        The inherited pattern (``<tournament>.+(?:Table|Torneo) (\\d+)``) never
+        matches an iPoker title: the tournament number is absent from it and the
+        table is not labelled "Table <n>". A title reads
+
+            "Twister 0.25€ 1200531183 | NL Hold'em | Niveau 1 | 10/20"
+
+        so the id is the long number closing the first segment. Without this,
+        ``get_table_no`` always returned False and a window that changed table --
+        an MTT reseat, or the next match of a Twister series taking over the same
+        window -- was never detected.
+        """
+        return r"^[^|]*?(\d{6,})"
+
+    @staticmethod
     def getTableTitleRe(
         game_type: str,
         table_name: str | None = None,
@@ -1362,9 +1379,25 @@ class iPoker(IPokerStreetsActionsMixin, IPokerHandInfoMixin, IPokerTournamentRes
                 is_twister = True
 
             if is_twister:
-                # Twister tables don't have table numbers in the window title, they are named "Twister" or "Spins"
-                # We return a regex matching either Twister or Spins (branded on some French skins like Bwin.fr/PMU)
-                regex = r"(?:Twister|Spins)"
+                # Twister/Spins titles carry no "Table <n>", but they do end the
+                # name segment with the physical table id:
+                #   "Twister 0.25€ 1200531183 | NL Hold'em | Niveau 1 | 10/20"
+                # Pinning the regex to that id matters because the client reuses
+                # the SAME window for the next match of a Twister series: a bare
+                # "(?:Twister|Spins)" matched the recycled window, so the HUD of a
+                # tournament that had just ended was drawn -- previous opponents
+                # and all -- on the table of the new one, and every Twister of a
+                # multi-tabling session matched the same window.
+                table_id = str(table_number) if table_number is not None else ""
+                min_table_id_digits = 6  # every real iPoker table id is 9-10 digits
+                if table_id.isdigit() and len(table_id) >= min_table_id_digits and table_id != str(tournament):
+                    regex = rf"(?:Twister|Spins)[^|]*\b{table_id}\b"
+                else:
+                    # No usable table id (hand histories that never carried one,
+                    # so TableWindow handed back the tournament number or a bare
+                    # seat-style index): keep the loose match rather than pinning
+                    # the search to a number the title does not contain.
+                    regex = r"(?:Twister|Spins)"
                 log.debug("Generated regex for Twister/Spins SNG: %s", regex)
                 return regex
 

--- a/fpdb_3_legacy/iPoker/hand_info.py
+++ b/fpdb_3_legacy/iPoker/hand_info.py
@@ -22,6 +22,9 @@ _PLAYER_TAG_RE = re.compile(
     r'<player\b(?=[^>]*\bname="(?P<PNAME>[^"]*)")(?=[^>]*\bseat="(?P<SEAT>\d+)")[^>]*>',
 )
 _SESSION_CODE_RE = re.compile(r'sessioncode="(?P<CODE>\d+)"')
+_GAMECODE_RE = re.compile(r'<game gamecode="(?P<HID>\d+)"')
+# Prefix of the placeholder a seat gets when the session names nobody for it.
+_ANON_SCOPE_PREFIX = "anon_"
 
 
 class IPokerHandInfoMixin:
@@ -88,7 +91,16 @@ class IPokerHandInfoMixin:
         self._seat_names = resolved
         return resolved
 
-    def _deanonymize_players(self, hand: Any) -> None:
+    @staticmethod
+    def _named_players(hand_text: str) -> list[str]:
+        """Players the hand can actually be credited to, placeholders excluded."""
+        return [
+            m.group("PNAME")
+            for m in _PLAYER_TAG_RE.finditer(hand_text)
+            if not m.group("PNAME").startswith(_ANON_SCOPE_PREFIX)
+        ]
+
+    def _deanonymize_players(self, hand: Any) -> tuple[int, int]:
         """Recover anonymous "Player N" opponents in place on hand.handText.
 
         Only hands where the hero is not dealt are anonymous. There is therefore
@@ -102,6 +114,10 @@ class IPokerHandInfoMixin:
         markStreets/readBlinds/readAction/readHoleCards/readCollectPot all
         re-parse hand.handText, so rewriting it once here keeps players, actions,
         cards and collectees consistent under the recovered names.
+
+        Returns how many players were anonymous and how many of them were
+        recovered, which is what lets readHandInfo drop a hand nobody can be put
+        a name to.
         """
         hero_nick = getattr(self, "hero", "") or ""
 
@@ -111,7 +127,7 @@ class IPokerHandInfoMixin:
             if _ANON_NAME_RE.match(m.group("PNAME"))
         ]
         if not anon_players:
-            return  # named hand (hero dealt in): real names already present.
+            return 0, 0  # named hand (hero dealt in): real names already present.
 
         session = self._session_code()
         seat_names = self._session_seat_names()
@@ -135,6 +151,7 @@ class IPokerHandInfoMixin:
         if recovered:
             log.info("iPoker de-anonymisation: recovered opponents from session seat map: %s", recovered)
         log.debug("iPoker de-anonymisation rename map: %s", rename)
+        return len(anon_players), len(recovered)
 
     def readHandInfo(self, hand: Any) -> None:
         """Parses the hand text and extracts relevant information about the hand.
@@ -144,6 +161,8 @@ class IPokerHandInfoMixin:
 
         Raises:
             FpdbParseError: If the hand text cannot be parsed.
+            FpdbHandPartial: If every player in the hand is anonymous and no seat
+                can be put a name to.
 
         Returns:
             None
@@ -152,7 +171,22 @@ class IPokerHandInfoMixin:
 
         # Recover anonymous "Player N" opponents before anything else reads
         # player names (see _deanonymize_players).
-        self._deanonymize_players(hand)
+        anonymous, recovered = self._deanonymize_players(hand)
+        if anonymous and not recovered and not self._named_players(hand.handText):
+            # Nothing in the session names a single seat yet -- live import
+            # reaching an observed hand before the hero has played one. Storing
+            # it would create a Players row per seat ("anon_<session>_<seat>")
+            # that no statistic can ever be read back through: the hero is not in
+            # the hand, so it builds no HUD, and the real names the file reveals
+            # minutes later never reach the rows already written. Leave the hand
+            # out instead; a later full import of the file, by then holding the
+            # named hands, stores it under the real opponents.
+            gamecode = _GAMECODE_RE.search(hand.handText)
+            msg = (
+                f"Hand {gamecode.group('HID') if gamecode else '?'} is fully anonymous and no seat is named "
+                f"anywhere in the session yet; skipped rather than stored under placeholder players"
+            )
+            raise FpdbHandPartial(msg)
 
         # Parse hand info from regex
         match = self._parse_hand_info_regex(hand.handText)

--- a/fpdb_3_legacy/iPoker/hand_info.py
+++ b/fpdb_3_legacy/iPoker/hand_info.py
@@ -23,8 +23,11 @@ _PLAYER_TAG_RE = re.compile(
 )
 _SESSION_CODE_RE = re.compile(r'sessioncode="(?P<CODE>\d+)"')
 _GAMECODE_RE = re.compile(r'<game gamecode="(?P<HID>\d+)"')
-# Prefix of the placeholder a seat gets when the session names nobody for it.
-_ANON_SCOPE_PREFIX = "anon_"
+# The placeholder a seat gets when the session names nobody for it. Matched in
+# full rather than by its "anon_" prefix: "anon_hunter" is a screen name someone
+# may well be sitting under, and reading it as a placeholder would drop the
+# hands that player is recovered in.
+_ANON_SCOPE_RE = re.compile(r"^anon_\d+_\d+$")
 
 
 class IPokerHandInfoMixin:
@@ -97,7 +100,7 @@ class IPokerHandInfoMixin:
         return [
             m.group("PNAME")
             for m in _PLAYER_TAG_RE.finditer(hand_text)
-            if not m.group("PNAME").startswith(_ANON_SCOPE_PREFIX)
+            if not _ANON_SCOPE_RE.match(m.group("PNAME"))
         ]
 
     def _deanonymize_players(self, hand: Any) -> tuple[int, int]:
@@ -147,7 +150,7 @@ class IPokerHandInfoMixin:
             text = text.replace(f'name="{old}"', f'name="{new}"').replace(f'player="{old}"', f'player="{new}"')
         hand.handText = text
 
-        recovered = {old: new for old, new in rename.items() if not new.startswith("anon_")}
+        recovered = {old: new for old, new in rename.items() if not _ANON_SCOPE_RE.match(new)}
         if recovered:
             log.info("iPoker de-anonymisation: recovered opponents from session seat map: %s", recovered)
         log.debug("iPoker de-anonymisation rename map: %s", rename)

--- a/fpdb_3_legacy/iPoker/xml_format.py
+++ b/fpdb_3_legacy/iPoker/xml_format.py
@@ -470,8 +470,17 @@ class IPokerXMLFormatMixin:
             except (ValueError, TypeError):
                 self.tinfo["endTime"] = None
 
-        # Set table name for tournament
+        # Set table name for tournament.
+        # The session header's <tablename> ("Twister 0.25€, 1200531183") is the
+        # only place the physical table id appears, and it sits before the first
+        # <game>: re_game_info therefore matches the first hand of a file only,
+        # and every later hand -- i.e. all of live auto-import -- lands here.
+        # Falling back to <tournamentname> dropped the ", <tableId>" suffix, so
+        # the same table was stored under two names, the HUD keyed it twice
+        # ("<tour> Table 1200531183" then "<tour> Table 0.25€") and rebuilt
+        # itself from scratch on the second hand of every tournament.
         self.tablename = "1"
-        self.info["table_name"] = self.tinfo["tourName"]
+        session_tablename = re.search(r"<tablename>([^<]*)</tablename>", self.whole_file)
+        self.info["table_name"] = session_tablename.group(1) if session_tablename else self.tinfo["tourName"]
 
         log.debug("Initialized tournament info: %s", self.tinfo)

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -3071,3 +3071,48 @@ def test_a_closed_table_is_not_reported_as_an_error(hud_main) -> None:
 
     error.assert_not_called()
     assert info.call_count == 1
+
+
+def test_the_baseline_is_the_table_the_hud_was_built_on(hud_main) -> None:
+    """A window handed to the next match before the first poll must not set it.
+
+    Seeding at attach is what makes the poll compare against the table this HUD
+    was actually built on; taking the first poll's read as the baseline would
+    adopt the replacement table and leave the stale HUD in place for good.
+    """
+    table = _tour_table([1200533055, 1200533055])  # window already moved on
+    table.title_table_no = 1200531183  # what seed_title_table_no() recorded
+    hud = SimpleNamespace(table=table)
+
+    with patch.object(hud_main, "table_is_stale") as stale:
+        hud_main._handle_tour_table_switch(hud, table)
+
+    stale.assert_called_once_with(hud)
+
+
+def test_a_seeded_table_window_reads_its_number_from_the_matched_title() -> None:
+    """seed_title_table_no() uses the title the window search already captured."""
+    from fpdb_3_legacy.TableWindow import Table_Window
+
+    table = Table_Window.__new__(Table_Window)
+    table.tableno_re = r"^[^|]*?(?<!\d)(\d{6,})\s*(?:\||$)"
+    table.title = "Twister 0.25€ 1200531183 | NL Hold'em | Niveau 1 | 10/20"
+    table.title_table_no = None
+
+    table.seed_title_table_no()
+
+    assert table.title_table_no == 1200531183
+
+
+def test_a_title_the_pattern_cannot_read_leaves_no_baseline() -> None:
+    """No baseline means the poll leaves that HUD alone, which is the safe end."""
+    from fpdb_3_legacy.TableWindow import Table_Window
+
+    table = Table_Window.__new__(Table_Window)
+    table.tableno_re = r"(?:Twister|Spins)"  # no capturing group
+    table.title = "Twister 0.25€ | NL Hold'em"
+    table.title_table_no = None
+
+    table.seed_title_table_no()
+
+    assert table.title_table_no is None

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -3047,3 +3047,27 @@ def test_a_title_without_a_table_id_never_signals_a_switch(hud_main) -> None:
 
     stale.assert_not_called()
     assert table.title_table_no is None
+
+
+def test_a_table_that_was_never_found_is_an_error_once(hud_main) -> None:
+    """A table open on screen that never gets a HUD is the case worth shouting about."""
+    window = SimpleNamespace(search_string="Sea Lake")
+
+    with patch.object(HUD_main.log, "error") as error, patch.object(HUD_main.log, "debug") as debug:
+        hud_main._log_table_not_found("Sea Lake, 1", "Sea Lake, 1", "Bwin.fr Poker", "Bwin.fr Poker", window)
+        hud_main._log_table_not_found("Sea Lake, 1", "Sea Lake, 1", "Bwin.fr Poker", "Bwin.fr Poker", window)
+
+    assert error.call_count == 1
+    assert debug.call_count == 1  # the repeat, not a second error
+
+
+def test_a_closed_table_is_not_reported_as_an_error(hud_main) -> None:
+    """Hands reach the HUD seconds late, so a just-closed table has no window left."""
+    window = SimpleNamespace(search_string="Sea Lake")
+    hud_main._tables_attached.add("Sea Lake, 1")
+
+    with patch.object(HUD_main.log, "error") as error, patch.object(HUD_main.log, "info") as info:
+        hud_main._log_table_not_found("Sea Lake, 1", "Sea Lake, 1", "Bwin.fr Poker", "Bwin.fr Poker", window)
+
+    error.assert_not_called()
+    assert info.call_count == 1

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -2993,3 +2993,57 @@ def test_hud_is_fast_fold_matches_base_name_and_sets_flag(hud_main) -> None:
 
     assert hud_main._hud_is_fast_fold(hud, "Bucarest 1") is True
     assert hud.is_fast_fold is True
+
+
+def _tour_table(numbers: list[int | bool]) -> SimpleNamespace:
+    """A tournament table window whose title reports `numbers` in turn."""
+    reads = iter(numbers)
+    return SimpleNamespace(
+        type="tour",
+        number=19310,
+        key="1200531182 Table 1200531183",
+        title_table_no=None,
+        get_table_no=lambda: next(reads),
+    )
+
+
+def test_a_window_staying_on_its_table_keeps_its_hud(hud_main) -> None:
+    """The poll must not disturb a table that is simply still being played."""
+    table = _tour_table([1200531183, 1200531183])
+    hud = SimpleNamespace(table=table)
+
+    with patch.object(hud_main, "table_is_stale") as stale:
+        hud_main._handle_tour_table_switch(hud, table)  # attaches the baseline
+        hud_main._handle_tour_table_switch(hud, table)
+
+    stale.assert_not_called()
+    assert table.title_table_no == 1200531183
+
+
+def test_a_window_taken_over_by_the_next_match_drops_its_hud(hud_main) -> None:
+    """A Twister client reuses the window for the next match of the series.
+
+    Without this the finished tournament's HUD stayed on screen -- previous
+    opponents and all -- until a hand of the new match was imported.
+    """
+    table = _tour_table([1200531183, 1200533055])
+    hud = SimpleNamespace(table=table)
+
+    with patch.object(hud_main, "table_is_stale") as stale:
+        hud_main._handle_tour_table_switch(hud, table)
+        hud_main._handle_tour_table_switch(hud, table)
+
+    stale.assert_called_once_with(hud)
+
+
+def test_a_title_without_a_table_id_never_signals_a_switch(hud_main) -> None:
+    """Sites whose title omits the table id must not have their HUD killed."""
+    table = _tour_table([False, False])
+    hud = SimpleNamespace(table=table)
+
+    with patch.object(hud_main, "table_is_stale") as stale:
+        hud_main._handle_tour_table_switch(hud, table)
+        hud_main._handle_tour_table_switch(hud, table)
+
+    stale.assert_not_called()
+    assert table.title_table_no is None

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from tools.cleanup_ipoker_anon_players import (
     DELETE_BY_HAND,
     DELETE_BY_PLAYER,
@@ -17,6 +19,7 @@ from tools.cleanup_ipoker_anon_players import (
     SELECT_PLACEHOLDERS,
     SELECT_PLAYERS_OF_HAND,
     SELECT_REMAINING_HANDS_OF_PLAYER,
+    build_parser,
     delete,
     survey,
 )
@@ -238,19 +241,10 @@ def test_a_matching_name_on_another_site_is_left_alone() -> None:
     assert hands == {}
 
 
-def test_apply_and_rehearse_cannot_be_asked_for_together() -> None:
+def test_apply_and_rehearse_cannot_be_asked_for_together(capsys) -> None:
     """--rehearse promises a rollback; combined with --apply it used to commit."""
-    import subprocess
-    import sys
-    from pathlib import Path
+    with pytest.raises(SystemExit) as exit_code:
+        build_parser().parse_args(["--apply", "--rehearse"])
 
-    tool = Path(__file__).resolve().parent.parent / "tools" / "cleanup_ipoker_anon_players.py"
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, str(tool), "--apply", "--rehearse"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert "not allowed with argument" in result.stderr
+    assert exit_code.value.code != 0
+    assert "not allowed with argument --apply" in capsys.readouterr().err

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -34,6 +34,7 @@ PLAYERS_OF_HAND = {
     1114: [(655, "anon_5879604460_1"), (656, "anon_5879604460_5")],
     2000: [(658, "anon_5879604460_9"), (659, "anon_hunter")],
 }
+IPOKER_SITES = {"Bwin.fr Poker"}
 HAND_ROWS = {
     1114: (1114, "Sea Lake, 560237915", "2026-08-27 21:12:11"),
     2000: (2000, "Scone, 560235983", "2026-08-27 21:30:00"),
@@ -79,7 +80,7 @@ def _db(cursor: _Cursor) -> SimpleNamespace:
 
 
 def test_only_hands_made_entirely_of_placeholders_are_offered() -> None:
-    placeholders, hands, kept = survey(_db(_Cursor()))
+    placeholders, hands, kept = survey(_db(_Cursor()), IPOKER_SITES)
 
     assert [p[0] for p in placeholders] == [655, 656, 658]  # 659 is a real name
     assert list(hands) == [1114]  # 2000 seats a real player, so it stays
@@ -92,7 +93,7 @@ def test_a_real_player_named_like_a_placeholder_is_never_deleted() -> None:
     Deleting them would take every hand they played with them, which is why the
     generated form is matched in full rather than by its prefix.
     """
-    placeholders, hands, _kept = survey(_db(_Cursor()))
+    placeholders, hands, _kept = survey(_db(_Cursor()), IPOKER_SITES)
 
     assert 659 not in [p[0] for p in placeholders]
     assert 2000 not in hands  # the hand they sit in is not offered either
@@ -223,3 +224,33 @@ def test_nothing_points_at_a_deleted_table_from_outside_the_script() -> None:
             if parent not in tables:
                 continue
             assert child in cleared, f"{child} references {parent} but is never deleted"
+
+
+def test_a_matching_name_on_another_site_is_left_alone() -> None:
+    """Only the iPoker converter ever wrote these names.
+
+    A player on any other site whose screen name happens to read like one is
+    somebody real, and this tool deletes players.
+    """
+    placeholders, hands, _kept = survey(_db(_Cursor()), {"PokerStars"})
+
+    assert placeholders == []
+    assert hands == {}
+
+
+def test_apply_and_rehearse_cannot_be_asked_for_together() -> None:
+    """--rehearse promises a rollback; combined with --apply it used to commit."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    tool = Path(__file__).resolve().parent.parent / "tools" / "cleanup_ipoker_anon_players.py"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(tool), "--apply", "--rehearse"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -128,3 +128,26 @@ def test_every_table_hanging_off_a_hand_is_cleared() -> None:
     executed = {statement for statement, _params in cursor.executed}
     for _table, statement in DELETE_BY_HAND:
         assert statement in executed
+
+
+def test_every_table_named_matches_the_schema_casing() -> None:
+    """MySQL with case-sensitive table names fails mid-transaction on a typo.
+
+    PostgreSQL folds an unquoted name either way, so a wrong casing survives
+    every rehearsal on it and only breaks on somebody else's backend, after the
+    earlier deletions have already run.
+    """
+    import re
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parent.parent
+    ddl = {"RawHands"}  # built by _raw_table_ddl(db_server, "RawHands", ...)
+    for schema in list(repo.glob("fpdb_3_legacy/sql_schema_*.py")) + list(repo.glob("fpdb_3_legacy/sql_queries_*.py")):
+        ddl |= set(re.findall(r"CREATE TABLE (?:IF NOT EXISTS )?([A-Za-z_]+)", schema.read_text(encoding="utf-8")))
+
+    source = (repo / "tools" / "cleanup_ipoker_anon_players.py").read_text(encoding="utf-8")
+    named = set(re.findall(r"DELETE FROM ([A-Za-z_]+)", source))
+    named |= set(re.findall(r"FROM ([A-Za-z_]+) ", source)) | set(re.findall(r"JOIN ([A-Za-z_]+) ", source))
+
+    assert named, "no table names found; the extraction above stopped matching"
+    assert named <= ddl, f"not in the schema with this casing: {sorted(named - ddl)}"

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -21,15 +21,18 @@ from tools.cleanup_ipoker_anon_players import (
     survey,
 )
 
+# What the LIKE pre-filter returns: "anon_hunter" matches it and is a real
+# player, which is why the tool tests the name in full before deleting anybody.
 PLACEHOLDERS = [
     (655, "anon_5879604460_1", "Bwin.fr Poker"),
     (656, "anon_5879604460_5", "Bwin.fr Poker"),
     (658, "anon_5879604460_9", "Bwin.fr Poker"),
+    (659, "anon_hunter", "Bwin.fr Poker"),
 ]
 HANDS_OF_PLAYER = {655: [1114], 656: [1114], 658: [2000]}
 PLAYERS_OF_HAND = {
     1114: [(655, "anon_5879604460_1"), (656, "anon_5879604460_5")],
-    2000: [(658, "anon_5879604460_9"), (700, "Requinbleu")],
+    2000: [(658, "anon_5879604460_9"), (659, "anon_hunter")],
 }
 HAND_ROWS = {
     1114: (1114, "Sea Lake, 560237915", "2026-08-27 21:12:11"),
@@ -78,9 +81,21 @@ def _db(cursor: _Cursor) -> SimpleNamespace:
 def test_only_hands_made_entirely_of_placeholders_are_offered() -> None:
     placeholders, hands, kept = survey(_db(_Cursor()))
 
-    assert [p[0] for p in placeholders] == [655, 656, 658]
+    assert [p[0] for p in placeholders] == [655, 656, 658]  # 659 is a real name
     assert list(hands) == [1114]  # 2000 seats a real player, so it stays
     assert kept == [(658, "anon_5879604460_9", 2000)]
+
+
+def test_a_real_player_named_like_a_placeholder_is_never_deleted() -> None:
+    """"anon_hunter" passes the LIKE pre-filter and is somebody's screen name.
+
+    Deleting them would take every hand they played with them, which is why the
+    generated form is matched in full rather than by its prefix.
+    """
+    placeholders, hands, _kept = survey(_db(_Cursor()))
+
+    assert 659 not in [p[0] for p in placeholders]
+    assert 2000 not in hands  # the hand they sit in is not offered either
 
 
 def test_a_hand_is_emptied_before_it_is_removed() -> None:

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -151,3 +151,75 @@ def test_every_table_named_matches_the_schema_casing() -> None:
 
     assert named, "no table names found; the extraction above stopped matching"
     assert named <= ddl, f"not in the schema with this casing: {sorted(named - ddl)}"
+
+
+def _schema_foreign_keys() -> list[tuple[str, str]]:
+    """(child, parent) for every foreign key the schema declares."""
+    import re
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parent.parent
+    keys: list[tuple[str, str]] = []
+    for schema in repo.glob("fpdb_3_legacy/sql_schema_*.py"):
+        text = schema.read_text(encoding="utf-8")
+        for table in re.finditer(r"CREATE TABLE (\w+)(.*?)(?=CREATE TABLE |\Z)", text, re.S):
+            for fk in re.finditer(r"FOREIGN KEY \(\w+\) REFERENCES (\w+)\(", table.group(2)):
+                keys.append((table.group(1), fk.group(1)))
+    return keys
+
+
+def test_nothing_is_deleted_before_what_points_at_it() -> None:
+    """No foreign key in this schema cascades, so order is the whole safety.
+
+    Checked against the DDL rather than against the list, because the list is
+    what gets it wrong: AofDecisionAnalyses points at AofDecisions and Backings
+    at TourneysPlayers, and both were deleted the wrong way round -- which
+    PostgreSQL only reveals when such a row actually exists, mid-transaction,
+    after the hands are already gone.
+
+    Each pass is checked on its own. The hand pass runs first and in full, so a
+    table it clears (PlayerAutoNotes) may legitimately be deleted again in the
+    player pass, for rows pointing at hands that are staying.
+    """
+    keys = _schema_foreign_keys()
+
+    for pass_name, statements in (("hand", DELETE_BY_HAND), ("player", DELETE_BY_PLAYER)):
+        order = [table for table, _sql in statements]
+        first = {table: min(i for i, t in enumerate(order) if t == table) for table in order}
+        last = {table: max(i for i, t in enumerate(order) if t == table) for table in order}
+        for child, parent in keys:
+            if parent not in first or child not in first:
+                continue
+            assert last[child] < first[parent], (
+                f"{pass_name} pass: {child} still references {parent} when {parent} is deleted"
+            )
+
+
+def test_the_foreign_keys_are_actually_read() -> None:
+    """A silent extraction failure would make the order test vacuous."""
+    keys = _schema_foreign_keys()
+
+    assert ("AofDecisionAnalyses", "AofDecisions") in keys
+    assert ("Backings", "TourneysPlayers") in keys
+
+
+def test_nothing_points_at_a_deleted_table_from_outside_the_script() -> None:
+    """Ordering is only half of it: a child table left out entirely still fails.
+
+    That is how AofDecisionAnalyses slipped through -- it references
+    AofDecisions, which the hand pass deletes, and it was in no pass at all, so
+    an order check had nothing to compare.
+
+    A child cleared by an earlier pass counts: the hand pass removes the rows of
+    the hands being deleted, and `delete()` refuses a player still seated in any
+    hand, so no row of theirs survives in a hand that stays.
+    """
+    passes = [[table for table, _sql in DELETE_BY_HAND], [table for table, _sql in DELETE_BY_PLAYER]]
+    keys = _schema_foreign_keys()
+
+    for index, tables in enumerate(passes):
+        cleared = {table for earlier in passes[: index + 1] for table in earlier}
+        for child, parent in keys:
+            if parent not in tables:
+                continue
+            assert child in cleared, f"{child} references {parent} but is never deleted"

--- a/test/test_cleanup_ipoker_anon_players.py
+++ b/test/test_cleanup_ipoker_anon_players.py
@@ -1,0 +1,115 @@
+"""Tests for the placeholder-player cleanup tool.
+
+The tool deletes hands and players, so the rule that decides what it may touch
+is the part worth pinning down: a placeholder that shares a hand with a real
+player must survive, and so must that hand.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools.cleanup_ipoker_anon_players import (
+    DELETE_BY_HAND,
+    DELETE_BY_PLAYER,
+    SELECT_HAND,
+    SELECT_HANDS_OF_PLAYER,
+    SELECT_PLACEHOLDERS,
+    SELECT_PLAYERS_OF_HAND,
+    SELECT_REMAINING_HANDS_OF_PLAYER,
+    delete,
+    survey,
+)
+
+PLACEHOLDERS = [
+    (655, "anon_5879604460_1", "Bwin.fr Poker"),
+    (656, "anon_5879604460_5", "Bwin.fr Poker"),
+    (658, "anon_5879604460_9", "Bwin.fr Poker"),
+]
+HANDS_OF_PLAYER = {655: [1114], 656: [1114], 658: [2000]}
+PLAYERS_OF_HAND = {
+    1114: [(655, "anon_5879604460_1"), (656, "anon_5879604460_5")],
+    2000: [(658, "anon_5879604460_9"), (700, "Requinbleu")],
+}
+HAND_ROWS = {
+    1114: (1114, "Sea Lake, 560237915", "2026-08-27 21:12:11"),
+    2000: (2000, "Scone, 560235983", "2026-08-27 21:30:00"),
+}
+
+
+class _Cursor:
+    """Answers the tool's queries from the dicts above and records writes."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple]] = []
+        self._result: list = []
+        self.rowcount = 1
+
+    def execute(self, statement: str, params: tuple = ()) -> None:
+        self.executed.append((statement, params))
+        if statement == SELECT_PLACEHOLDERS:
+            self._result = list(PLACEHOLDERS)
+        elif statement == SELECT_HANDS_OF_PLAYER:
+            self._result = [(hand,) for hand in HANDS_OF_PLAYER.get(params[0], [])]
+        elif statement == SELECT_PLAYERS_OF_HAND:
+            self._result = list(PLAYERS_OF_HAND.get(params[0], []))
+        elif statement == SELECT_HAND:
+            self._result = [HAND_ROWS[params[0]]]
+        elif statement == SELECT_REMAINING_HANDS_OF_PLAYER:
+            self._result = [(0,)]
+        else:
+            self._result = []
+
+    def fetchall(self) -> list:
+        return self._result
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+
+def _db(cursor: _Cursor) -> SimpleNamespace:
+    return SimpleNamespace(
+        sql=SimpleNamespace(query={"placeholder": "%s"}),
+        get_cursor=lambda: cursor,
+        connection=SimpleNamespace(commit=lambda: None, rollback=lambda: None),
+    )
+
+
+def test_only_hands_made_entirely_of_placeholders_are_offered() -> None:
+    placeholders, hands, kept = survey(_db(_Cursor()))
+
+    assert [p[0] for p in placeholders] == [655, 656, 658]
+    assert list(hands) == [1114]  # 2000 seats a real player, so it stays
+    assert kept == [(658, "anon_5879604460_9", 2000)]
+
+
+def test_a_hand_is_emptied_before_it_is_removed() -> None:
+    """Children first: deleting Hands before its rows would trip a foreign key."""
+    cursor = _Cursor()
+
+    delete(_db(cursor), [1114], [655], commit=False)
+
+    order = [statement for statement, _params in cursor.executed]
+    assert order.index("DELETE FROM HandsPlayers WHERE handId = %s") < order.index("DELETE FROM Hands WHERE id = %s")
+    assert order.index("DELETE FROM Hands WHERE id = %s") < order.index("DELETE FROM Players WHERE id = %s")
+
+
+def test_the_caches_a_placeholder_left_behind_are_removed_too() -> None:
+    """A HudCache row is what a statistic would otherwise still be read out of."""
+    cursor = _Cursor()
+
+    delete(_db(cursor), [], [655], commit=False)
+
+    executed = {statement for statement, _params in cursor.executed}
+    for _table, statement in DELETE_BY_PLAYER:
+        assert statement in executed
+
+
+def test_every_table_hanging_off_a_hand_is_cleared() -> None:
+    cursor = _Cursor()
+
+    delete(_db(cursor), [1114], [], commit=False)
+
+    executed = {statement for statement, _params in cursor.executed}
+    for _table, statement in DELETE_BY_HAND:
+        assert statement in executed

--- a/test/test_ipoker_anonymized_players.py
+++ b/test/test_ipoker_anonymized_players.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 
 from fpdb_3_legacy.Configuration import Config
+from fpdb_3_legacy.HandHistoryConverter import FpdbHandPartial
 from fpdb_3_legacy.iPoker.base import iPoker
 
 NICK = "jejesat76"
@@ -183,3 +184,34 @@ def test_ambiguous_seat_occupant_is_scoped_not_guessed(config: Config) -> None:
     hand = SimpleNamespace(handText=ANON_GAME, handid="9026868234")
     parser._deanonymize_players(hand)
     assert f'name="anon_{SESSION_CODE}_3"' in hand.handText
+
+
+def test_a_fully_anonymous_hand_is_not_stored(config: Config) -> None:
+    """Live import reaching an observed hand before the hero has played one.
+
+    Nothing names a seat yet, so storing the hand would create a Players row per
+    seat that no statistic is ever read back through -- the hero is not in the
+    hand, so it builds no HUD, and the real names the file reveals minutes later
+    never reach the rows already written. The hand is dropped instead; a later
+    full import of the file stores it under the real opponents.
+    """
+    only_anon = HEADER + ANON_GAME + "\n</session>"
+    parser = _parser(config, only_anon)
+    parser.info = {"type": "ring"}
+    hand = SimpleNamespace(handText=HEADER + ANON_GAME, handid="")
+
+    with pytest.raises(FpdbHandPartial):
+        parser.readHandInfo(hand)
+
+
+def test_a_hand_with_one_recovered_seat_is_still_stored(config: Config) -> None:
+    """Partial knowledge is real knowledge: only a nameless hand is dropped."""
+    parser = _parser(config, SESSION_FILE)  # holds a named hand
+    parser.info = {"type": "ring"}
+    parser.tablename = "Scone, 560235983"
+    hand = SimpleNamespace(handText=HEADER + ANON_GAME, handid="")
+
+    parser.readHandInfo(hand)  # must not raise
+
+    assert hand.handid == "9026868234"
+    assert 'name="CR7012"' in hand.handText

--- a/test/test_ipoker_anonymized_players.py
+++ b/test/test_ipoker_anonymized_players.py
@@ -215,3 +215,48 @@ def test_a_hand_with_one_recovered_seat_is_still_stored(config: Config) -> None:
 
     assert hand.handid == "9026868234"
     assert 'name="CR7012"' in hand.handText
+
+
+def test_a_real_opponent_named_like_a_placeholder_is_still_a_name(config: Config) -> None:
+    """"anon_hunter" is somebody's screen name, not a placeholder.
+
+    Reading it as one would count the seat as unrecovered and drop a hand the
+    seat map had in fact resolved.
+    """
+    named = NAMED_GAME.replace('name="CR7012"', 'name="anon_hunter"')
+    session = HEADER + ANON_GAME + "\n" + named + "\n</session>"
+    parser = _parser(config, session)
+    parser.info = {"type": "ring"}
+    hand = SimpleNamespace(handText=HEADER + ANON_GAME, handid="")
+
+    anonymous, recovered = parser._deanonymize_players(hand)
+
+    assert 'name="anon_hunter"' in hand.handText  # seat 3, recovered
+    assert (anonymous, recovered) == (5, 4)
+    assert parser._named_players(hand.handText) == ["anon_hunter", "Moula42", "TheDarkRaise", "confusius5"]
+
+
+def test_a_hand_recovered_only_under_such_a_name_is_kept(config: Config) -> None:
+    """The whole hand rests on that distinction: one real seat is enough.
+
+    Every seat here resolves to "anon_hunter", so a prefix test would count the
+    hand as nameless and drop it.
+    """
+    one_seat = """ <game gamecode="9026868299">
+  <general>
+   <startdate>2026-07-22 23:28:00</startdate>
+   <players>
+    <player seat="3" name="Player 3" chips="2,63€" dealer="1" win="0€" bet="0,04€"/>
+   </players>
+  </general>
+ </game>"""
+    named = NAMED_GAME.replace('name="CR7012"', 'name="anon_hunter"')
+    parser = _parser(config, HEADER + named + "\n</session>")
+    parser.info = {"type": "ring"}
+    parser.tablename = "Scone, 560235983"
+    hand = SimpleNamespace(handText=HEADER + one_seat, handid="")
+
+    parser.readHandInfo(hand)  # must not raise
+
+    assert hand.handid == "9026868299"
+    assert 'name="anon_hunter"' in hand.handText

--- a/test/test_ipoker_twister_table_identity.py
+++ b/test/test_ipoker_twister_table_identity.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Regression tests for the identity of an iPoker (Bwin.fr) tournament table.
+
+A Twister/Spins client reuses the SAME window for the next match of the series,
+so a HUD that cannot tell one match's table from another's ends up on the wrong
+one. Three defects combined to make that happen:
+
+1. Only the first hand of a session file carries the header <tablename> that
+   re_game_info needs, so every later hand -- all of live auto-import -- fell
+   back to the XML parser, which named the table after <tournamentname> and
+   dropped the ", <tableId>" suffix. The same table was then stored under two
+   names and the HUD, which keys on the trailing token, rebuilt itself from
+   scratch on the second hand of every tournament.
+2. The window search regex for a Twister was the bare "(?:Twister|Spins)", which
+   matches any Twister window, including the recycled one of the next match.
+3. getTableNoRe was the inherited "<tournament>.+Table (\\d+)", which no iPoker
+   title ever matches, so a window changing table was never detected.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fpdb_3_legacy.iPoker.xml_format import IPokerXMLFormatMixin
+from fpdb_3_legacy.iPokerToFpdb import iPoker
+
+# Trimmed to the tags the parsers read; two <game> blocks so the second one
+# exercises the header-less path that live auto-import always takes.
+TWISTER_SESSION = """<?xml version="1.0" encoding="UTF-8"?>
+<session sessioncode="5879605893">
+<general>
+<client_version>26.1.1.31</client_version>
+<mode>real</mode>
+<gametype>Holdem NL €0.05/€0.10</gametype>
+<tablename>Twister 0.25€, 1200531183</tablename>
+<duration>00:05:54</duration>
+<gamecount>2</gamecount>
+<startdate>2026-08-27 21:17:37</startdate>
+<currency>EUR</currency>
+<nickname>hero</nickname>
+<bets>0,25€</bets>
+<wins>0€</wins>
+<tournamentcode>1200531182</tournamentcode>
+<tournamentname>Twister 0.25€</tournamentname>
+<place>3</place>
+<buyin>0,24€+0,01€</buyin>
+<totalbuyin>0,25€</totalbuyin>
+<win>0€</win>
+<tablesize>3</tablesize>
+</general>
+<games>
+<game gamecode="9069037993">
+<general>
+<startdate>2026-08-27 21:17:37</startdate>
+<players>
+<player seat="1" name="villain_a" chips="500€" dealer="0" win="0€" bet="20€"/>
+<player seat="2" name="villain_b" chips="500€" dealer="1" win="40€" bet="10€"/>
+<player seat="3" name="hero" chips="500€" dealer="0" win="0€" bet="10€"/>
+</players>
+</general>
+</game>
+<game gamecode="9069038035">
+<general>
+<startdate>2026-08-27 21:17:48</startdate>
+<players>
+<player seat="1" name="villain_a" chips="480€" dealer="1" win="0€" bet="20€"/>
+<player seat="2" name="villain_b" chips="530€" dealer="0" win="40€" bet="10€"/>
+<player seat="3" name="hero" chips="490€" dealer="0" win="0€" bet="10€"/>
+</players>
+</game>
+</games>
+</session>
+"""
+
+# What the Bwin.fr client actually puts in the window title bar. The number is
+# the physical table id (tournament code + 1), and it is the only id present.
+TITLE_MATCH_1 = "Twister 0.25€ 1200531183 | NL Hold'em | Niveau 1 | 10/20     v.26.1.1.31"
+TITLE_MATCH_2 = "Twister 0.25€ 1200530962 | NL Hold'em     v.26.1.1.31"
+
+
+class _XMLParser(IPokerXMLFormatMixin):
+    """The XML fallback path on its own, with no Config and no file on disk."""
+
+    def __init__(self, whole_file: str) -> None:
+        self.whole_file = whole_file
+        self.info: dict = {}
+        self.tinfo: dict = {}
+        self.tablename = ""
+        self.hero = ""
+
+    def _filename_game_info_source(self) -> str:
+        return "Twister.xml"
+
+
+def _hand_chunks(session: str) -> list[str]:
+    """Split a session the way HandHistoryConverter feeds hands to the parser."""
+    return [chunk + "</game>" for chunk in session.split("</game>") if "<game " in chunk]
+
+
+def test_second_hand_keeps_the_table_id() -> None:
+    """Every hand of a file must name the table the same way.
+
+    The second hand carries no <tablename> of its own; taking it from the
+    session header is what keeps the HUD key stable across the whole match.
+    """
+    chunks = _hand_chunks(TWISTER_SESSION)
+    assert len(chunks) == 2
+    assert "<tablename>" not in chunks[1], "fixture no longer exercises the header-less path"
+
+    names = []
+    for chunk in chunks:
+        parser = _XMLParser(TWISTER_SESSION)
+        info = parser._parse_xml_format(chunk)
+        assert info["type"] == "tour"
+        names.append(info["table_name"])
+
+    assert names[0] == "Twister 0.25€, 1200531183"
+    assert names[1] == names[0]
+
+
+def test_table_name_falls_back_to_the_tournament_name() -> None:
+    """A session without <tablename> still has to produce a name."""
+    session = TWISTER_SESSION.replace("<tablename>Twister 0.25€, 1200531183</tablename>\n", "")
+    info = _XMLParser(session)._parse_xml_format(_hand_chunks(session)[1])
+    assert info["table_name"] == "Twister 0.25€"
+
+
+@pytest.mark.parametrize("title", [TITLE_MATCH_1, TITLE_MATCH_2])
+def test_twister_regex_only_matches_its_own_window(title: str) -> None:
+    """A Twister HUD must not attach to the next match's recycled window."""
+    import re
+
+    regex = iPoker.getTableTitleRe(
+        "tour",
+        tournament="1200531182",
+        table_number=1200531183,
+        tourney_name="Twister 0.25€",
+    )
+    assert (re.search(regex, title) is not None) == (title == TITLE_MATCH_1)
+
+
+@pytest.mark.parametrize(
+    "table_number",
+    [
+        1200531182,  # TableWindow's fallback: the tournament number itself
+        1,  # a seat-style index, which no Twister title contains
+        None,
+    ],
+)
+def test_twister_regex_stays_loose_without_a_table_id(table_number: int | None) -> None:
+    """Hand histories that never carried a table id keep the old behaviour.
+
+    Pinning the search to a number the title cannot contain would find no window
+    at all, which is worse than the loose match it replaces.
+    """
+    import re
+
+    regex = iPoker.getTableTitleRe(
+        "tour",
+        tournament="1200531182",
+        table_number=table_number,
+        tourney_name="Twister 0.25€",
+    )
+    assert re.search(regex, TITLE_MATCH_1)
+    assert re.search(regex, TITLE_MATCH_2)
+
+
+def test_table_no_regex_reads_the_id_from_the_title() -> None:
+    """get_table_no() must return the table id, not False, on an iPoker title."""
+    import re
+
+    regex = iPoker.getTableNoRe(tournament="1200531182")
+    assert int(re.search(regex, TITLE_MATCH_1).group(1)) == 1200531183
+    assert int(re.search(regex, TITLE_MATCH_2).group(1)) == 1200530962
+    # Blinds and levels are not table ids.
+    assert re.search(regex, "Twister 0.25€ | NL Hold'em | Niveau 1 | 10/20") is None

--- a/test/test_ipoker_twister_table_identity.py
+++ b/test/test_ipoker_twister_table_identity.py
@@ -179,3 +179,27 @@ def test_table_no_regex_reads_the_id_from_the_title() -> None:
     assert int(re.search(regex, TITLE_MATCH_2).group(1)) == 1200530962
     # Blinds and levels are not table ids.
     assert re.search(regex, "Twister 0.25€ | NL Hold'em | Niveau 1 | 10/20") is None
+
+
+def test_the_table_id_is_read_from_the_end_of_the_name() -> None:
+    """A table can be named after its tournament as well as its own id.
+
+    Reading the first long number would return the tournament, which never
+    matches the table the hand history names -- and has_table_title_changed()
+    would then call every hand a reseat and kill the HUD on each one.
+    """
+    import re
+
+    regex = iPoker.getTableNoRe(tournament="1193390834")
+    title = "1193390834 Twister 5867402179 | NL Hold'em | Niveau 3"
+
+    assert int(re.search(regex, title).group(1)) == 5867402179
+
+
+def test_a_title_without_a_table_id_reads_as_no_table() -> None:
+    """No number to anchor on must mean "no signal", never a wrong one."""
+    import re
+
+    regex = iPoker.getTableNoRe(tournament="1200531182")
+
+    assert re.search(regex, "Twister 0.25€ | NL Hold'em | Niveau 1 | 10/20") is None

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -210,7 +210,8 @@ def report(placeholders: list, hands: dict, kept: list) -> None:
             print(f"  player {player_id} ({name}) in hand {hand_id}")
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """The command line, built apart from main() so a test can exercise it."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--config", help="HUD_config.xml to read the database from (default: the configured one)")
     # Mutually exclusive: "--apply --rehearse" would otherwise commit, which is
@@ -222,7 +223,11 @@ def main() -> int:
         action="store_true",
         help="run the deletion against the real database and roll it back, reporting what it did",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
 
     config = Config(file=args.config) if args.config else Config()
     db = Database(config)

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -64,6 +64,10 @@ DELETE_BY_HAND = (
     ("HandsShowdown", "DELETE FROM HandsShowdown WHERE handId = %s"),
     ("HandsPots", "DELETE FROM HandsPots WHERE handId = %s"),
     ("HandsCashout", "DELETE FROM HandsCashout WHERE handId = %s"),
+    (
+        "AofDecisionAnalyses",
+        "DELETE FROM AofDecisionAnalyses WHERE decisionId IN (SELECT id FROM AofDecisions WHERE handId = %s)",
+    ),
     ("AofDecisions", "DELETE FROM AofDecisions WHERE handId = %s"),
     ("Boards", "DELETE FROM Boards WHERE handId = %s"),
     ("RawHands", "DELETE FROM RawHands WHERE handId = %s"),
@@ -73,16 +77,27 @@ DELETE_BY_HAND = (
 )
 
 # Everything keyed on a player, the caches included: a placeholder's HudCache
-# row is what a statistic would otherwise still be read out of.
+# row is what a statistic would otherwise still be read out of. Order matters
+# here too -- none of the schema's foreign keys cascade, so a table is emptied
+# before anything it points at (test_cleanup_ipoker_anon_players.py checks that
+# against the DDL rather than trusting this list to stay right).
 DELETE_BY_PLAYER = (
     ("HudCache", "DELETE FROM HudCache WHERE playerId = %s"),
     ("CardsCache", "DELETE FROM CardsCache WHERE playerId = %s"),
     ("PositionsCache", "DELETE FROM PositionsCache WHERE playerId = %s"),
     ("SessionsCache", "DELETE FROM SessionsCache WHERE playerId = %s"),
     ("TourneysCache", "DELETE FROM TourneysCache WHERE playerId = %s"),
+    # Both directions of Backings, and both before the entries they point at:
+    # somebody else backing the placeholder is a row the placeholder's own id
+    # does not match, and either one still referencing a TourneysPlayers row
+    # fails the deletion below.
+    (
+        "Backings",
+        "DELETE FROM Backings WHERE tourneysPlayersId IN (SELECT id FROM TourneysPlayers WHERE playerId = %s)",
+    ),
+    ("Backings", "DELETE FROM Backings WHERE playerId = %s"),
     ("TourneysPlayers", "DELETE FROM TourneysPlayers WHERE playerId = %s"),
     ("Autorates", "DELETE FROM Autorates WHERE playerId = %s"),
-    ("Backings", "DELETE FROM Backings WHERE playerId = %s"),
     ("PlayerAutoNotes", "DELETE FROM PlayerAutoNotes WHERE playerId = %s"),
     ("Players", "DELETE FROM Players WHERE id = %s"),
 )

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -25,6 +25,7 @@ named hands the seat map is learned from.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -34,9 +35,12 @@ sys.path.insert(0, str(REPO))
 from fpdb_3_legacy.Configuration import Config  # noqa: E402
 from fpdb_3_legacy.Database import Database  # noqa: E402
 
-# "!" escapes the underscore, which is a LIKE wildcard: without it "anon_x"
-# would also match "anonyx". ESCAPE is understood by PostgreSQL, MySQL and
-# SQLite alike.
+# What the importer generated, matched in full. "anon_hunter" is a screen name
+# somebody may well be sitting under, and this tool deletes players: a prefix
+# test would take a real one, and every hand they played, with it. The LIKE is
+# only a cheap pre-filter -- "!" escapes the underscore, which is a LIKE
+# wildcard, and ESCAPE is understood by PostgreSQL, MySQL and SQLite alike.
+PLACEHOLDER_RE = re.compile(r"^anon_\d+_\d+$")
 SELECT_PLACEHOLDERS = (
     "SELECT p.id, p.name, s.name FROM Players p "
     "JOIN Sites s ON s.id = p.siteId "
@@ -98,7 +102,7 @@ def survey(db) -> tuple[list, dict, list]:
     cursor = db.get_cursor()
 
     cursor.execute(SELECT_PLACEHOLDERS)
-    placeholders = [(int(row[0]), row[1], row[2]) for row in cursor.fetchall()]
+    placeholders = [(int(row[0]), row[1], row[2]) for row in cursor.fetchall() if PLACEHOLDER_RE.match(str(row[1]))]
 
     hands: dict[int, tuple] = {}
     kept: list[tuple[int, str, int]] = []
@@ -109,7 +113,7 @@ def survey(db) -> tuple[list, dict, list]:
                 continue
             cursor.execute(_sql(SELECT_PLAYERS_OF_HAND, ph), (hand_id,))
             seated = cursor.fetchall()
-            if any(not str(seat_name).startswith("anon_") for _pid, seat_name in seated):
+            if any(not PLACEHOLDER_RE.match(str(seat_name)) for _pid, seat_name in seated):
                 kept.append((player_id, name, int(hand_id)))
                 continue
             cursor.execute(_sql(SELECT_HAND, ph), (hand_id,))

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -55,14 +55,16 @@ SELECT_REMAINING_HANDS_OF_PLAYER = "SELECT COUNT(*) FROM HandsPlayers WHERE play
 
 # Everything hanging off a hand, children before parents. Written out one
 # statement per table rather than built from a table name, so what runs is
-# exactly what is read here.
+# exactly what is read here. Table names carry the schema's own casing
+# ("AofDecisions", "Autorates"): PostgreSQL folds them either way, MySQL with
+# case-sensitive table names does not, and a miss there fails mid-transaction.
 DELETE_BY_HAND = (
     ("HandsStove", "DELETE FROM HandsStove WHERE handId = %s"),
     ("HandsActions", "DELETE FROM HandsActions WHERE handId = %s"),
     ("HandsShowdown", "DELETE FROM HandsShowdown WHERE handId = %s"),
     ("HandsPots", "DELETE FROM HandsPots WHERE handId = %s"),
     ("HandsCashout", "DELETE FROM HandsCashout WHERE handId = %s"),
-    ("AoFDecisions", "DELETE FROM AoFDecisions WHERE handId = %s"),
+    ("AofDecisions", "DELETE FROM AofDecisions WHERE handId = %s"),
     ("Boards", "DELETE FROM Boards WHERE handId = %s"),
     ("RawHands", "DELETE FROM RawHands WHERE handId = %s"),
     ("PlayerAutoNotes", "DELETE FROM PlayerAutoNotes WHERE handId = %s"),
@@ -79,7 +81,7 @@ DELETE_BY_PLAYER = (
     ("SessionsCache", "DELETE FROM SessionsCache WHERE playerId = %s"),
     ("TourneysCache", "DELETE FROM TourneysCache WHERE playerId = %s"),
     ("TourneysPlayers", "DELETE FROM TourneysPlayers WHERE playerId = %s"),
-    ("AutoRates", "DELETE FROM AutoRates WHERE playerId = %s"),
+    ("Autorates", "DELETE FROM Autorates WHERE playerId = %s"),
     ("Backings", "DELETE FROM Backings WHERE playerId = %s"),
     ("PlayerAutoNotes", "DELETE FROM PlayerAutoNotes WHERE playerId = %s"),
     ("Players", "DELETE FROM Players WHERE id = %s"),

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -108,7 +108,18 @@ def _sql(statement: str, placeholder: str) -> str:
     return statement.replace("%s", placeholder)
 
 
-def survey(db) -> tuple[list, dict, list]:
+def ipoker_sites(config) -> set[str]:
+    """Site names whose hands the iPoker converter reads.
+
+    Only that converter ever wrote these placeholders, so only its sites are
+    candidates. A player on another site whose screen name happens to look like
+    one is somebody real -- and a site the config does not list at all is left
+    alone rather than guessed at.
+    """
+    return {name for name, hhc in config.hhcs.items() if hhc.converter == "iPokerToFpdb"}
+
+
+def survey(db, sites: set[str]) -> tuple[list, dict, list]:
     """Report the placeholders, the hands made only of them, and what is kept.
 
     Returns (placeholders, hands_by_id, kept), where `kept` holds the
@@ -119,7 +130,11 @@ def survey(db) -> tuple[list, dict, list]:
     cursor = db.get_cursor()
 
     cursor.execute(SELECT_PLACEHOLDERS)
-    placeholders = [(int(row[0]), row[1], row[2]) for row in cursor.fetchall() if PLACEHOLDER_RE.match(str(row[1]))]
+    placeholders = [
+        (int(row[0]), row[1], row[2])
+        for row in cursor.fetchall()
+        if PLACEHOLDER_RE.match(str(row[1])) and row[2] in sites
+    ]
 
     hands: dict[int, tuple] = {}
     kept: list[tuple[int, str, int]] = []
@@ -131,6 +146,8 @@ def survey(db) -> tuple[list, dict, list]:
             cursor.execute(_sql(SELECT_PLAYERS_OF_HAND, ph), (hand_id,))
             seated = cursor.fetchall()
             if any(not PLACEHOLDER_RE.match(str(seat_name)) for _pid, seat_name in seated):
+                # A real player at the table: the hand carries information, and
+                # deleting the placeholder would orphan it.
                 kept.append((player_id, name, int(hand_id)))
                 continue
             cursor.execute(_sql(SELECT_HAND, ph), (hand_id,))
@@ -177,26 +194,8 @@ def delete(db, hand_ids: list[int], player_ids: list[int], *, commit: bool = Tru
     return removed
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--config", help="HUD_config.xml to read the database from (default: the configured one)")
-    parser.add_argument("--apply", action="store_true", help="delete; without it nothing is written")
-    parser.add_argument(
-        "--rehearse",
-        action="store_true",
-        help="run the deletion against the real database and roll it back, reporting what it did",
-    )
-    args = parser.parse_args()
-
-    config = Config(file=args.config) if args.config else Config()
-    db = Database(config)
-    print(f"Database {db.database}@{db.host}\n")
-
-    placeholders, hands, kept = survey(db)
-    if not placeholders:
-        print("No placeholder players found; nothing to clean up.")
-        return 0
-
+def report(placeholders: list, hands: dict, kept: list) -> None:
+    """Print what was found, including what is deliberately being left alone."""
     print(f"{len(placeholders)} placeholder player(s):")
     for player_id, name, site in placeholders:
         print(f"  {player_id:>7}  {name}  ({site})")
@@ -209,6 +208,37 @@ def main() -> int:
         print("\nLeft alone, because the hand also seats a real player:")
         for player_id, name, hand_id in kept:
             print(f"  player {player_id} ({name}) in hand {hand_id}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", help="HUD_config.xml to read the database from (default: the configured one)")
+    # Mutually exclusive: "--apply --rehearse" would otherwise commit, which is
+    # the exact opposite of what the person typing --rehearse asked for.
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="delete; without it nothing is written")
+    mode.add_argument(
+        "--rehearse",
+        action="store_true",
+        help="run the deletion against the real database and roll it back, reporting what it did",
+    )
+    args = parser.parse_args()
+
+    config = Config(file=args.config) if args.config else Config()
+    db = Database(config)
+    print(f"Database {db.database}@{db.host}\n")
+
+    sites = ipoker_sites(config)
+    if not sites:
+        print("No iPoker site in this configuration; nothing this tool wrote can be here.")
+        return 0
+
+    placeholders, hands, kept = survey(db, sites)
+    if not placeholders:
+        print("No placeholder players found; nothing to clean up.")
+        return 0
+
+    report(placeholders, hands, kept)
 
     deletable = sorted({pid for pid, _n, _s in placeholders} - {pid for pid, _n, _h in kept})
     if not deletable:

--- a/tools/cleanup_ipoker_anon_players.py
+++ b/tools/cleanup_ipoker_anon_players.py
@@ -1,0 +1,211 @@
+"""Remove the placeholder players a live iPoker import used to invent.
+
+iPoker anonymises the hands the hero was not dealt into, and the seat -> name
+map that recovers their opponents is learned from the hands the hero did play.
+Live import reaching the first observed hand of a session had neither, so every
+seat fell back to "anon_<sessioncode>_<seat>" and those names were written to
+Players. The importer no longer does that -- such a hand is skipped and comes
+back with the real names on a later full import of the file -- but databases
+already carry the rows it wrote.
+
+This removes them: the hands in which every single player is a placeholder, the
+rows that hang off those hands, and then the placeholder players themselves. A
+placeholder still seated in a hand that is kept (which the importer never
+produced, but a hand-edited database might) is reported and left alone, along
+with its hands.
+
+    python tools/cleanup_ipoker_anon_players.py              # report only
+    python tools/cleanup_ipoker_anon_players.py --apply      # delete
+
+Re-import the hand history files afterwards. The hands removed here are stored
+again under their real opponents, because by now the session files hold the
+named hands the seat map is learned from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from fpdb_3_legacy.Configuration import Config  # noqa: E402
+from fpdb_3_legacy.Database import Database  # noqa: E402
+
+# "!" escapes the underscore, which is a LIKE wildcard: without it "anon_x"
+# would also match "anonyx". ESCAPE is understood by PostgreSQL, MySQL and
+# SQLite alike.
+SELECT_PLACEHOLDERS = (
+    "SELECT p.id, p.name, s.name FROM Players p "
+    "JOIN Sites s ON s.id = p.siteId "
+    "WHERE p.name LIKE 'anon!_%' ESCAPE '!' ORDER BY p.id"
+)
+SELECT_HANDS_OF_PLAYER = "SELECT DISTINCT handId FROM HandsPlayers WHERE playerId = %s"
+SELECT_PLAYERS_OF_HAND = (
+    "SELECT p.id, p.name FROM HandsPlayers hp JOIN Players p ON p.id = hp.playerId WHERE hp.handId = %s"
+)
+SELECT_HAND = "SELECT id, tableName, startTime FROM Hands WHERE id = %s"
+SELECT_REMAINING_HANDS_OF_PLAYER = "SELECT COUNT(*) FROM HandsPlayers WHERE playerId = %s"
+
+# Everything hanging off a hand, children before parents. Written out one
+# statement per table rather than built from a table name, so what runs is
+# exactly what is read here.
+DELETE_BY_HAND = (
+    ("HandsStove", "DELETE FROM HandsStove WHERE handId = %s"),
+    ("HandsActions", "DELETE FROM HandsActions WHERE handId = %s"),
+    ("HandsShowdown", "DELETE FROM HandsShowdown WHERE handId = %s"),
+    ("HandsPots", "DELETE FROM HandsPots WHERE handId = %s"),
+    ("HandsCashout", "DELETE FROM HandsCashout WHERE handId = %s"),
+    ("AoFDecisions", "DELETE FROM AoFDecisions WHERE handId = %s"),
+    ("Boards", "DELETE FROM Boards WHERE handId = %s"),
+    ("RawHands", "DELETE FROM RawHands WHERE handId = %s"),
+    ("PlayerAutoNotes", "DELETE FROM PlayerAutoNotes WHERE handId = %s"),
+    ("HandsPlayers", "DELETE FROM HandsPlayers WHERE handId = %s"),
+    ("Hands", "DELETE FROM Hands WHERE id = %s"),
+)
+
+# Everything keyed on a player, the caches included: a placeholder's HudCache
+# row is what a statistic would otherwise still be read out of.
+DELETE_BY_PLAYER = (
+    ("HudCache", "DELETE FROM HudCache WHERE playerId = %s"),
+    ("CardsCache", "DELETE FROM CardsCache WHERE playerId = %s"),
+    ("PositionsCache", "DELETE FROM PositionsCache WHERE playerId = %s"),
+    ("SessionsCache", "DELETE FROM SessionsCache WHERE playerId = %s"),
+    ("TourneysCache", "DELETE FROM TourneysCache WHERE playerId = %s"),
+    ("TourneysPlayers", "DELETE FROM TourneysPlayers WHERE playerId = %s"),
+    ("AutoRates", "DELETE FROM AutoRates WHERE playerId = %s"),
+    ("Backings", "DELETE FROM Backings WHERE playerId = %s"),
+    ("PlayerAutoNotes", "DELETE FROM PlayerAutoNotes WHERE playerId = %s"),
+    ("Players", "DELETE FROM Players WHERE id = %s"),
+)
+
+
+def _sql(statement: str, placeholder: str) -> str:
+    """Adapt a statement to the backend's parameter marker ("%s" or "?")."""
+    return statement.replace("%s", placeholder)
+
+
+def survey(db) -> tuple[list, dict, list]:
+    """Report the placeholders, the hands made only of them, and what is kept.
+
+    Returns (placeholders, hands_by_id, kept), where `kept` holds the
+    placeholders that share a hand with a real player: deleting those would take
+    a hand with real information down with them, so they are left in place.
+    """
+    ph = db.sql.query["placeholder"]
+    cursor = db.get_cursor()
+
+    cursor.execute(SELECT_PLACEHOLDERS)
+    placeholders = [(int(row[0]), row[1], row[2]) for row in cursor.fetchall()]
+
+    hands: dict[int, tuple] = {}
+    kept: list[tuple[int, str, int]] = []
+    for player_id, name, _site in placeholders:
+        cursor.execute(_sql(SELECT_HANDS_OF_PLAYER, ph), (player_id,))
+        for (hand_id,) in cursor.fetchall():
+            if hand_id in hands:
+                continue
+            cursor.execute(_sql(SELECT_PLAYERS_OF_HAND, ph), (hand_id,))
+            seated = cursor.fetchall()
+            if any(not str(seat_name).startswith("anon_") for _pid, seat_name in seated):
+                kept.append((player_id, name, int(hand_id)))
+                continue
+            cursor.execute(_sql(SELECT_HAND, ph), (hand_id,))
+            hands[int(hand_id)] = cursor.fetchone()
+
+    return placeholders, hands, kept
+
+
+def delete(db, hand_ids: list[int], player_ids: list[int], *, commit: bool = True) -> dict[str, int]:
+    """Delete the hands and then the players, in one transaction.
+
+    ``commit=False`` runs the whole thing and rolls it back, which is the only
+    way to find out what the real database says -- a foreign key nobody thought
+    of, a table this schema does not have -- without writing to it.
+    """
+    ph = db.sql.query["placeholder"]
+    cursor = db.get_cursor()
+    removed: dict[str, int] = {}
+
+    for hand_id in hand_ids:
+        for table, statement in DELETE_BY_HAND:
+            cursor.execute(_sql(statement, ph), (hand_id,))
+            if cursor.rowcount and cursor.rowcount > 0:
+                removed[table] = removed.get(table, 0) + cursor.rowcount
+
+    for player_id in player_ids:
+        cursor.execute(_sql(SELECT_REMAINING_HANDS_OF_PLAYER, ph), (player_id,))
+        (remaining,) = cursor.fetchone()
+        if remaining:
+            # Should not happen: survey() only offers players whose every hand
+            # is being removed. Refuse rather than orphan a hand.
+            db.connection.rollback()
+            msg = f"player {player_id} is still seated in {remaining} hand(s); nothing was deleted"
+            raise SystemExit(msg)
+        for table, statement in DELETE_BY_PLAYER:
+            cursor.execute(_sql(statement, ph), (player_id,))
+            if cursor.rowcount and cursor.rowcount > 0:
+                removed[table] = removed.get(table, 0) + cursor.rowcount
+
+    if commit:
+        db.connection.commit()
+    else:
+        db.connection.rollback()
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", help="HUD_config.xml to read the database from (default: the configured one)")
+    parser.add_argument("--apply", action="store_true", help="delete; without it nothing is written")
+    parser.add_argument(
+        "--rehearse",
+        action="store_true",
+        help="run the deletion against the real database and roll it back, reporting what it did",
+    )
+    args = parser.parse_args()
+
+    config = Config(file=args.config) if args.config else Config()
+    db = Database(config)
+    print(f"Database {db.database}@{db.host}\n")
+
+    placeholders, hands, kept = survey(db)
+    if not placeholders:
+        print("No placeholder players found; nothing to clean up.")
+        return 0
+
+    print(f"{len(placeholders)} placeholder player(s):")
+    for player_id, name, site in placeholders:
+        print(f"  {player_id:>7}  {name}  ({site})")
+
+    print(f"\n{len(hands)} hand(s) whose every player is a placeholder:")
+    for hand_id, row in sorted(hands.items()):
+        print(f"  {hand_id:>7}  {row[1]}  {row[2]}")
+
+    if kept:
+        print("\nLeft alone, because the hand also seats a real player:")
+        for player_id, name, hand_id in kept:
+            print(f"  player {player_id} ({name}) in hand {hand_id}")
+
+    deletable = sorted({pid for pid, _n, _s in placeholders} - {pid for pid, _n, _h in kept})
+    if not deletable:
+        print("\nNothing can be removed without taking a real hand with it.")
+        return 0
+
+    if not (args.apply or args.rehearse):
+        print(f"\nDry run. {len(deletable)} player(s) and {len(hands)} hand(s) would be removed. Re-run with --apply.")
+        return 0
+
+    removed = delete(db, sorted(hands), deletable, commit=args.apply)
+    print("\nRemoved:" if args.apply else "\nWould remove (rolled back):")
+    for table, count in sorted(removed.items()):
+        print(f"  {count:>5}  {table}")
+    if args.apply:
+        print("\nRe-import the hand history files: those hands come back under their real opponents.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The report

On Bwin.fr (iPoker), the first hand of a Twister goes all in, the match ends, the client offers the next one of the series — and the HUD of the tournament that just finished appears on the new table, showing the previous opponents, until a hand of the new match is imported half a minute later.

Reconstructed from the session files and the `Hands` rows behind the reported log:

| | Twister #1 | Twister #2 |
|---|---|---|
| `tournamentcode` | 1200530961 | 1200531182 |
| `tablename` | Twister 0.25€, **1200530962** | Twister 0.25€, **1200531183** |
| start | 21:16:47 | 21:17:37 |
| duration / hands | 00:00:26 / 1 (the all-in) | 05:54 / 18 |
| file written | 21:17:15 | 21:17:37 → 21:23:33 |

The client reuses the same window (hwnd 19310, geometry unchanged) for the next match. At 21:17:24 fpdb imported the finished tournament's hand, found no window for table `1200530962`, fell back to the loose Twister search and attached to the recycled window; HUD generation 4 was built with `patpol84` and `frbutdepavard`, who were done playing. Generation 5 superseded it at 21:17:52, when a hand of the new match finally arrived.

## Three defects, each of which had to hold

**Only the first hand of a file carries the header `<tablename>`.** `re_game_info` requires that header, so every later hand — all of live auto-import — fell through to the XML parser, which named the table after `<tournamentname>` and dropped the `, <tableId>` suffix. The same table was stored under two names and keyed twice by the HUD, which reads the trailing token: `1200531182 Table 1200531183` for the first hand of a match, `1200531182 Table 0.25€` for all the rest. The log shows generations 6, 7 and 8 on one table in 20 seconds, each a HUD demolished and rebuilt with its statistics reset.

**The Twister window regex was the bare `(?:Twister|Spins)`**, matching any Twister window — the recycled one, and in multi-tabling every other one. The title does carry the table id (`Twister 0.25€ 1200531183 | NL Hold'em | Niveau 1 | 10/20`), so the regex is pinned to it when it is known and stays loose when it is not.

**Nothing noticed a window changing table on its own:** `check_table()` watches geometry only, and `getTableNoRe` was the inherited `<tournament>.+Table (\d+)`, which no iPoker title can match. The converter now supplies a pattern that reads the id out of the title, and the 800 ms poll drops a tournament HUD whose window has moved on. The number the title showed when the HUD attached is the baseline, so a site whose title has no table id never signals here rather than being killed on a mismatch it cannot control.

## Two things the same log surfaced

**`[ERROR] table name … not found` on a table that has closed.** A hand reaches the HUD 15 to 30 seconds after it was played, so the last hands of a just-closed table routinely arrive with no window left — one closed table logged three errors in the same second. That case now reports at info (the window was found before, the table has since closed), a repeat drops to debug, and the case that is a real failure — a table open on screen that never gets a HUD — still logs an error, once, naming the search string it failed on.

**Placeholder players invented by live import.** iPoker anonymises the hands the hero was not dealt into, and the seat → name map that recovers their opponents is learned from the hands the hero did play. Live import reaching the first observed hand of a session has neither, so every seat fell back to `anon_<session>_<seat>`. Those rows are pure loss: the hero is not in the hand, so it builds no HUD, the statistics accumulate under a name no lookup will ever ask for, and the real names the file reveals two minutes later never reach the rows already written. Such a hand is now dropped as partial; a later full import of the file stores it under the real opponents. A hand with even one recovered seat is stored as before.

`tools/cleanup_ipoker_anon_players.py` removes the rows already written: the hands in which every player is a placeholder, what hangs off them (HudCache included), then the players. A placeholder sharing a hand with a real player is reported and left alone. Default reports, `--rehearse` runs the deletion and rolls it back, `--apply` commits.

## Verification

Against the reporter's own files and database:

- `5879605893.xml`: all 18 hands now yield `1200531182 Twister 0.25€, 1200531183`, where hands 2 to 18 gave `1200531182 Twister 0.25€` before — exactly the split visible in `Hands` rows 1122 to 1125.
- `5879604460.xml`: at live-import time the fully anonymous hand `9069041425` is skipped; from the complete file it imports as `Requinbleu`, `cecuabinglobal`, `rainbowladder19`.
- Cleanup applied to the reporting database after a `pg_dump`: 1 hand, 3 HandsPlayers, 10 HandsActions, 7 HandsStove, 3 HudCache, 3 Players removed; re-importing the file brought the hand back (id 1149) under the three real opponents, and no placeholder remains.
- Full suite: 8227 passed, 16 skipped; 720 passed under `-m qt`. Ruff clean.

Not verified here: a live Twister series end to end, which needs real play. The line to watch is `HUD dropped: window … left table …` when the next match takes the window, and the absence of a new `HUD created … generation=N+1` on every hand.
