### PR TITLE
fix(windows): unfreeze HUD teardown, gate the SwC tap, and find Winamax where the client writes

### DIFF
--- a/fpdb_3_legacy/Aux_Base.py
+++ b/fpdb_3_legacy/Aux_Base.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import contextlib
 import math
+import time
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QApplication, QWidget
 
 if TYPE_CHECKING:
@@ -47,17 +49,59 @@ _RING_FIT_TIE = 1.05
 # suspend its 800ms geometry scan + window re-raise (topify), which on macOS
 # re-orders the dragged window mid-drag and makes the drag stutter.
 _drag_active = False
+_drag_started_at = 0.0
+
+#: How long a drag is believed without any other sign of life. Long enough that
+#: no real drag is cut short, short enough that a closed table's blocks go away
+#: while the user is still looking at where they were.
+DRAG_ACTIVE_TIMEOUT_S = 5.0
+
+
+def _a_mouse_button_is_down() -> bool:
+    """Whether the platform still reports a held mouse button.
+
+    True when it cannot be asked -- no QGuiApplication yet, or a stubbed Qt in a
+    test. The timeout is then the only bound, which is the right way to be
+    wrong: cancelling a drag that is really in progress is worse.
+    """
+    try:
+        return bool(QGuiApplication.mouseButtons())
+    except (AttributeError, RuntimeError, TypeError):
+        return True
 
 
 def is_drag_active() -> bool:
-    """Whether a HUD window is currently being dragged."""
-    return _drag_active
+    """Whether a HUD window is currently being dragged.
+
+    The flag is cleared by SeatWindow's mouse release, and that release is not
+    guaranteed to arrive. ``startSystemMove()`` hands the drag to the window
+    manager, which runs its own modal loop and does not deliver the release to
+    the widget; the widget can also be destroyed mid-drag, when the table it
+    belongs to is the one being closed.
+
+    The flag then stayed True for the rest of the process's life -- and since
+    ``HUD_main.check_tables`` polls it *before* looking at any table, one such
+    drag meant no HUD was ever taken down again. Closing a table, or quitting
+    the client, left its blocks on screen until FPDB was restarted.
+
+    So a set flag is now believed only while it is plausible: a mouse button
+    still down, and not older than :data:`DRAG_ACTIVE_TIMEOUT_S`. Being wrong
+    here costs one stuttering drag; being wrong the other way cost every HUD.
+    """
+    if not _drag_active:
+        return False
+    if time.monotonic() - _drag_started_at > DRAG_ACTIVE_TIMEOUT_S or not _a_mouse_button_is_down():
+        _drag_trace("drag-flag cleared: no release was delivered")
+        set_drag_active(False)
+        return False
+    return True
 
 
 def set_drag_active(active: bool) -> None:
     """Mark drag start/stop (set from SeatWindow press/release)."""
-    global _drag_active
+    global _drag_active, _drag_started_at
     _drag_active = active
+    _drag_started_at = time.monotonic() if active else 0.0
 
 
 def _nearest_screen(app: Any, x: int, y: int) -> Any:

--- a/fpdb_3_legacy/DetectInstalledSites.py
+++ b/fpdb_3_legacy/DetectInstalledSites.py
@@ -256,6 +256,14 @@ class WinamaxDetector(SiteDetector):
         if self.platform == "Windows":
             paths = get_windows_paths()
             base_path = self._check_path_exists(
+                # The current client keeps its accounts under a "documents"
+                # folder, exactly as it does on macOS and Linux. Only the two
+                # older layouts were probed here, so a Windows player of the
+                # current client was told Winamax was not installed and had to
+                # type the path in by hand -- and, one level being easy to miss,
+                # sometimes typed the parent of the history folder.
+                str(Path(paths["appdata"]) / "Winamax" / "documents" / "accounts"),
+                str(Path(paths["local_appdata"]) / "Winamax" / "documents" / "accounts"),
                 str(Path(paths["appdata"]) / "Winamax" / "accounts"),
                 str(Path(paths["local_appdata"]) / "Winamax" / "accounts"),
             )

--- a/fpdb_3_legacy/DetectInstalledSites.py
+++ b/fpdb_3_legacy/DetectInstalledSites.py
@@ -251,14 +251,34 @@ class WinamaxDetector(SiteDetector):
 
     def detect(self) -> dict[str, Any]:
         """Detect Winamax installation."""
-        base_path = None
+        for base_path in self._account_roots():
+            found = self._first_account_with_history(base_path)
+            if found is not None:
+                account, history_path = found
+                return {
+                    "detected": True,
+                    "hhpath": history_path,
+                    "heroname": account,
+                    "tspath": "",  # Winamax doesn't separate tournament summaries
+                }
 
+        return {"detected": False, "hhpath": "", "heroname": "", "tspath": ""}
+
+    def _account_roots(self) -> list[str]:
+        """Every place this platform's client may keep its accounts, best first.
+
+        All of them are tried, and the search stops at the first that holds an
+        actual history -- not at the first that merely exists. The client
+        creates its tree as soon as it runs, so a root can be there and empty
+        while the hands sit in another one; stopping at it would hide them, and
+        report a client that is plainly installed as not detected.
+        """
         if self.platform == "Windows":
             paths = get_windows_paths()
-            base_path = self._check_path_exists(
+            return [
                 # The current client keeps its accounts under a "documents"
                 # folder, exactly as it does on macOS and Linux. Only the two
-                # older layouts were probed here, so a Windows player of the
+                # older layouts used to be probed, so a Windows player of the
                 # current client was told Winamax was not installed and had to
                 # type the path in by hand -- and, one level being easy to miss,
                 # sometimes typed the parent of the history folder.
@@ -266,47 +286,45 @@ class WinamaxDetector(SiteDetector):
                 str(Path(paths["local_appdata"]) / "Winamax" / "documents" / "accounts"),
                 str(Path(paths["appdata"]) / "Winamax" / "accounts"),
                 str(Path(paths["local_appdata"]) / "Winamax" / "accounts"),
-            )
+            ]
 
