### PR TITLE
fix(perf): log a [PERF] line at WARNING only when it reports something slow

### DIFF
--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -102,7 +102,7 @@ from fpdb_3_legacy.Exceptions import FpdbError
 from fpdb_3_legacy.GuiConfigObserver import GuiConfigObserver
 from fpdb_3_legacy.i18n import gettext as _
 from fpdb_3_legacy.L10n import set_locale_translation
-from fpdb_3_legacy.ui_instrumentation import TabOpenProfiler
+from fpdb_3_legacy.ui_instrumentation import TabOpenProfiler, perf_level
 
 np = import_module("numpy")
 
@@ -223,13 +223,18 @@ class fpdb(QMainWindow):
 
         if not allow_multiple and new_tab_name in self.nb_tab_names:
             self.display_tab(new_tab_name)
-            # At WARNING like the other [PERF] diagnostics: the root logger is
-            # pinned to WARNING (loggingFpdb.DIAGNOSTIC_LEVEL_CAP), so this line
-            # logged at INFO never reached a single user log.
-            log.warning(
+            # WARNING only when it was slow, like the other [PERF] diagnostics.
+            # The root logger is pinned to WARNING
+            # (loggingFpdb.DIAGNOSTIC_LEVEL_CAP), so a line logged at INFO never
+            # reached a single user log -- but logging every switch there, and a
+            # switch is usually under a millisecond, buried the warnings a reader
+            # is looking for instead.
+            switch_ms = (time.perf_counter() - t0) * 1000
+            log.log(
+                perf_level(switch_ms),
                 "[PERF] switched to existing tab '%s' in %.0f ms",
                 new_tab_name,
-                (time.perf_counter() - t0) * 1000,
+                switch_ms,
             )
             if new_page is not None:
                 with contextlib.suppress(ValueError):

--- a/fpdb_3_legacy/loggingFpdb.py
+++ b/fpdb_3_legacy/loggingFpdb.py
@@ -1633,6 +1633,26 @@ class FpdbLogger:
         stacklevel = self._get_stacklevel()
         self.logger.exception(msg, *args, stacklevel=stacklevel, **kwargs)
 
+    def log(self, level: int, msg: object, *args: Any, **kwargs: Any) -> None:
+        """Log at a level decided at runtime.
+
+        The wrapper mirrors logging.Logger's per-level methods, and callers that
+        pick their level from what they measured need the variable-level form
+        too -- a diagnostic that is a WARNING when it reports a problem and a
+        DEBUG when it reports that there is none. Without this, such a caller
+        raised AttributeError against the real logger while passing every test
+        that handed it a standard logging.Logger.
+
+        Args:
+            level (int): The level to log at (e.g. logging.WARNING).
+            msg (str): The log message.
+            *args: Positional arguments for message formatting.
+            **kwargs: Keyword arguments for message formatting.
+
+        """
+        stacklevel = self._get_stacklevel()
+        self.logger.log(level, msg, *args, stacklevel=stacklevel, **kwargs)
+
     def setLevel(self, level: int) -> None:
         """Set the logging level for this logger.
 
@@ -1670,6 +1690,7 @@ class FpdbLogger:
                 "info",
                 "warning",
                 "error",
+                "log",
                 "__init__",
                 "_get_stacklevel",
             ):

--- a/fpdb_3_legacy/ui_instrumentation.py
+++ b/fpdb_3_legacy/ui_instrumentation.py
@@ -35,6 +35,7 @@ the symptom is worse than none, because it answers.
 
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -43,7 +44,6 @@ from typing import TYPE_CHECKING, Any
 from PySide6.QtCore import QEvent, QObject, QTimer
 
 if TYPE_CHECKING:
-    import logging
     from collections.abc import Callable, Iterator
 
     from PySide6.QtWidgets import QWidget
@@ -59,6 +59,34 @@ UI_STALL_BUDGET_MS = 100.0
 #: before logging anyway. A tab that has not drawn within this window is the
 #: symptom being investigated, so the line must not be lost to it.
 FIRST_PAINT_TIMEOUT_MS = 10_000
+
+#: A tab open slow enough that a user would call it slow. Above this the report
+#: is a WARNING, so it reaches a log running at the default level; below it the
+#: same line goes to DEBUG.
+SLOW_TAB_OPEN_MS = 1000.0
+
+
+def perf_level(total_ms: float, max_stall_ms: float | None = None) -> int:
+    """The level a ``[PERF]`` line deserves: WARNING if slow, DEBUG if not.
+
+    Every one of these lines used to be a WARNING, on the reasoning that the
+    root logger is pinned there (``loggingFpdb.DIAGNOSTIC_LEVEL_CAP``) and a
+    slow tab is reported by users whose logs are not running at DEBUG. That
+    part still holds, and is why the slow case is left alone. What did not hold
+    is the other half: a tab that opened in 5 ms was logged at WARNING too, so
+    an ordinary session filled the log viewer with lines saying nothing was
+    wrong -- eleven of eleven, in the session that prompted this -- and buried
+    the warnings a reader is actually looking for.
+
+    A line is kept at WARNING when either figure says the user waited: the
+    total, or the longest the event loop was blocked, which is the one that
+    matches what "frozen" means to them and can be bad while the total is not.
+    """
+    if total_ms >= SLOW_TAB_OPEN_MS:
+        return logging.WARNING
+    if max_stall_ms is not None and max_stall_ms >= UI_STALL_BUDGET_MS:
+        return logging.WARNING
+    return logging.DEBUG
 
 
 @dataclass
@@ -228,11 +256,16 @@ class TabOpenProfiler:
     def report(self, log: logging.Logger) -> TabTiming:
         """Log the timing and return it.
 
-        At WARNING for the same reason the HUD's diagnostics are: a slow tab
-        is reported by users whose logs are not running at DEBUG.
+        A slow open stays at WARNING, for the same reason the HUD's diagnostics
+        are: it is reported by users whose logs are not running at DEBUG. A fast
+        one is DEBUG -- see :func:`perf_level`.
         """
         timing = self.result()
-        log.warning("[PERF] tab open: %s", timing.format())
+        log.log(
+            perf_level(timing.total_ms, timing.max_stall_ms),
+            "[PERF] tab open: %s",
+            timing.format(),
+        )
         return timing
 
 

--- a/test/test_fastfold_support_modules.py
+++ b/test/test_fastfold_support_modules.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from fpdb_3_legacy import hud_diagnostics
 from fpdb_3_legacy.hud_window_registry import HudWindowRegistry
 from fpdb_3_legacy.ui_instrumentation import (
+    SLOW_TAB_OPEN_MS,
     UI_STALL_BUDGET_MS,
     TabOpenProfiler,
     UiStallMonitor,
@@ -111,6 +112,10 @@ def test_a_tab_timing_is_reported_as_one_line(caplog) -> None:
     profiler = TabOpenProfiler("Session Stats")
     with profiler.phase("construct"):
         pass
+    # Only a slow open is a WARNING now, and this test asserts one. Backdating
+    # the start is what makes it slow: sleeping for a second to prove a log
+    # line's format would be a second added to every run of the suite.
+    profiler._started -= SLOW_TAB_OPEN_MS / 1000 + 0.1
 
     with caplog.at_level(logging.WARNING, logger=log.name):
         timing = profiler.report(log)

--- a/test/test_perf_log_levels.py
+++ b/test/test_perf_log_levels.py
@@ -1,0 +1,89 @@
+"""A [PERF] line must be a WARNING only when it reports something slow.
+
+Every one of these lines was a WARNING, because the root logger is pinned there
+(``loggingFpdb.DIAGNOSTIC_LEVEL_CAP``) and a slow tab has to reach a log that is
+not running at DEBUG. True for a slow tab -- and applied to every tab. A user
+sent in a log viewer holding eleven WARNING lines, all of them [PERF], the
+slowest tab 528 ms and six of them under 60 ms, with the actual problem nowhere
+in sight. An instrument that reports "nothing is wrong" at WARNING costs the
+reader the warnings that mean something.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+# No sys.path.insert of the repo root: pytest.ini already sets `pythonpath = .`,
+# so the inserts the older test modules carry are redundant here.
+from fpdb_3_legacy.ui_instrumentation import (
+    SLOW_TAB_OPEN_MS,
+    UI_STALL_BUDGET_MS,
+    TabOpenProfiler,
+    perf_level,
+)
+
+
+def test_a_fast_tab_open_is_not_a_warning() -> None:
+    """The lines that flooded the viewer: 5 ms, nothing stalled."""
+    assert perf_level(5.0, 0.0) == logging.DEBUG
+
+
+def test_a_slow_tab_open_is_still_a_warning() -> None:
+    """The case the WARNING exists for must survive this change."""
+    assert perf_level(SLOW_TAB_OPEN_MS + 1, 0.0) == logging.WARNING
+
+
+def test_a_frozen_event_loop_is_a_warning_even_when_the_total_is_not() -> None:
+    """max_stall is what "frozen" means to a user; a short total does not excuse it."""
+    assert perf_level(200.0, UI_STALL_BUDGET_MS + 1) == logging.WARNING
+
+
+def test_an_unmeasured_stall_does_not_promote_a_fast_open() -> None:
+    """max_stall is None when no monitor ran -- absence of a figure is not a stall."""
+    assert perf_level(5.0) == logging.DEBUG
+
+
+@pytest.mark.parametrize(
+    ("total_ms", "stall_ms"),
+    [(SLOW_TAB_OPEN_MS, 0.0), (0.0, UI_STALL_BUDGET_MS)],
+)
+def test_the_thresholds_are_inclusive(total_ms: float, stall_ms: float) -> None:
+    assert perf_level(total_ms, stall_ms) == logging.WARNING
+
+
+def _report_record(monkeypatch, total_ms: float) -> logging.LogRecord:
+    """Run TabOpenProfiler.report against a captured logger."""
+    profiler = TabOpenProfiler("Help")
+    records: list[logging.LogRecord] = []
+
+    class Recorder(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    log = logging.getLogger("test_perf_log_levels")
+    log.handlers = [Recorder()]
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+
+    monkeypatch.setattr(
+        profiler,
+        "result",
+        lambda: profiler._timing.__class__(name="Help", total_ms=total_ms),
+    )
+    profiler.report(log)
+    assert len(records) == 1
+    return records[0]
+
+
+def test_report_logs_a_fast_open_at_debug(monkeypatch) -> None:
+    record = _report_record(monkeypatch, 5.0)
+    assert record.levelno == logging.DEBUG
+    assert "[PERF] tab open" in record.getMessage()
+
+
+def test_report_logs_a_slow_open_at_warning(monkeypatch) -> None:
+    record = _report_record(monkeypatch, SLOW_TAB_OPEN_MS + 500)
+    assert record.levelno == logging.WARNING
+    assert "[PERF] tab open" in record.getMessage()

--- a/test/test_perf_log_levels.py
+++ b/test/test_perf_log_levels.py
@@ -17,6 +17,7 @@ import pytest
 
 # No sys.path.insert of the repo root: pytest.ini already sets `pythonpath = .`,
 # so the inserts the older test modules carry are redundant here.
+from fpdb_3_legacy.loggingFpdb import get_logger
 from fpdb_3_legacy.ui_instrumentation import (
     SLOW_TAB_OPEN_MS,
     UI_STALL_BUDGET_MS,
@@ -87,3 +88,56 @@ def test_report_logs_a_slow_open_at_warning(monkeypatch) -> None:
     record = _report_record(monkeypatch, SLOW_TAB_OPEN_MS + 500)
     assert record.levelno == logging.WARNING
     assert "[PERF] tab open" in record.getMessage()
+
+
+def _record_via(logger, handler_target, total_ms: float) -> logging.LogRecord:
+    """Drive TabOpenProfiler.report through `logger`, return the record it emitted."""
+    records: list[logging.LogRecord] = []
+
+    class Recorder(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler_target.handlers = [Recorder()]
+    handler_target.setLevel(logging.DEBUG)
+    handler_target.propagate = False
+
+    profiler = TabOpenProfiler("Help")
+    profiler._started -= total_ms / 1000
+    profiler.report(logger)
+
+    assert len(records) == 1
+    return records[0]
+
+
+def test_report_works_against_the_logger_the_application_uses() -> None:
+    """The production logger is a wrapper, not a logging.Logger.
+
+    get_logger() returns FpdbLogger, which mirrors logging.Logger's per-level
+    methods. Reporting at a level chosen at runtime needs the variable-level
+    form, and the wrapper had none -- so the first version of this change raised
+    AttributeError on every tab open in the real application while every test
+    here passed, because they all handed report() a standard logging.Logger.
+    Reported by Codex on the pull request.
+    """
+    logger = get_logger("test_perf_log_levels_wrapper_fast")
+    record = _record_via(logger, logger.logger, total_ms=5)
+
+    assert record.levelno == logging.DEBUG
+    assert "[PERF] tab open" in record.getMessage()
+
+
+def test_the_wrapper_reports_a_slow_open_at_warning() -> None:
+    logger = get_logger("test_perf_log_levels_wrapper_slow")
+    record = _record_via(logger, logger.logger, total_ms=SLOW_TAB_OPEN_MS + 500)
+
+    assert record.levelno == logging.WARNING
+
+
+def test_the_wrapper_still_credits_the_caller_with_the_line() -> None:
+    """_get_stacklevel has to know about log(), or every record points at the wrapper."""
+    logger = get_logger("test_perf_log_levels_wrapper_stack")
+    record = _record_via(logger, logger.logger, total_ms=5)
+
+    assert record.funcName != "log"
+    assert record.filename != "loggingFpdb.py"

--- a/test/test_tab_open_reporting.py
+++ b/test/test_tab_open_reporting.py
@@ -118,9 +118,17 @@ class _RecordingLogger(logging.Logger):
     def __init__(self) -> None:
         super().__init__("test-tab-open")
         self.lines: list[str] = []
+        self.levels: list[int] = []
+
+    # Capture whichever call the profiler makes: it reports through log() now,
+    # because only a slow open is a WARNING. A stub that intercepts one method
+    # name says nothing about the code once it uses the other.
+    def log(self, level, msg, *args, **kwargs) -> None:
+        self.levels.append(level)
+        self.lines.append(msg % args if args else msg)
 
     def warning(self, msg, *args, **kwargs) -> None:  # noqa: A002 - mirrors logging API
-        self.lines.append(msg % args if args else msg)
+        self.log(logging.WARNING, msg, *args, **kwargs)
 
 
 def test_reopening_a_single_instance_tab_builds_nothing() -> None:


### PR DESCRIPTION
## What a user's log viewer actually contained

Eleven WARNING lines. All eleven `[PERF] tab open`. Six under 60 ms, the slowest
528 ms. Nothing else â€” no errors, no other warnings, nothing to diagnose the
problem he had opened the viewer to look at.

```
WARNING  ui_instrumentation  _emit_pending  [PERF] tab open: tab='Help' construct=0ms add_tab=1ms first_paint=5ms total=5ms max_stall=0ms
WARNING  ui_instrumentation  _emit_pending  [PERF] tab open: tab='Help' construct=0ms add_tab=2ms first_paint=5ms total=5ms max_stall=0ms
...
```

## Why they were WARNING, and which half of that still holds

The root logger is pinned to WARNING (`loggingFpdb.DIAGNOSTIC_LEVEL_CAP`), so a
line logged lower never reaches a user's log at all. A slow tab is reported by
users who are not running at DEBUG, so the report has to arrive at WARNING â€”
that reasoning is right, and this PR leaves it alone.

What it does not justify is logging a 5 ms tab open at the same level. An
instrument that announces "nothing is wrong" in the channel reserved for
problems buries the lines that mean something, which is the opposite of the
reason #249 raised them.

## The rule

`perf_level()` keeps WARNING when either figure says the user waited:

- total past `SLOW_TAB_OPEN_MS` (1000 ms), or
- a stall past `UI_STALL_BUDGET_MS` (100 ms) â€” the figure that matches what
  "frozen" means to a user, and which can be bad while the total looks fine.

Everything else goes to DEBUG, still there for anyone who turns the logger up.
Applied to `TabOpenProfiler.report()` and to the tab-switch line in `fpdb.pyw`,
which is usually under a millisecond.

Against the log above: the 528 ms / 469 ms stall open stays a WARNING, and so do
the three other real stalls. The six that said nothing go quiet.

## Two tests were coupled to the level, not the behaviour

- `_RecordingLogger` intercepted `warning()` **by name**, so it captured nothing
  once the profiler reported through `log()`. It now captures whichever call is
  made, and records the level.
- `test_a_tab_timing_is_reported_as_one_line` asserted a WARNING for a timing it
  had made instant. It backdates the profiler's start so the open is genuinely
  slow â€” which is what its docstring claimed all along â€” instead of sleeping a
  second in every run.

## `FpdbLogger` needed the variable-level form

Review feedback on this PR (thanks @chatgpt-codex-connector), and it was a real
break, not a nit. `get_logger()` returns `FpdbLogger`, a wrapper that mirrors
`logging.Logger`'s per-level methods and has **no `log()`**. Choosing the level
at runtime therefore raised

```
AttributeError: 'FpdbLogger' object has no attribute 'log'
```

on every tab open and every reopen of a single-instance tab in the real
application — while every test passed, because they all handed `report()` a
standard `logging.Logger`. A stub more capable than the real thing tests nothing
about the real thing. Three tests now drive `report()` through `get_logger()`
itself, and they fail with that AttributeError against the previous commit.

The method goes on the wrapper rather than being hand-dispatched at the two call
sites: any caller picking a level at runtime needs it. `"log"` also joins the
`_get_stacklevel()` frame list, or every `[PERF]` line would be credited to
`loggingFpdb.py:log` instead of the code that emitted it — asserted too.

## Tests

`test/test_perf_log_levels.py` (new), 8 cases: fast open is DEBUG, slow open is
WARNING, a frozen event loop is WARNING even when the total is not, an unmeasured
stall does not promote a fast open, and both thresholds are inclusive; plus two
that drive `report()` end to end and read the level off the emitted record.

Both modes CI runs pass: `-m "not qt and not perf"` 32 passed, `-m qt` 18 passed.
Full default suite: 4327 passed, 16 skipped. `ruff` clean.

The one failure in the full run is
`test_macos_packaging.py::test_mach_o_search_covers_extensionless_framework_binaries`
â€” `OSError: [WinError 1314]`, `os.symlink` without the Windows privilege. Nothing
to do with this change.

## Unrelated landmine found while verifying

Running the Qt and non-Qt tests together (`-m ""`, which CI never does) crashes
`test_tab_open_reporting.py` with a `Windows fatal exception: access violation`
inside pytest-qt's `_process_events`. **Reproducible on `development` with no
source change**, by adding any test module that does
`sys.path.insert(0, <repo root>)` and imports from `fpdb_3_legacy.ui_instrumentation`
â€” the insert lets the module resolve either from the source tree or from the
installed package, and two identities for the `QObject` subclasses in it are
enough to take the event loop down. It is latent today because CI keeps the two
marker sets apart, but every one of those `sys.path.insert` lines is redundant
(`pytest.ini` already sets `pythonpath = .`). Worth its own PR; this one only
declines to add another insert.