-        elif self.platform == "Linux":
-            # Check for native Linux Winamax app first
-            native_path = str(Path.home() / ".config" / "winamax" / "documents" / "accounts")
-            if Path(native_path).exists():
-                base_path = native_path
-            else:
-                # Fallback to Wine installation
-                paths = get_linux_paths()
-                wine_users_path = Path(paths["wine_users"])
-                wine_paths = [str(path) for path in wine_users_path.glob("*/AppData/Roaming/Winamax/accounts")]
-                if wine_paths:
-                    base_path = wine_paths[0]
+        if self.platform == "Linux":
+            # The native app first, then every Wine prefix.
+            paths = get_linux_paths()
+            wine_users_path = Path(paths["wine_users"])
+            return [
+                str(Path.home() / ".config" / "winamax" / "documents" / "accounts"),
+                *(str(path) for path in wine_users_path.glob("*/AppData/Roaming/Winamax/accounts")),
+            ]
 
-        elif self.platform == "Darwin":  # macOS
+        if self.platform == "Darwin":  # macOS
             paths = get_mac_paths()
-            base_path = self._check_path_exists(
+            return [
                 str(Path(paths["app_support"]) / "Winamax" / "documents" / "accounts"),
                 str(Path(paths["app_support"]) / "Winamax" / "accounts"),
-            )
+            ]
 
-        if base_path and Path(base_path).exists():
-            try:
-                # Look for account folders
-                accounts = os.listdir(base_path)
-                for account in accounts:
-                    account_path = str(Path(base_path) / account)
-                    if Path(account_path).is_dir():
-                        history_path = str(Path(account_path) / "history")
-                        if Path(history_path).exists():
-                            return {
-                                "detected": True,
-                                "hhpath": history_path,
-                                "heroname": account,
-                                "tspath": "",  # Winamax doesn't separate tournament summaries
-                            }
-            except (OSError, PermissionError):
-                log.exception("Error detecting Winamax")
+        return []
 
-        return {"detected": False, "hhpath": "", "heroname": "", "tspath": ""}
+    @staticmethod
+    def _first_account_with_history(base_path: str) -> tuple[str, str] | None:
+        """The first account under ``base_path`` with a history folder, if any."""
+        try:
+            accounts = os.listdir(base_path)
+        except (FileNotFoundError, NotADirectoryError):
+            # Ordinary, now that every candidate root is tried: most of them do
+            # not exist on any one machine. Only a real access failure below is
+            # worth a trace.
+            return None
+        except OSError:
+            log.exception("Error detecting Winamax under %s", base_path)
+            return None
+
+        for account in accounts:
+            history_path = Path(base_path) / account / "history"
+            if history_path.exists():
+                return account, str(history_path)
+        return None
 
 
 # Skins whose Windows data directory is not named after the skin itself.

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -79,6 +79,10 @@ DEFERRED_CYCLES_BEFORE_WARNING = 6
 # enough for an ordinary cycle to land, short enough not to read as a freeze.
 STOP_WAIT_MS = 5000
 
+# The one room with no hand history files, and so the only one the native
+# capture has anything to do for.
+SWC_SITE_NAME = "SealsWithClubs"
+
 
 def to_raw(string) -> str:
     return rf"{string}"
@@ -544,8 +548,34 @@ class GuiAutoImport(QWidget):
         self.intervalEntry.setEnabled(True)
         self.startButton.setEnabled(True)
 
+    def _swc_capture_wanted(self) -> bool:
+        """Whether this configuration has any use for the SwC native capture.
+
+        The capture exists because SwC ships no hand history files; every other
+        room writes them, so for a player of one of those there is nothing here
+        to start. That matters because building the tap shells out to a C
+        compiler, which a Windows machine almost never has, and the failure was
+        reported to every user on every Start:
+
+            SwC Native Capture warning: [WinError 2] Le fichier specifie est introuvable
+
+        -- a SealsWithClubs message sending Winamax players to look for a
+        Winamax bug. Nothing is attempted for a site that is not configured.
+        """
+        try:
+            params = self.config.get_site_parameters(SWC_SITE_NAME)
+        except KeyError:
+            log.debug("SwC native capture skipped: %s is not in the configuration", SWC_SITE_NAME)
+            return False
+        if not params.get("enabled", False):
+            log.debug("SwC native capture skipped: %s is not enabled", SWC_SITE_NAME)
+            return False
+        return True
+
     def start_swc_native_capture(self) -> None:
         """Launch SwC native TLS capture and start live raw tailing thread."""
+        if not self._swc_capture_wanted():
+            return
         try:
             from fpdb_3_legacy.swc_native_capture import DEFAULT_ARCHIVE, build_tap
 
@@ -557,7 +587,12 @@ class GuiAutoImport(QWidget):
                 self.addText(_("\nSwC Native Live HUD tailing thread started."), "poker")
         except Exception as e:
             log.warning("Could not start SwC native capture: %s", e)
-            self.addText(f"\nSwC Native Capture warning: {e}", "warning")
+            self.addText(
+                _("\nSwC live capture unavailable: {reason}. Importing SwC hand history files still works.").format(
+                    reason=e,
+                ),
+                "warning",
+            )
 
     def _on_swc_native_hand_imported(self, hand_data: dict) -> None:
         """Callback when a new live SwC hand is parsed from swc-native.raw."""

--- a/fpdb_3_legacy/GuiAutoImport.py
+++ b/fpdb_3_legacy/GuiAutoImport.py
@@ -577,7 +577,23 @@ class GuiAutoImport(QWidget):
         if not self._swc_capture_wanted():
             return
         try:
-            from fpdb_3_legacy.swc_native_capture import DEFAULT_ARCHIVE, build_tap
+            from fpdb_3_legacy.swc_native_capture import (
+                DEFAULT_ARCHIVE,
+                build_tap,
+                native_capture_supported,
+            )
+
+            if not native_capture_supported():
+                # The tap is loaded into the client by library interposition,
+                # which Windows has no equivalent of. Building it there was the
+                # compiler failure users kept reporting -- for a library nothing
+                # on the platform could have loaded even if it had built.
+                log.info("SwC live capture needs library interposition, which this platform does not have.")
+                self.addText(
+                    _("\nSwC live capture is not available on this platform. Importing SwC files still works."),
+                    "info",
+                )
+                return
 
             build_tap(check_executable=False)
             if self.swc_tailing_thread is None or not self.swc_tailing_thread.isRunning():

--- a/fpdb_3_legacy/Importer.py
+++ b/fpdb_3_legacy/Importer.py
@@ -678,7 +678,16 @@ class Importer:
                         continue
                     if not self._is_valid_import_file(filename) or self.failed_files.failed(filename):
                         continue
-                    if (time() - os.stat(filename).st_mtime) <= 43200:  # look all files modded in the last 12 hours
+                    try:
+                        modified_at = os.stat(filename).st_mtime
+                    except OSError as e:
+                        # os.walk listed the name; the client can still rotate or
+                        # delete it before we get to stat it. Raising here aborted
+                        # the whole cycle -- every other tracked file included --
+                        # over one file that is simply no longer there.
+                        log.debug("Skipping %s: %s", filename, e)
+                        continue
+                    if (time() - modified_at) <= 43200:  # look all files modded in the last 12 hours
                         # need long time because FTP in Win does not
                         # update the timestamp on the HH during session
                         self.addImportFile(filename, "auto")
@@ -1473,7 +1482,18 @@ class Importer:
 
             if fpdbfile.ftype == "both":
                 both_files_count += 1
-                stat_info = os.stat(f)
+                try:
+                    stat_info = os.stat(f)
+                except OSError as e:
+                    # A tracked file can be deleted between two cycles. Raising
+                    # here aborted the cycle before runUpdated() -- the only
+                    # thing that purges a vanished file from filelist -- could
+                    # run, so the next cycle stat'd the same missing file and
+                    # failed the same way. Auto-import then imported nothing at
+                    # all, every interval, until it was restarted. Skipping
+                    # leaves the entry for runUpdated() to drop, this cycle.
+                    log.debug("Skipping summary for %s: %s", f, e)
+                    continue
                 file_age = time() - stat_info.st_mtime
                 log.debug(f"File {f} marked as 'both', age: {file_age:.1f}s, force: {force}")
 

--- a/fpdb_3_legacy/swc_native_capture.py
+++ b/fpdb_3_legacy/swc_native_capture.py
@@ -41,6 +41,23 @@ from fpdb_3_legacy.swc_tap_build import (  # noqa: E402
     get_tap_library_path,
 )
 
+#: The platforms the live capture can actually run on. The tap is loaded into
+#: the client by library interposition -- DYLD_INSERT_LIBRARIES on macOS,
+#: LD_PRELOAD on Linux, see ``native_client_environment`` -- and Windows has no
+#: equivalent, so a tap built there is a library nothing can load. The C source
+#: does carry a Windows branch (GetModuleHandleA over the bundled OpenSSL DLLs)
+#: and CI compiles it on a Windows runner, but no injection path uses it yet:
+#: ``SWC_EXECUTABLE`` is a macOS bundle path and ``running_client_pids`` shells
+#: out to pgrep. Until one exists, building on Windows only produces a compiler
+#: error for a library that would go unused.
+INTERPOSABLE_SYSTEMS = frozenset({"Darwin", "Linux"})
+
+
+def native_capture_supported(system_name: str | None = None) -> bool:
+    """Whether the live native capture can be started on this platform."""
+    return (system_name or platform.system()) in INTERPOSABLE_SYSTEMS
+
+
 TAP_LIBRARY = get_tap_library_path()
 DEFAULT_ARCHIVE = BUILD_DIR / "swc-native.raw"
 DEFAULT_STATUS = BUILD_DIR / "swc-native.status"

--- a/fpdb_3_legacy/swc_tap_build.py
+++ b/fpdb_3_legacy/swc_tap_build.py
@@ -34,10 +34,50 @@ def get_tap_library_path() -> Path:
     return BUILD_DIR / "libswc_native_tap.so"
 
 
+#: The compilers tried for each platform, in order of preference.
+COMPILERS: dict[str, tuple[str, ...]] = {
+    "Darwin": ("clang",),
+    "Windows": ("x86_64-w64-mingw32-gcc", "gcc"),
+    "Linux": ("clang", "gcc"),
+}
+
+#: What to tell someone who has none of them.
+INSTALL_HINTS: dict[str, str] = {
+    "Darwin": "Install the Xcode command line tools: xcode-select --install",
+    "Windows": "Install MSYS2 or another MinGW-w64 distribution and put gcc on PATH.",
+    "Linux": "Install clang or gcc with your package manager.",
+}
+
+
+def resolve_compiler(system_name: str) -> str:
+    """The compiler to build the tap with, or a message saying what is missing.
+
+    subprocess used to be handed a compiler name that had never been checked,
+    so a machine without one failed with the operating system's own words for
+    "that program does not exist":
+
+        SwC Native Capture warning: [WinError 2] Le fichier specifie est introuvable
+
+    Which names no compiler, no file, and nothing to do about it -- it was read
+    as an FPDB bug for months. Windows is where it always bit, because a Windows
+    machine essentially never has gcc, but a Linux box without a toolchain got
+    exactly the same non-answer.
+    """
+    candidates = COMPILERS.get(system_name, ())
+    for name in candidates:
+        if shutil.which(name):
+            return name
+    msg = (
+        f"no C compiler found to build the SwC tap: looked for {', '.join(candidates)}. "
+        f"{INSTALL_HINTS.get(system_name, 'Install one and try again.')}"
+    )
+    raise FileNotFoundError(msg)
+
+
 def _compile_command(system_name: str, tap_lib: Path) -> list[str]:
     if system_name == "Darwin":
         return [
-            "clang",
+            resolve_compiler(system_name),
             "-arch",
             "x86_64",
             "-dynamiclib",
@@ -50,10 +90,9 @@ def _compile_command(system_name: str, tap_lib: Path) -> list[str]:
             str(tap_lib),
             str(SOURCE_PATH),
         ]
+    compiler = resolve_compiler(system_name)
     if system_name == "Windows":
-        compiler = "x86_64-w64-mingw32-gcc" if shutil.which("x86_64-w64-mingw32-gcc") else "gcc"
         return [compiler, "-shared", "-O2", "-Wall", "-Wextra", "-o", str(tap_lib), str(SOURCE_PATH), "-lws2_32"]
-    compiler = "clang" if shutil.which("clang") else "gcc"
     return [compiler, "-shared", "-fPIC", "-O2", "-Wall", "-Wextra", "-o", str(tap_lib), str(SOURCE_PATH), "-ldl"]
 
 

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -701,15 +701,22 @@ def test_check_tables(hud_main, status, expected_method) -> None:
         mock_method.assert_called_once_with(None, mock_hud)
 
 
-def test_check_tables_skipped_during_drag(hud_main) -> None:
+def test_check_tables_skipped_during_drag(hud_main, monkeypatch) -> None:
     """While a HUD window is dragged, check_tables must not poll geometry or
-    re-raise windows (that stutters the drag on macOS)."""
+    re-raise windows (that stutters the drag on macOS).
+
+    A held mouse button is part of what makes a drag real now: the flag alone is
+    no longer believed, because the release that clears it is not guaranteed to
+    arrive and a stuck flag used to stop every HUD from ever being taken down.
+    See test_hud_drag_flag.py for that half.
+    """
     from fpdb_3_legacy import Aux_Base
 
     mock_hud = MagicMock()
     mock_hud.table.check_table.return_value = "client_moved"
     hud_main.hud_dict = {"test_table": mock_hud}
 
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: True)
     Aux_Base.set_drag_active(True)
     try:
         with (

--- a/test/test_detect_installed_sites.py
+++ b/test/test_detect_installed_sites.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from fpdb_3_legacy.DetectInstalledSites import SiteDetector
+from fpdb_3_legacy.DetectInstalledSites import SiteDetector, WinamaxDetector
 
 
 def _detector() -> SiteDetector:
@@ -23,3 +23,68 @@ def test_find_heroes_ignores_archives_and_hidden_directories(tmp_path) -> None:
         (tmp_path / directory).mkdir()
 
     assert sorted(_detector()._find_heroes_in_path(str(tmp_path))) == ["HeroOne", "HeroTwo"]
+
+
+def _winamax_detector() -> WinamaxDetector:
+    detector = WinamaxDetector(SimpleNamespace(os_family="windows"))
+    detector.platform = "Windows"
+    return detector
+
+
+def _winamax_history(root, *segments: str):
+    """Create <root>/<segments>/Dyvinitos/history and return it."""
+    history = root.joinpath(*segments) / "Dyvinitos" / "history"
+    history.mkdir(parents=True)
+    return history
+
+
+def test_windows_winamax_is_found_under_documents(tmp_path, monkeypatch) -> None:
+    """The current client keeps its accounts under a "documents" folder.
+
+    Only "Winamax/accounts" was probed, so a Windows player of the current
+    client was told the site was not installed and had to type the path in by
+    hand -- and, one level being easy to miss, sometimes typed the parent of the
+    history folder, which imports nothing.
+    """
+    history = _winamax_history(tmp_path, "Winamax", "documents", "accounts")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    result = _winamax_detector().detect()
+
+    assert result["detected"] is True
+    assert result["hhpath"] == str(history)
+    assert result["heroname"] == "Dyvinitos"
+
+
+def test_windows_winamax_still_found_in_the_older_layout(tmp_path, monkeypatch) -> None:
+    history = _winamax_history(tmp_path, "Winamax", "accounts")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert _winamax_detector().detect()["hhpath"] == str(history)
+
+
+def test_windows_winamax_documents_wins_over_the_older_layout(tmp_path, monkeypatch) -> None:
+    """A client upgraded in place leaves the old folder behind, empty of hands."""
+    _winamax_history(tmp_path, "Winamax", "accounts")
+    current = _winamax_history(tmp_path, "Winamax", "documents", "accounts")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert _winamax_detector().detect()["hhpath"] == str(current)
+
+
+def test_windows_winamax_is_found_under_local_appdata(tmp_path, monkeypatch) -> None:
+    history = _winamax_history(tmp_path / "local", "Winamax", "documents", "accounts")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "roaming"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert _winamax_detector().detect()["hhpath"] == str(history)
+
+
+def test_windows_winamax_absent_is_reported_as_not_detected(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("APPDATA", str(tmp_path / "roaming"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert _winamax_detector().detect() == {"detected": False, "hhpath": "", "heroname": "", "tspath": ""}

--- a/test/test_detect_installed_sites.py
+++ b/test/test_detect_installed_sites.py
@@ -1,7 +1,10 @@
 """Regression tests for installed-site directory detection."""
 
+import logging
+import os
 from types import SimpleNamespace
 
+from fpdb_3_legacy import DetectInstalledSites
 from fpdb_3_legacy.DetectInstalledSites import SiteDetector, WinamaxDetector
 
 
@@ -88,3 +91,68 @@ def test_windows_winamax_absent_is_reported_as_not_detected(tmp_path, monkeypatc
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
 
     assert _winamax_detector().detect() == {"detected": False, "hhpath": "", "heroname": "", "tspath": ""}
+
+
+def test_windows_winamax_falls_back_when_the_preferred_root_holds_no_history(tmp_path, monkeypatch) -> None:
+    """A root that exists is not proof the hands are in it.
+
+    The client creates its "documents" tree as soon as it runs. Stopping at the
+    first root that merely exists hid a real history left in the older layout,
+    and reported a client that is plainly installed as not detected.
+    """
+    (tmp_path / "Winamax" / "documents" / "accounts").mkdir(parents=True)
+    history = _winamax_history(tmp_path, "Winamax", "accounts")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    assert _winamax_detector().detect()["hhpath"] == str(history)
+
+
+def test_windows_winamax_skips_an_account_with_no_history_folder(tmp_path, monkeypatch) -> None:
+    """An account directory alone is not a history; the next one may be."""
+    accounts = tmp_path / "Winamax" / "documents" / "accounts"
+    (accounts / "LoggedInOnce").mkdir(parents=True)
+    history = accounts / "Dyvinitos" / "history"
+    history.mkdir(parents=True)
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    result = _winamax_detector().detect()
+
+    assert result["hhpath"] == str(history)
+    assert result["heroname"] == "Dyvinitos"
+
+
+def test_windows_winamax_falls_back_past_an_unreadable_root(tmp_path, monkeypatch, caplog) -> None:
+    """A root that cannot be listed must not end the search, but must be logged."""
+    _winamax_history(tmp_path, "Winamax", "accounts")
+    preferred = tmp_path / "Winamax" / "documents" / "accounts"
+    preferred.mkdir(parents=True)
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    real_listdir = os.listdir
+
+    def listdir(path, *args, **kwargs):
+        if str(path) == str(preferred):
+            raise PermissionError(13, "Permission denied")
+        return real_listdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(DetectInstalledSites.os, "listdir", listdir)
+
+    with caplog.at_level(logging.ERROR, logger="detect_installed_sites"):
+        result = _winamax_detector().detect()
+
+    assert result["detected"] is True
+    assert "Error detecting Winamax" in caplog.text
+
+
+def test_a_missing_root_is_not_logged_as_an_error(tmp_path, monkeypatch, caplog) -> None:
+    """Most candidate roots do not exist on any one machine; that is not news."""
+    monkeypatch.setenv("APPDATA", str(tmp_path / "roaming"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+
+    with caplog.at_level(logging.ERROR, logger="detect_installed_sites"):
+        assert _winamax_detector().detect()["detected"] is False
+
+    assert caplog.text == ""

--- a/test/test_hud_drag_flag.py
+++ b/test/test_hud_drag_flag.py
@@ -1,0 +1,112 @@
+"""A drag whose release never arrived must not keep every HUD alive.
+
+``HUD_main.check_tables`` polls ``Aux_Base.is_drag_active()`` *before* looking
+at any table, and returns immediately while a HUD block is being dragged -- on
+macOS the geometry scan and the window re-raise both re-order the dragged
+window and make the drag stutter.
+
+The flag was cleared only by SeatWindow's mouse release, and that release is not
+guaranteed to arrive: ``startSystemMove()`` hands the drag to the window
+manager, which runs its own modal loop and does not deliver it, and the widget
+can be destroyed mid-drag when the table it belongs to is the one being closed.
+One such drag left the flag set for the rest of the process's life, so no HUD
+was ever taken down again -- closing a table, or quitting the client, left its
+blocks on screen until FPDB was restarted.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from fpdb_3_legacy import Aux_Base  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_drag_left_behind():
+    """The flag is module state; a test must not leak it into the next one."""
+    Aux_Base.set_drag_active(False)
+    yield
+    Aux_Base.set_drag_active(False)
+
+
+def test_a_drag_in_progress_still_suspends_the_table_check(monkeypatch) -> None:
+    """The behaviour being protected: a real drag must not stutter."""
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: True)
+    Aux_Base.set_drag_active(True)
+
+    assert Aux_Base.is_drag_active() is True
+
+
+def test_a_released_button_ends_a_drag_whose_release_was_never_delivered(monkeypatch) -> None:
+    """The window manager's modal move loop swallows the release."""
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: False)
+    Aux_Base.set_drag_active(True)
+
+    assert Aux_Base.is_drag_active() is False
+
+
+def test_the_flag_is_cleared_and_not_merely_reported_as_false(monkeypatch) -> None:
+    """Left set, it would be re-tested on every one of the 800ms ticks."""
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: False)
+    Aux_Base.set_drag_active(True)
+    Aux_Base.is_drag_active()
+
+    assert Aux_Base._drag_active is False
+
+
+def test_a_drag_older_than_the_timeout_is_over(monkeypatch) -> None:
+    """Belt and braces: the button state can be stale too, after a native move."""
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: True)
+    Aux_Base.set_drag_active(True)
+    monkeypatch.setattr(
+        Aux_Base.time,
+        "monotonic",
+        lambda: Aux_Base._drag_started_at + Aux_Base.DRAG_ACTIVE_TIMEOUT_S + 1,
+    )
+
+    assert Aux_Base.is_drag_active() is False
+
+
+def test_an_unaskable_button_state_leaves_the_timeout_in_charge(monkeypatch) -> None:
+    """Cancelling a drag that is really in progress is the worse way to be wrong."""
+    monkeypatch.setattr(
+        Aux_Base.QGuiApplication,
+        "mouseButtons",
+        MagicMock(side_effect=RuntimeError("no application")),
+    )
+    Aux_Base.set_drag_active(True)
+
+    assert Aux_Base.is_drag_active() is True
+
+
+def test_the_release_path_still_clears_the_flag() -> None:
+    Aux_Base.set_drag_active(True)
+    Aux_Base.set_drag_active(False)
+
+    assert Aux_Base.is_drag_active() is False
+
+
+def test_check_tables_looks_at_the_tables_once_the_drag_flag_goes_stale(monkeypatch) -> None:
+    """The regression itself, at the level it was reported: HUDs stopped closing."""
+    from fpdb_3_legacy import HUD_main
+
+    monkeypatch.setattr(Aux_Base, "_a_mouse_button_is_down", lambda: False)
+    Aux_Base.set_drag_active(True)
+
+    hud = SimpleNamespace(table=SimpleNamespace())
+    hud_main = SimpleNamespace(
+        refresh_profiles_from_config=MagicMock(),
+        hud_dict={"Nice 18": hud},
+        _handle_table_status=MagicMock(),
+        _topify_mac_windows=MagicMock(),
+    )
+
+    HUD_main.HudMain.check_tables(hud_main)
+
+    hud_main._handle_table_status.assert_called_once_with(hud)

--- a/test/test_importer_vanished_files.py
+++ b/test/test_importer_vanished_files.py
@@ -1,0 +1,124 @@
+"""A file that disappears must not take the whole auto-import cycle with it.
+
+``autoSummaryGrab()`` stat'd every file it tracked as "both" without checking it
+was still there, and ``ImportThread`` runs it *before* ``runUpdated()`` -- which
+is the only thing that purges a vanished file from ``filelist``. So deleting a
+tracked file wedged auto-import permanently: the stat raised, the cycle never
+reached the purge, and the next cycle stat'd the same missing file and failed
+the same way. Nothing was imported again, every interval, until FPDB was
+restarted.
+
+``addImportDirectory()`` carries the same shape more briefly: ``os.walk`` lists
+a name, the client rotates it away, and the stat a few lines later took down the
+cycle for every other file too.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fpdb_3_legacy.Importer import Importer
+
+
+def _tracked(path, ftype: str) -> SimpleNamespace:
+    return SimpleNamespace(path=str(path), ftype=ftype, fileId=7, site=SimpleNamespace(name="Merge"))
+
+
+def _summary_importer(files) -> Importer:
+    """An Importer holding only what autoSummaryGrab reads."""
+    importer = Importer.__new__(Importer)
+    importer.filelist = {str(path): tracked for path, tracked in files}
+    importer._import_summary_file = MagicMock()
+    return importer
+
+
+def test_a_deleted_summary_does_not_abort_the_grab(tmp_path) -> None:
+    gone = tmp_path / "tourney-gone.txt"
+    importer = _summary_importer([(gone, _tracked(gone, "both"))])
+
+    importer.autoSummaryGrab(force=True)
+
+    importer._import_summary_file.assert_not_called()
+
+
+def test_the_files_still_there_are_grabbed_anyway(tmp_path) -> None:
+    """The wedge was worst here: one deleted file stopped every other one."""
+    gone = tmp_path / "tourney-gone.txt"
+    present = tmp_path / "tourney-present.txt"
+    present.write_text("summary", encoding="utf-8")
+    kept = _tracked(present, "both")
+    # Dict order puts the missing file first, which is the order that used to raise.
+    importer = _summary_importer([(gone, _tracked(gone, "both")), (present, kept)])
+
+    importer.autoSummaryGrab(force=True)
+
+    importer._import_summary_file.assert_called_once_with(kept)
+    assert kept.ftype == "hh"
+
+
+def test_the_cycle_reaches_the_purge_and_imports_the_rest(tmp_path) -> None:
+    """The regression that matters: the whole cycle, in the order the GUI runs it.
+
+    The deleted entry is dropped from filelist by runUpdated -- which only gets
+    to run because autoSummaryGrab no longer raises -- and the hand history file
+    beside it is imported as usual.
+    """
+    gone = tmp_path / "tourney-gone.txt"
+    hand_file = tmp_path / "hand-123456.txt"
+    hand_file.write_text("hand", encoding="utf-8")
+
+    importer = _summary_importer(
+        [(gone, _tracked(gone, "both")), (hand_file, _tracked(hand_file, "hh"))],
+    )
+    importer.dirlist = {}
+    importer.updatedsize = {str(hand_file): 0}
+    importer.updatedtime = {str(hand_file): 0}
+    importer.removeFromFileList = {}
+    importer._import_despatch = MagicMock(return_value=(1, 0, 0, 0, 0, 0.1, "Merge"))
+    importer.logImport = MagicMock()
+    importer.caller = MagicMock()
+    importer.database = MagicMock()
+    importer.runPostImport = MagicMock()
+
+    importer.autoSummaryGrab()
+    importer.runUpdated()
+
+    assert str(gone) not in importer.filelist
+    assert str(hand_file) in importer.filelist
+    importer._import_despatch.assert_called_once()
+
+
+def _directory_importer() -> Importer:
+    importer = Importer.__new__(Importer)
+    importer.monitor = False
+    importer.dirlist = {}
+    importer.failed_files = MagicMock()
+    importer.failed_files.failed.return_value = False
+    importer._is_valid_import_file = MagicMock(return_value=True)
+    importer.addImportFile = MagicMock()
+    return importer
+
+
+def test_a_file_rotated_away_mid_scan_is_skipped(tmp_path) -> None:
+    """os.walk listed it; it is gone by the time we stat it."""
+    vanishing = tmp_path / "rotated.txt"
+    surviving = tmp_path / "current.txt"
+    for path in (vanishing, surviving):
+        path.write_text("hand", encoding="utf-8")
+
+    importer = _directory_importer()
+    real_stat = os.stat
+
+    def stat(path, *args, **kwargs):
+        if str(path) == str(vanishing):
+            msg = "[WinError 2] The system cannot find the file specified"
+            raise FileNotFoundError(msg)
+        return real_stat(path, *args, **kwargs)
+
+    with patch("fpdb_3_legacy.Importer.os.stat", side_effect=stat):
+        importer.addImportDirectory(str(tmp_path))
+
+    added = [call.args[0] for call in importer.addImportFile.call_args_list]
+    assert added == [str(surviving)]

--- a/test/test_swc_capture_gate.py
+++ b/test/test_swc_capture_gate.py
@@ -19,6 +19,8 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # GuiAutoImport uses legacy-style bare imports, so the package directory itself
 # must be importable (same as test_guiautoimport_headless).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
@@ -59,13 +61,14 @@ def _make_gui(config):
         return GuiAutoImport.GuiAutoImport(settings, config, cli=True)
 
 
-def _start_capture(config):
+def _start_capture(config, *, supported=True):
     """Run start_swc_native_capture with the compiler and thread mocked out."""
     from fpdb_3_legacy import GuiAutoImport, swc_native_capture
 
     gui = _make_gui(config)
     with (
         patch.object(swc_native_capture, "build_tap") as build_tap,
+        patch.object(swc_native_capture, "native_capture_supported", return_value=supported),
         patch.object(GuiAutoImport, "SwCNativeTailingThread") as thread,
     ):
         gui.start_swc_native_capture()
@@ -90,3 +93,64 @@ def test_the_capture_still_starts_for_a_swc_player() -> None:
     build_tap.assert_called_once()
     thread.assert_called_once()
     thread.return_value.start.assert_called_once()
+
+
+def test_nothing_is_built_where_the_tap_could_not_be_loaded() -> None:
+    """Windows has no library interposition, so the tap has nothing to be loaded into.
+
+    Building it there was the compiler failure users kept reporting -- for a
+    library that nothing on the platform could have loaded even if gcc had been
+    installed and it had built.
+    """
+    build_tap, thread = _start_capture(_make_config({"enabled": True}), supported=False)
+    build_tap.assert_not_called()
+    thread.assert_not_called()
+
+
+def test_the_supported_platforms_are_the_ones_that_can_interpose() -> None:
+    from fpdb_3_legacy.swc_native_capture import native_capture_supported
+
+    assert native_capture_supported("Darwin") is True
+    assert native_capture_supported("Linux") is True
+    assert native_capture_supported("Windows") is False
+
+
+def test_swc_tap_build_uses_the_first_compiler_on_the_path(monkeypatch) -> None:
+    from fpdb_3_legacy import swc_tap_build
+
+    monkeypatch.setattr(swc_tap_build.shutil, "which", lambda name: name == "gcc")
+
+    assert swc_tap_build.resolve_compiler("Windows") == "gcc"
+
+
+def test_swc_tap_build_reports_a_missing_compiler(monkeypatch) -> None:
+    """The message users got was the OS's, and named nothing they could act on.
+
+        SwC Native Capture warning: [WinError 2] Le fichier specifie est introuvable
+    """
+    from fpdb_3_legacy import swc_tap_build
+
+    monkeypatch.setattr(swc_tap_build.shutil, "which", lambda _name: None)
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        swc_tap_build.resolve_compiler("Windows")
+
+    message = str(excinfo.value)
+    assert "x86_64-w64-mingw32-gcc" in message
+    assert "gcc" in message
+    assert "MinGW-w64" in message
+
+
+def test_the_compiler_is_checked_before_it_is_run(monkeypatch, tmp_path) -> None:
+    """No compiler must fail with our message, not with subprocess's."""
+    from fpdb_3_legacy import swc_tap_build
+
+    monkeypatch.setattr(swc_tap_build, "BUILD_DIR", tmp_path)
+    monkeypatch.setattr(swc_tap_build.shutil, "which", lambda _name: None)
+    run = MagicMock()
+    monkeypatch.setattr(swc_tap_build.subprocess, "run", run)
+
+    with pytest.raises(FileNotFoundError, match="no C compiler found"):
+        swc_tap_build.build_tap(force=True)
+
+    run.assert_not_called()

--- a/test/test_swc_capture_gate.py
+++ b/test/test_swc_capture_gate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""The SwC native capture must not run for a player of another room.
+
+Starting Auto Import compiled the SealsWithClubs TLS tap unconditionally. The
+tap is built by shelling out to a C compiler, which a Windows machine almost
+never has, so every user got the same line in the Auto Import log on every
+Start:
+
+    SwC Native Capture warning: [WinError 2] Le fichier specifie est introuvable
+
+It was reported as a Winamax bug, which is exactly what it looks like from the
+outside. SwC is the one room that ships no hand history files -- for every other
+room the capture has nothing to do, so it is no longer started at all.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# GuiAutoImport uses legacy-style bare imports, so the package directory itself
+# must be importable (same as test_guiautoimport_headless).
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _make_config(swc_parameters):
+    """A config whose get_site_parameters answers for SealsWithClubs only.
+
+    ``swc_parameters`` is the dict to return, or a KeyError to raise -- which is
+    what Configuration does for a site that is not in HUD_config.xml at all.
+    """
+    config = MagicMock()
+    config.get_import_parameters.return_value = {"interval": "5"}
+    config.get_supported_sites.return_value = []
+    config.get_db_parameters.return_value = {}
+
+    def get_site_parameters(site):
+        if isinstance(swc_parameters, Exception):
+            raise swc_parameters
+        return swc_parameters
+
+    config.get_site_parameters.side_effect = get_site_parameters
+    return config
+
+
+def _make_gui(config):
+    from fpdb_3_legacy import GuiAutoImport
+
+    settings = {
+        "db-host": "localhost",
+        "db-user": "fpdb",
+        "db-password": "",
+        "db-databaseName": "fpdb",
+        "global_lock": MagicMock(),
+    }
+    with patch.object(GuiAutoImport.Importer, "Importer", return_value=MagicMock()):
+        return GuiAutoImport.GuiAutoImport(settings, config, cli=True)
+
+
+def _start_capture(config):
+    """Run start_swc_native_capture with the compiler and thread mocked out."""
+    from fpdb_3_legacy import GuiAutoImport, swc_native_capture
+
+    gui = _make_gui(config)
+    with (
+        patch.object(swc_native_capture, "build_tap") as build_tap,
+        patch.object(GuiAutoImport, "SwCNativeTailingThread") as thread,
+    ):
+        gui.start_swc_native_capture()
+    return build_tap, thread
+
+
+def test_a_site_that_is_not_configured_builds_nothing() -> None:
+    """The reported case: no SealsWithClubs entry, so no compiler is invoked."""
+    build_tap, thread = _start_capture(_make_config(KeyError("SealsWithClubs")))
+    build_tap.assert_not_called()
+    thread.assert_not_called()
+
+
+def test_a_configured_but_disabled_site_builds_nothing() -> None:
+    build_tap, thread = _start_capture(_make_config({"enabled": False}))
+    build_tap.assert_not_called()
+    thread.assert_not_called()
+
+
+def test_the_capture_still_starts_for_a_swc_player() -> None:
+    build_tap, thread = _start_capture(_make_config({"enabled": True}))
+    build_tap.assert_called_once()
+    thread.assert_called_once()
+    thread.return_value.start.assert_called_once()

--- a/test/test_swc_native_capture.py
+++ b/test/test_swc_native_capture.py
@@ -1,4 +1,6 @@
 import io
+import platform
+import shutil
 import struct
 import threading
 from dataclasses import replace
@@ -1518,7 +1520,20 @@ def test_iter_capture_records_rejects_corruption(data, message):
 
 
 def test_build_tap_cross_platform(tmp_path, monkeypatch):
+    """The compile itself, on whichever platform this is running.
+
+    Skipped where no compiler is installed rather than failed: this asserts that
+    the C builds, and a developer machine without a toolchain -- which is most
+    Windows machines -- cannot answer that question either way. What such a
+    machine *should* get is covered by
+    test_swc_tap_build_reports_a_missing_compiler.
+    """
     from fpdb_3_legacy import swc_native_capture
+    from fpdb_3_legacy.swc_tap_build import COMPILERS
+
+    system_name = platform.system()
+    if not any(shutil.which(name) for name in COMPILERS.get(system_name, ())):
+        pytest.skip(f"no C compiler on this {system_name} machine")
 
     monkeypatch.setattr(swc_native_capture, "BUILD_DIR", tmp_path)
     tap_path = swc_native_capture.build_tap(force=True)


### PR DESCRIPTION
Everything here comes from one user's Winamax session on Windows.

The missing HUD itself is **not** fixed here — that is the lobby-attach bug,
already fixed by #274 and shipped in 3.8.0. What this PR fixes is what came
after: HUD blocks that never went away, a SealsWithClubs error on every Start,
and a hand history folder that had to be typed in by hand.

## HUD blocks of a classic table never go away

Reported with a screenshot: a live table's HUD working perfectly, and beside it
the blocks of tables closed long ago, sitting over the desktop and over the
lobby.

`check_tables()` polls `Aux_Base.is_drag_active()` **before looking at any
table** and returns immediately while a block is being dragged — on macOS its
geometry scan and window re-raise both re-order the dragged window and make the
drag stutter. The flag was cleared only by `SeatWindow`'s mouse release, and
that release is not guaranteed to arrive:

- `button_press_left` prefers `startSystemMove()`. The window manager then runs
  its own modal move loop and does not deliver the release to the widget.
- the widget can be destroyed mid-drag — when the table it belongs to is the one
  being closed.

Either way the flag stayed `True` for the rest of the process's life, and
`check_tables` never got past its first line again. **Drag one block once, and no
HUD is ever taken down again.**

Why *classic* tables specifically, which is how it was reported: the other timer,
`_cleanup_closed_windows`, opens with

```python
if not getattr(hud, "is_fast_fold", False):
    continue
```

so Fast-Fold tables had a second mechanism and kept closing. Classic tables have
only `check_tables`.

A set flag is now believed only while it is plausible: a mouse button still down,
and not older than `DRAG_ACTIVE_TIMEOUT_S`. Being wrong here costs one stuttering
drag; being wrong the other way cost every HUD until FPDB was restarted.

## The SwC `[WinError 2]` is a real bug, in two halves

**It named nothing actionable.** `subprocess` was handed a compiler name that had
never been checked, so a machine without one failed with the OS's own words for
"that program does not exist":

```
SwC Native Capture warning: [WinError 2] Le fichier specifie est introuvable
```

`resolve_compiler()` now looks the candidates up on `PATH` first and says which
ones it tried and how to install one. Windows is where it always bit, but a Linux
box with no toolchain got the same non-answer.

**And it should not have been building anything there.** The tap is loaded into
the client by library interposition — `DYLD_INSERT_LIBRARIES` on macOS,
`LD_PRELOAD` on Linux. Windows has no equivalent, and nothing else in the launch
path is Windows-ready either: `SWC_EXECUTABLE` is a macOS bundle path,
`running_client_pids` shells out to `pgrep`. The C source *does* carry a Windows
branch and CI compiles it, but no injection path uses the result. So on Windows
the GUI compiled a library nothing could load, then reported the compiler's
absence as if that were the problem. It now says the live capture is not
available on this platform, and that file import is unaffected.

**And it ran for everyone.** `start_swc_native_capture()` fired on every Start
whatever the enabled sites, which is how a Winamax player came to be reading a
SealsWithClubs error while looking for the cause of a missing HUD. The site is
checked first now.

## Find the Windows Winamax history folder

Detection probed `%APPDATA%\Winamax\accounts` and the `LOCALAPPDATA` equivalent.
The current client keeps its accounts one level deeper, under `documents` —
exactly as it already does on macOS and Linux:

```
%APPDATA%\Winamax\documents\accounts\<hero>\history
```

So the site came back "not detected", the path had to be typed in, and the
reporter typed the parent of the history folder, which imports nothing.

Per review feedback on this PR (thanks @chatgpt-codex-connector): adding those
roots in front made an existing flaw reachable. `_check_path_exists()` returns
the first root that *exists* and only that one was scanned, so a `documents` tree
the client creates on first run but has not filled would hide a real history in
the older layout. The candidate roots are now a list, and the search stops at the
first that holds an actual `<account>/history`. Linux gains the same for free:
every Wine prefix is tried, where only the first glob hit used to be.

## Stop one vanished file wedging auto-import for good

Found while checking whether the reporter's summary files could be the cause.
They could not — only `MergeToFpdb` sets `summaryInFile`, so a Winamax player's
summaries never reach that path, which is exactly what they observed on retrying
— but this is real.

`autoSummaryGrab()` stat'd every `"both"` file without checking it was still
there, and `ImportThread` runs it **before** `runUpdated()` — the only thing that
purges a vanished file from `filelist`. So deleting a tracked file cost not one
cycle but every cycle after it, until FPDB was restarted. `addImportDirectory()`
carries the same shape more briefly and is guarded the same way.

## Tests

New: `test_hud_drag_flag.py` (7), `test_swc_capture_gate.py` (8),
`test_importer_vanished_files.py` (4), plus 9 added to
`test_detect_installed_sites.py`. Every test that pins new behaviour was checked
to fail on `development`.

Two existing tests were coupled to the old contract and now describe the new one:
`test_check_tables_skipped_during_drag` holds a mouse button, because a flag
alone is no longer a drag; `test_build_tap_cross_platform` skips where no
toolchain is installed, because it asserts that the C compiles and a machine
without a compiler cannot answer that either way — CI still compiles it on all
three runners.

Both modes CI runs, against `development` on the same machine:

| | `-m "not qt and not perf"` | `-m qt` |
|---|---|---|
| `development` | 8265 passed, 7 failed, 41 skipped | 722 passed, 3 failed |
| this branch | 8293 passed, 6 failed, 42 skipped | 722 passed, 3 failed |

The failure that went away is `test_build_tap_cross_platform`, now a skip on a
machine with no compiler. The rest are pre-existing and environmental in this
Windows checkout (`os.symlink` without the privilege, four order-dependent
`test_stats_100_coverage` cases that pass in isolation, and two COM-dependent
`test_wintables_coinpoker` ones). `ruff` clean.
