### PR TITLE
chore(test): drop the sys.path inserts that only re-add the repo root

### DIFF
--- a/test/test_5omaha8_profit_issue137.py
+++ b/test/test_5omaha8_profit_issue137.py
@@ -12,11 +12,8 @@ Player6 wins the pot uncontested:
 """
 
 import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars

--- a/test/test_BovadaToFpdb.py
+++ b/test/test_BovadaToFpdb.py
@@ -14,14 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
-try:
-    from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
-except ImportError:
-    import sys
-
-    sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
-    from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
-
+from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
 
 # --- Mocks ---
 from tests.helpers.mock_hand import ParserMockHand as MockHand  # noqa: E402

--- a/test/test_BovadaToFpdb_comprehensive.py
+++ b/test/test_BovadaToFpdb_comprehensive.py
@@ -10,17 +10,9 @@ import os
 import unittest
 from pathlib import Path
 
-try:
-    from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
-    from fpdb_3_legacy.Configuration import Config
-    from fpdb_3_legacy.Hand import DrawHand, Hand, HoldemOmahaHand, StudHand
-except ImportError:
-    import sys
-
-    sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
-    from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
-    from fpdb_3_legacy.Configuration import Config
-    from fpdb_3_legacy.Hand import DrawHand, Hand, HoldemOmahaHand, StudHand
+from fpdb_3_legacy.BovadaToFpdb import Bovada, FpdbHandPartial, FpdbParseError
+from fpdb_3_legacy.Configuration import Config
+from fpdb_3_legacy.Hand import DrawHand, Hand, HoldemOmahaHand, StudHand
 
 # Logging configuration for debugging
 logging.basicConfig(level=logging.WARNING)

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -21,7 +21,6 @@ from fpdb.infrastructure.platform import permissions as macos_permissions
 # import zmq
 
 # Add parent directory to path before imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 source_file = Path(__file__).parent.parent / "fpdb_3_legacy" / "HUD_main.pyw"
 

--- a/test/test_action_counting.py
+++ b/test/test_action_counting.py
@@ -5,14 +5,9 @@ This module tests the calls, bets, raises, and folds functions which count
 player actions on specific streets.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_action_enum_hud_stats.py
+++ b/test/test_action_enum_hud_stats.py
@@ -12,15 +12,11 @@ reads.
 
 from __future__ import annotations
 
-import os
 import re
 import sqlite3
-import sys
 from contextlib import closing
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import fpdb_3_legacy.SQL as SQL
 import fpdb_3_legacy.Stats as Stats

--- a/test/test_action_enum_persistence.py
+++ b/test/test_action_enum_persistence.py
@@ -7,15 +7,11 @@ each import and thrown away. These tests cover the three places that have to
 agree and the round trip through a real insert.
 """
 
-import os
 import re
 import sqlite3
-import sys
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import fpdb_3_legacy.Database as Database
 import fpdb_3_legacy.SQL as SQL

--- a/test/test_aggr.py
+++ b/test/test_aggr.py
@@ -5,14 +5,9 @@ This module tests the aggr functionality which calculates aggression statistics
 for players based on their betting actions on specific streets.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_assemble_hands.py
+++ b/test/test_assemble_hands.py
@@ -1,18 +1,14 @@
 """Test suite for assembleHands method in DerivedStats."""
 
-import sys
 from collections.abc import Callable
 from datetime import datetime, timezone
 
 UTC = timezone.utc  # datetime.UTC is 3.11+; the packaged builds embed 3.10
 from decimal import Decimal
-from pathlib import Path
 
 import pytest
 
 # Add parent directory to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
 import fpdb_3_legacy.Card as Card
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_assemble_hands_actions.py
+++ b/test/test_assemble_hands_actions.py
@@ -1,13 +1,9 @@
 """Test suite for assembleHandsActions method in DerivedStats."""
 
-import sys
 from decimal import Decimal
-from pathlib import Path
 from unittest.mock import Mock
 
 # Add parent directory to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
 from fpdb_3_legacy.DerivedStats import DerivedStats
 
 

--- a/test/test_aux_classic_hud.py
+++ b/test/test_aux_classic_hud.py
@@ -2,7 +2,6 @@
 Tests for Aux_Classic_Hud.py.
 """
 
-import os
 import sys
 import unittest
 from contextlib import contextmanager
@@ -13,7 +12,6 @@ import pytest
 pytestmark = pytest.mark.qt
 
 # Make repo root importable
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Very light stubs to avoid real GUI deps
 sys.modules.setdefault("PySide6", Mock())

--- a/test/test_aux_simple.py
+++ b/test/test_aux_simple.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
 """Simplified tests for Aux_Classic_Hud.py (fixed)."""
 
-import os
 import sys
 import types
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
-
-# Add repo root to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestAuxClassicHudBasics(unittest.TestCase):

--- a/test/test_aux_uncreated_windows.py
+++ b/test/test_aux_uncreated_windows.py
@@ -9,15 +9,12 @@ which is how ``'ClassicHud' object has no attribute 'adj'`` reached the log.
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import Mock
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 sys.modules.setdefault("PySide6", Mock())
 sys.modules.setdefault("PySide6.QtWidgets", Mock())

--- a/test/test_boards_list.py
+++ b/test/test_boards_list.py
@@ -10,11 +10,7 @@ divided the pot by the number of streets rather than the number of runs.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_3bet_postflop.py
+++ b/test/test_calc_3bet_postflop.py
@@ -9,11 +9,7 @@ and river (street3).
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_4bet_postflop.py
+++ b/test/test_calc_4bet_postflop.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_bet_made.py
+++ b/test/test_calc_bet_made.py
@@ -8,12 +8,8 @@ pot before the bet (PT4 amt_{f,t,r}_bet_made / val_*_bet_made_pct), alongside th
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_bet_sizing_extra.py
+++ b/test/test_calc_bet_sizing_extra.py
@@ -8,12 +8,8 @@ calcRaiseMade, and preflop 5-bet faced.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_cbets.py
+++ b/test/test_calc_cbets.py
@@ -5,14 +5,9 @@ This module tests the calcCBets functionality which calculates continuation bet
 statistics for players based on hand actions.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_check_call_raise.py
+++ b/test/test_calc_check_call_raise.py
@@ -5,14 +5,9 @@ This module tests the calcCheckCallRaise functionality which calculates
 check-call and check-raise statistics for players based on hand actions.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import MIN_ACTIONS_FOR_CHECK_CALL_RAISE, DerivedStats
 

--- a/test/test_calc_delayed_cbet.py
+++ b/test/test_calc_delayed_cbet.py
@@ -7,13 +7,9 @@ occurred). These exercise the in-position and out-of-position lines plus the
 edge cases that must NOT count (c-bet flop, check-call flop, facing a turn bet,
 folding the flop, no turn).
 """
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_donk_defense.py
+++ b/test/test_calc_donk_defense.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import _INIT_STATS, DerivedStats
 

--- a/test/test_calc_face_raise.py
+++ b/test/test_calc_face_raise.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_faced_allin.py
+++ b/test/test_calc_faced_allin.py
@@ -7,11 +7,7 @@ decision (PT4 enum_face_allin), modelled as a chance/done boolean pair.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_float_stats.py
+++ b/test/test_calc_float_stats.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import _INIT_STATS, DerivedStats
 

--- a/test/test_calc_flop_bet_facing.py
+++ b/test/test_calc_flop_bet_facing.py
@@ -9,12 +9,8 @@ preflop that seeds a known pot.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_gp_stats.py
+++ b/test/test_calc_gp_stats.py
@@ -9,12 +9,8 @@ being a call in an unraised pot. The denominator is the open opportunity.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_postflop_first_raise.py
+++ b/test/test_calc_postflop_first_raise.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_postflop_open.py
+++ b/test/test_calc_postflop_open.py
@@ -3,11 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_postflop_raise_facing.py
+++ b/test/test_calc_postflop_raise_facing.py
@@ -7,12 +7,8 @@ level 2 (2-bet), a re-raise level 3, etc. Running pot carried across streets.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_preflop_raise_facing.py
+++ b/test/test_calc_preflop_raise_facing.py
@@ -8,12 +8,8 @@ blinds and preflop actions.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_raise_made.py
+++ b/test/test_calc_raise_made.py
@@ -8,12 +8,8 @@ is not a raise and is not counted (PT4 amt_*_raise_made / val_*_raise_made_pct).
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_special_blinds.py
+++ b/test/test_calc_special_blinds.py
@@ -8,11 +8,7 @@ action, so flg_blind_db is never set here.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_squeeze_defense.py
+++ b/test/test_calc_squeeze_defense.py
@@ -9,11 +9,7 @@ before their first preflop action.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_street_spr.py
+++ b/test/test_calc_street_spr.py
@@ -8,12 +8,8 @@ min(own remaining, deepest active opponent). Stored as count + SPR*100.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Stats as Stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_calc_turn_probe.py
+++ b/test/test_calc_turn_probe.py
@@ -5,13 +5,9 @@ Turn probe = a NON-PFR opens the turn after the PFR checked the flop (declined
 the c-bet). The first eligible non-PFR to act with no bet in front of them is
 credited a chance; a bet/raise there is a done. Mirror of the delayed c-bet.
 """
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_calc_turn_river_bet_facing.py
+++ b/test/test_calc_turn_river_bet_facing.py
@@ -7,12 +7,8 @@ across all streets.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal as D
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_card_comprehensive.py
+++ b/test/test_card_comprehensive.py
@@ -5,15 +5,11 @@ This test suite provides complete coverage for all functions in the Card.py modu
 including edge cases and error conditions.
 """
 
-import os
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
 # Add the parent directory to the path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.Card import (
     HOLDEM_UNKNOWN_HAND,
     StartCardRank,

--- a/test/test_cashout_fees_migration.py
+++ b/test/test_cashout_fees_migration.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 """Tests for cash out fees database schema migration."""
 
-import os
-import sys
 import unittest
 from unittest.mock import Mock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.Database import HANDS_PLAYERS_KEYS
 from fpdb_3_legacy.SQL import Sql

--- a/test/test_cashout_fees_storage.py
+++ b/test/test_cashout_fees_storage.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """Tests for cash out fees database storage functionality."""
 
-import os
-import sys
 import unittest
 from decimal import Decimal
 from unittest.mock import Mock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.Database import HANDS_PLAYERS_KEYS
 from fpdb_3_legacy.DerivedStats import _INIT_STATS, CENTS_MULTIPLIER, DerivedStats

--- a/test/test_config_db_parameters.py
+++ b/test/test_config_db_parameters.py
@@ -12,12 +12,9 @@ from __future__ import annotations
 import os
 import re
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Configuration
 

--- a/test/test_config_initializer.py
+++ b/test/test_config_initializer.py
@@ -6,14 +6,11 @@ Unit tests for the ConfigInitializer class.
 Tests configuration initialization, fallback mechanisms, and error handling.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock, patch
 
 # Add the parent directory to the path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.ConfigInitializer import ConfigInitializer, ensure_config_initialized
 
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,10 +1,7 @@
-import sys
-from pathlib import Path
 from xml.dom.minidom import Document, parseString
 
 import pytest
 
-sys.path.append(str(Path(__file__).parent.parent))
 from fpdb_3_legacy.Configuration import Config, RawHands, RawTourneys
 
 

--- a/test/test_custom_themes.py
+++ b/test/test_custom_themes.py
@@ -6,17 +6,13 @@ Unit tests for custom theme functionality in ThemeManager.
 Tests custom theme installation, validation, removal, and application.
 """
 
-import os
 import shutil
 
 # Add the parent directory to the path to import our modules
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fpdb_3_legacy.ThemeManager import CUSTOM_THEMES_DIR, ThemeManager
 

--- a/test/test_database_isolation.py
+++ b/test/test_database_isolation.py
@@ -8,11 +8,7 @@ old integers onto the ``autocommit`` flag so both drivers work.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Database
 

--- a/test/test_db_backends.py
+++ b/test/test_db_backends.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import db_backends
 

--- a/test/test_db_migrate.py
+++ b/test/test_db_migrate.py
@@ -11,11 +11,8 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Configuration, db_migrate
 

--- a/test/test_dialects.py
+++ b/test/test_dialects.py
@@ -3,13 +3,9 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import dialects
 

--- a/test/test_disabled_sites.py
+++ b/test/test_disabled_sites.py
@@ -9,11 +9,7 @@ with, and the live-capture menu entry.
 
 from __future__ import annotations
 
-import os
-import sys
 from xml.dom.minidom import parseString
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Configuration import HHC, Site
 from fpdb_3_legacy.disabled_sites import DISABLED_SITES, is_site_disabled

--- a/test/test_fast_fold_engine_resilience.py
+++ b/test/test_fast_fold_engine_resilience.py
@@ -13,13 +13,9 @@ Windows and a Linux seat reader.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.fast_fold_engine import FastFoldEngine, is_fast_fold_table
 

--- a/test/test_fast_fold_first_hand_stats.py
+++ b/test/test_fast_fold_first_hand_stats.py
@@ -20,13 +20,10 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Configuration, HUD_main
 from fpdb_3_legacy.fast_fold_engine import FastFoldEngine, FastFoldStatsRequest

--- a/test/test_fast_fold_idle_sweep.py
+++ b/test/test_fast_fold_idle_sweep.py
@@ -14,14 +14,10 @@ A table nobody has said anything about for a while is now asked directly.
 
 from __future__ import annotations
 
-import os
-import sys
 import time
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import HUD_main
 

--- a/test/test_fastfold_cross_platform_contract.py
+++ b/test/test_fastfold_cross_platform_contract.py
@@ -24,15 +24,12 @@ implementation inherits them by existing rather than by remembering to.
 from __future__ import annotations
 
 import ast
-import os
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import winamax_ax_seats as ax
 from fpdb_3_legacy.winamax_ax_seats import AXSeat, WinamaxAXSeatReader, seat_slots_from_positions

--- a/test/test_fastfold_support_modules.py
+++ b/test/test_fastfold_support_modules.py
@@ -10,13 +10,10 @@ macOS is often ordinary elsewhere.
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import hud_diagnostics
 from fpdb_3_legacy.hud_window_registry import HudWindowRegistry

--- a/test/test_find_hud_windows.py
+++ b/test/test_find_hud_windows.py
@@ -18,8 +18,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from tools.find_hud_windows import (
     Window,
     group_by_process,

--- a/test/test_get_player_id_missing.py
+++ b/test/test_get_player_id_missing.py
@@ -11,11 +11,7 @@ not been imported under yet.
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Database
 

--- a/test/test_ggpoker_tablename.py
+++ b/test/test_ggpoker_tablename.py
@@ -10,13 +10,9 @@ tournament number, leaving a bare "249773363 ".
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.GGPokerToFpdb import GGPoker
 

--- a/test/test_gui_database.py
+++ b/test/test_gui_database.py
@@ -4,14 +4,12 @@
 from __future__ import annotations
 
 import os
-import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 pytest.importorskip("PySide6")
 

--- a/test/test_guiautoimport_headless.py
+++ b/test/test_guiautoimport_headless.py
@@ -19,7 +19,6 @@ import pytest
 # GuiAutoImport uses legacy-style bare imports (e.g. ``import interlocks``), so
 # the fpdb_3_legacy package directory must be importable directly.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def _make_settings(lock):

--- a/test/test_guibulkimport_cli.py
+++ b/test/test_guibulkimport_cli.py
@@ -6,12 +6,8 @@ point the TestHandsPlayers (THP) regression workflow depends on. These tests
 cover its argument contract; the import engine itself is exercised elsewhere.
 """
 
-import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import GuiBulkImport
 

--- a/test/test_guibulkimport_move_widgets.py
+++ b/test/test_guibulkimport_move_widgets.py
@@ -10,13 +10,11 @@ importer via _apply_move_settings. The Importer is mocked so no DB is needed.
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 pytest.importorskip("PySide6")
 

--- a/test/test_hand_cashout_pot.py
+++ b/test/test_hand_cashout_pot.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """Tests for Hand.addCashOutPot method."""
 
-import os
-import sys
 import unittest
 from decimal import Decimal
 from unittest.mock import Mock
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.Hand import HoldemOmahaHand
 

--- a/test/test_hand_completeness_check.py
+++ b/test/test_hand_completeness_check.py
@@ -11,14 +11,10 @@ warning about it reported a parser failure that had not happened.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.HandHistoryConverter import HandHistoryConverter
 from fpdb_3_legacy.WinamaxToFpdb import Winamax

--- a/test/test_handsplayers_insert_alignment.py
+++ b/test/test_handsplayers_insert_alignment.py
@@ -4,12 +4,8 @@ must stay aligned. A mismatch silently breaks every hand import, so this is a
 cheap canary whenever someone adds a persisted HandsPlayers column.
 """
 
-import os
 import sqlite3
-import sys
 from contextlib import closing
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import SQL
 from fpdb_3_legacy.Database import CACHE_KEYS, HANDS_PLAYERS_KEYS, HUDCACHE_EXTRA_KEYS

--- a/test/test_hh_path_detection.py
+++ b/test/test_hh_path_detection.py
@@ -11,12 +11,9 @@ silently skipped the site.
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Configuration
 

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -5,13 +5,11 @@ Test suite for the HUD management system.
 """
 
 import contextlib
-import os
 import sys
 import unittest
 from unittest.mock import Mock, patch
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def _setup_hud_mocks(original_modules: dict) -> None:

--- a/test/test_hud_db_outage.py
+++ b/test/test_hud_db_outage.py
@@ -24,8 +24,6 @@ import pytest
 
 pytestmark = pytest.mark.qt
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 
 def _load_hud_main():
     """Load HUD_main.pyw, reusing the instance another test module loaded.

--- a/test/test_hud_diagnostics.py
+++ b/test/test_hud_diagnostics.py
@@ -9,11 +9,8 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import hud_diagnostics
 from fpdb_3_legacy.hud_diagnostics import (

--- a/test/test_hud_display_no_data.py
+++ b/test/test_hud_display_no_data.py
@@ -6,7 +6,6 @@ between 0 (real value) and "-" (no data available) in the interface.
 """
 
 import os
-import sys
 from unittest.mock import Mock
 
 # Set Qt to use offscreen platform for headless CI environments
@@ -16,9 +15,6 @@ import pytest
 
 pytestmark = pytest.mark.qt
 from PySide6.QtWidgets import QLabel
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import HUD components
 from fpdb_3_legacy.Aux_Classic_Hud import ClassicStat

--- a/test/test_hud_display_simplified.py
+++ b/test/test_hud_display_simplified.py
@@ -5,13 +5,8 @@ This module focuses on testing the core Stats.py functionality integration
 with HUD display without complex PyQt5 mocking.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import only what we need
 import fpdb_3_legacy.Stats as Stats

--- a/test/test_hud_interactive_manual.py
+++ b/test/test_hud_interactive_manual.py
@@ -5,15 +5,11 @@ This script creates a real HUD display window that stays open for manual verific
 of the "-" vs "0" distinction. Close the window to exit.
 """
 
-import os
 import sys
 from unittest.mock import Mock
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QMainWindow, QPushButton, QVBoxLayout, QWidget
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Aux_Hud import SimpleStat
 

--- a/test/test_hud_label_teardown.py
+++ b/test/test_hud_label_teardown.py
@@ -11,11 +11,8 @@ main window.
 from __future__ import annotations
 
 import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_hud_menu_teardown.py
+++ b/test/test_hud_menu_teardown.py
@@ -12,14 +12,11 @@ menu then merely uncovered the one behind it, so Close looked inoperative.
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_hud_overlay_leak.py
+++ b/test/test_hud_overlay_leak.py
@@ -20,15 +20,12 @@ and destroying the aux leaves nothing behind.
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import Mock
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 sys.modules.setdefault("PySide6", Mock())
 sys.modules.setdefault("PySide6.QtWidgets", Mock())

--- a/test/test_hud_popup_complete.py
+++ b/test/test_hud_popup_complete.py
@@ -5,8 +5,6 @@ This module provides comprehensive tests for popup windows and their interaction
 with the "no data" feature, with fully resolved mocking issues.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
@@ -15,9 +13,6 @@ pytestmark = pytest.mark.qt
 from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import HUD components
 import fpdb_3_legacy.Stats as Stats

--- a/test/test_hud_popup_tooltips.py
+++ b/test/test_hud_popup_tooltips.py
@@ -5,8 +5,6 @@ This module tests the PyQt5 HUD popup windows and tooltip functionality to ensur
 proper display of "-" vs "0" values in extended stat views.
 """
 
-import os
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,9 +13,6 @@ pytestmark = pytest.mark.qt
 from PySide6.QtCore import QPoint, Qt
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QLabel
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import HUD components
 import fpdb_3_legacy.Popup as Popup

--- a/test/test_hud_restart_remediation.py
+++ b/test/test_hud_restart_remediation.py
@@ -5,15 +5,11 @@ This module tests the improved error handling, smart restart logic,
 and statistics persistence to prevent regressions.
 """
 
-import os
-import sys
 import time
 
 import pytest
 
 # Add parent directory to path for module imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 # Import modules to test
 from fpdb_3_legacy.HudStatsPersistence import HudStatsPersistence
 from fpdb_3_legacy.ImprovedErrorHandler import ErrorSeverity, ImprovedErrorHandler

--- a/test/test_hud_simple.py
+++ b/test/test_hud_simple.py
@@ -4,13 +4,11 @@
 Simplified test suite for the HUD management system.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock, patch
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestImportName(unittest.TestCase):

--- a/test/test_hud_single_renderer_regression.py
+++ b/test/test_hud_single_renderer_regression.py
@@ -22,8 +22,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from fpdb_3_legacy import HUD_main
 from fpdb_3_legacy.hud_window_registry import ClaimOutcome, HudWindowRegistry
 from fpdb_3_legacy.interlocks import acquire_hud_instance_lock

--- a/test/test_hud_visual_display.py
+++ b/test/test_hud_visual_display.py
@@ -5,8 +5,6 @@ This module creates tests that actually show the HUD on screen for visual verifi
 of the "-" vs "0" distinction in real GUI components.
 """
 
-import os
-import sys
 from unittest.mock import Mock
 
 import pytest
@@ -14,9 +12,6 @@ import pytest
 pytestmark = pytest.mark.qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QMainWindow, QVBoxLayout, QWidget
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import HUD components
 from fpdb_3_legacy.Aux_Classic_Hud import ClassicStat

--- a/test/test_hudcache_schema_sync.py
+++ b/test/test_hudcache_schema_sync.py
@@ -11,15 +11,11 @@ The structural tests below catch any future drift between ``CACHE_KEYS``,
 ``insert_hudcache`` and ``update_hudcache``.
 """
 
-import os
 import re
 import sqlite3
-import sys
 from contextlib import closing
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import fpdb_3_legacy.Database as Database
 import fpdb_3_legacy.SQL as SQL

--- a/test/test_identify_site_imports.py
+++ b/test/test_identify_site_imports.py
@@ -7,12 +7,8 @@ loaded zero sites ("Could not find module ..., skipping"). They now resolve via
 ``import_fpdb_module()``, which imports the package-qualified module.
 """
 
-import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Configuration as Configuration
 from fpdb_3_legacy.IdentifySite import IdentifySite, import_fpdb_module

--- a/test/test_importer_errors.py
+++ b/test/test_importer_errors.py
@@ -1,13 +1,9 @@
 import os
 import re  # Import re for Site
-import sys
 import time
 from unittest.mock import MagicMock, Mock, patch  # Import Mock and MagicMock
 
 import pytest
-
-# Add project path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.Database as Database  # Import Database for patching
 from fpdb_3_legacy.IdentifySite import FPDBFile, Site

--- a/test/test_importer_move_files.py
+++ b/test/test_importer_move_files.py
@@ -10,12 +10,7 @@ failed dir. These tests exercise the relocation helper directly (no DB needed).
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.IdentifySite import FPDBFile
 from fpdb_3_legacy.Importer import Importer

--- a/test/test_interlocks_complete.py
+++ b/test/test_interlocks_complete.py
@@ -25,8 +25,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from fpdb_3_legacy import interlocks
 
 

--- a/test/test_ipoker_skin_identity.py
+++ b/test/test_ipoker_skin_identity.py
@@ -10,11 +10,7 @@ PMU Poker file as "Redbet Poker (no changes)".
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.iPoker.base import iPoker
 from fpdb_3_legacy.iPoker.skins.pmu import PMUIPoker

--- a/test/test_ipoker_tournament_detection.py
+++ b/test/test_ipoker_tournament_detection.py
@@ -16,13 +16,10 @@ from __future__ import annotations
 
 import glob
 import os
-import sys
 import tempfile
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Configuration import Config
 from fpdb_3_legacy.iPokerToFpdb import iPoker

--- a/test/test_ipoker_twister_table_identity.py
+++ b/test/test_ipoker_twister_table_identity.py
@@ -19,12 +19,7 @@ one. Three defects combined to make that happen:
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.iPoker.xml_format import IPokerXMLFormatMixin
 from fpdb_3_legacy.iPokerToFpdb import iPoker

--- a/test/test_l10n_config_path.py
+++ b/test/test_l10n_config_path.py
@@ -7,10 +7,6 @@ it read ``CONFIG_PATH/HUD_config.xml`` directly. It must now resolve the config
 path gracefully and never crash startup.
 """
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import L10n
 

--- a/test/test_modern_hud_preferences.py
+++ b/test/test_modern_hud_preferences.py
@@ -4,13 +4,11 @@
 Test suite for the AddStatDialog class focusing on stat_loth and stat_hith validation.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestAddStatDialog(unittest.TestCase):

--- a/test/test_modern_popup.py
+++ b/test/test_modern_popup.py
@@ -4,13 +4,11 @@
 Comprehensive test suite for the modern popup system.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestModernStatRow(unittest.TestCase):

--- a/test/test_modern_popup_improvements.py
+++ b/test/test_modern_popup_improvements.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 """Test to validate modern popup improvements."""
 
-import sys
-from pathlib import Path
-
-# Add the main directory to sys.path to import FPDB modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 
 def _setup_popup_components() -> bool:
     """Setup popup components for testing."""

--- a/test/test_modern_popup_initialization.py
+++ b/test/test_modern_popup_initialization.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 """Test to verify the fix for ModernSubmenu initialization bug."""
 
-import sys
-from pathlib import Path
-
-# Add the main directory to sys.path to import FPDB modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 
 def _test_theme_methods(theme) -> None:
     """Test that the theme has the required methods."""

--- a/test/test_multiblock_hud.py
+++ b/test/test_multiblock_hud.py
@@ -8,7 +8,6 @@ stat-sets) and Aux_Hud rendering of stacked per-block grids in a seat window.
 from __future__ import annotations
 
 import os
-import sys
 import types
 
 # Only inline trusted XML literals are parsed here (no external input / DTD),
@@ -18,8 +17,6 @@ import xml.dom.minidom as minidom
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_multibox_preview.py
+++ b/test/test_multibox_preview.py
@@ -8,13 +8,10 @@ coloured title header and a grid of cells using per-stat hudcolor/hudbgcolor.
 from __future__ import annotations
 
 import os
-import sys
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_osx_tables.py
+++ b/test/test_osx_tables.py
@@ -14,14 +14,11 @@ contract and must not be able to change what macOS asks of it.
 
 from __future__ import annotations
 
-import os
 import sys
 import types
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 @pytest.fixture(scope="module")

--- a/test/test_pokerstars_addcollectpot_adjustments.py
+++ b/test/test_pokerstars_addcollectpot_adjustments.py
@@ -1,12 +1,8 @@
-import os
-import sys
 import unittest
 from decimal import Decimal
 from unittest.mock import Mock
 
 # Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 
 

--- a/test/test_pokerstars_bovada_adjustments.py
+++ b/test/test_pokerstars_bovada_adjustments.py
@@ -1,11 +1,7 @@
-import os
-import sys
 import unittest
 from unittest.mock import Mock
 
 # Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.PokerStarsToFpdb import SITE_MERGE, PokerStars
 
 

--- a/test/test_pokerstars_cashout.py
+++ b/test/test_pokerstars_cashout.py
@@ -2,12 +2,9 @@
 """Test cash out functionality for PokerStars parser."""
 
 import os
-import sys
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 

--- a/test/test_pokerstars_cashout_issue98.py
+++ b/test/test_pokerstars_cashout_issue98.py
@@ -7,13 +7,9 @@ out)". The parser used to count both that $X and the cash-out amount, inflating
 winnings (won 35.71 instead of 15.82, net 25.29 instead of 5.40).
 """
 
-import os
-import sys
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 

--- a/test/test_pokerstars_error_cases.py
+++ b/test/test_pokerstars_error_cases.py
@@ -6,12 +6,9 @@ These tests verify handling of problematic hands identified in import reports.
 """
 
 import os
-import sys
 import unittest
 
 # Add parent directory to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 from fpdb_3_legacy.Configuration import Config
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 

--- a/test/test_pokerstars_readhandinfo.py
+++ b/test/test_pokerstars_readhandinfo.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import unittest
 from unittest.mock import Mock, patch
-
-# Add the parent directory to Python path to import fpdb modules
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, parent_dir)
 
 from fpdb_3_legacy.Exceptions import FpdbHandPartial, FpdbParseError
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars

--- a/test/test_pokerstars_readplayerstacks.py
+++ b/test/test_pokerstars_readplayerstacks.py
@@ -2,14 +2,10 @@
 Comprehensive tests for PokerStarsToFpdb.readPlayerStacks method.
 """
 
-import os
-import sys
 import unittest
 from unittest.mock import Mock
 
 # Add parent directory to path to import modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 
 

--- a/test/test_pokerstars_showdown.py
+++ b/test/test_pokerstars_showdown.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import unittest
 from unittest.mock import Mock
-
-# Add the parent directory to sys.path to import modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fpdb_3_legacy.PokerStarsToFpdb import PokerStars
 

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -4,13 +4,11 @@
 Test suite for popup window functionality.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock, patch
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestPopupBase(unittest.TestCase):

--- a/test/test_popup_icons.py
+++ b/test/test_popup_icons.py
@@ -4,13 +4,9 @@
 Test suite for the modern popup icon system.
 """
 
-import os
-import sys
 import unittest
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.PopupIcons import (
     AVAILABLE_PROVIDERS,
     EmojiIconProvider,

--- a/test/test_popup_performance.py
+++ b/test/test_popup_performance.py
@@ -10,7 +10,6 @@ what the ``perf`` marker is for - the default run deselects it, and these are
 run on demand with ``pytest -m perf``.
 """
 
-import os
 import sys
 import time
 import unittest
@@ -19,7 +18,6 @@ from unittest.mock import Mock
 import pytest
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 pytestmark = pytest.mark.perf
 

--- a/test/test_popup_simple.py
+++ b/test/test_popup_simple.py
@@ -4,7 +4,6 @@
 Simplified test suite for popup window functionality.
 """
 
-import os
 import sys
 import unittest
 from unittest.mock import Mock, patch
@@ -14,7 +13,6 @@ import pytest
 pytestmark = pytest.mark.qt
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestPopupBasics(unittest.TestCase):

--- a/test/test_popup_themes.py
+++ b/test/test_popup_themes.py
@@ -4,13 +4,9 @@
 Test suite for the modern popup theme system.
 """
 
-import os
-import sys
 import unittest
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.PopupThemes import (
     AVAILABLE_THEMES,
     ClassicTheme,

--- a/test/test_popup_xml_config.py
+++ b/test/test_popup_xml_config.py
@@ -5,12 +5,10 @@ Test suite for validating HUD_config.xml popup configurations.
 """
 
 import os
-import sys
 import unittest
 import xml.etree.ElementTree as ET
 
 # Add the parent directory to Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestPopupXMLConfiguration(unittest.TestCase):

--- a/test/test_pot_eval_excludes_folders.py
+++ b/test/test_pot_eval_excludes_folders.py
@@ -11,14 +11,10 @@ out negative, which is how these hands were found in the wild.
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fpdb_3_legacy.DerivedStats as _derived_stats
 from fpdb_3_legacy.DerivedStats import DerivedStats

--- a/test/test_pt4_adapter.py
+++ b/test/test_pt4_adapter.py
@@ -1,9 +1,5 @@
 """Test suite for PT4 adapter module."""
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.pt4_adapter import Pt4Config, Pt4PlayerStat, StatComparison
 from fpdb_3_legacy.pt4_adapter.comparator import _compare_bool, _compare_ratio

--- a/test/test_pt4_ipoker.py
+++ b/test/test_pt4_ipoker.py
@@ -1,10 +1,5 @@
 """Test script for PokerTracker4 iPoker hands parsing."""
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent))
-
 from fpdb_3_legacy.Configuration import Config
 from fpdb_3_legacy.PokerTrackerToFpdb import PokerTracker
 

--- a/test/test_pt4hud_import.py
+++ b/test/test_pt4hud_import.py
@@ -10,13 +10,10 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_pt4hud_parser.py
+++ b/test/test_pt4hud_parser.py
@@ -20,8 +20,6 @@ import xml.dom.minidom as minidom
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from fpdb_3_legacy import pt4hud
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "generationpoker_3h.pt4hud")

--- a/test/test_range_chart_popup.py
+++ b/test/test_range_chart_popup.py
@@ -8,13 +8,10 @@ Covers the hand->matrix mapping, the contrast-text helper, and the rendered
 from __future__ import annotations
 
 import os
-import sys
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 

--- a/test/test_set_positions.py
+++ b/test/test_set_positions.py
@@ -2,15 +2,11 @@
 
 """Test suite for setPositions method in DerivedStats."""
 
-import os
-import sys
 from decimal import Decimal
 
 import pytest
 
 # Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.DerivedStats import _INIT_STATS, DerivedStats
 
 

--- a/test/test_site_identification.py
+++ b/test/test_site_identification.py
@@ -1,10 +1,5 @@
 """Test script for site identification with PokerTracker4 iPoker hands."""
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent))
-
 from fpdb_3_legacy.Configuration import Config
 from fpdb_3_legacy.IdentifySite import IdentifySite
 

--- a/test/test_stats_100_coverage.py
+++ b/test/test_stats_100_coverage.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 """100% coverage tests for Stats.py - targets all missing branches."""
 
-import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     __stat_override,

--- a/test/test_stats_advanced.py
+++ b/test/test_stats_advanced.py
@@ -10,13 +10,8 @@ This module tests the newly implemented advanced statistics:
 - Probe Bet River
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     cb_ip,

--- a/test/test_stats_blocks_bc.py
+++ b/test/test_stats_blocks_bc.py
@@ -9,10 +9,6 @@ Targets previously-uncovered lines in ``fpdb_3_legacy/Stats.py``:
   non-zero data so the division is actually performed.
 """
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Stats
 from fpdb_3_legacy.Stats import (

--- a/test/test_stats_continuation_donk.py
+++ b/test/test_stats_continuation_donk.py
@@ -5,13 +5,8 @@ This module tests the newly implemented format_no_data_stat functionality
 for cb1, cb2, cb3, cb4, dbr1, and dbr2 statistics.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     cb1,

--- a/test/test_stats_final.py
+++ b/test/test_stats_final.py
@@ -7,13 +7,8 @@ This module tests the newly implemented final statistics:
 - Overbet Frequency
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     avg_bet_size_flop,

--- a/test/test_stats_fold_checkraise.py
+++ b/test/test_stats_fold_checkraise.py
@@ -5,13 +5,8 @@ This module tests the fold frequency and check-raise statistics to ensure
 proper distinction between 0 (real value) and "-" (no data available).
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     cr1,

--- a/test/test_stats_full_coverage.py
+++ b/test/test_stats_full_coverage.py
@@ -6,8 +6,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from fpdb_3_legacy.Stats import STATLIST, do_stat
 
 # Sample stat_dict for testing most stats

--- a/test/test_stats_main_branch.py
+++ b/test/test_stats_main_branch.py
@@ -8,8 +8,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 def test_deprecated_stats():
     """Test deprecated stats return format_no_data_stat tuples."""

--- a/test/test_stats_new_preflop.py
+++ b/test/test_stats_new_preflop.py
@@ -11,13 +11,8 @@ This module tests the newly implemented preflop statistics:
 - Fold vs 4bet
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     call_vs_steal,

--- a/test/test_stats_no_data_additional.py
+++ b/test/test_stats_no_data_additional.py
@@ -5,13 +5,8 @@ This module tests the newly implemented format_no_data_stat functionality
 for additional steal and ratio statistics.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     f_steal,

--- a/test/test_stats_no_data_extended.py
+++ b/test/test_stats_no_data_extended.py
@@ -5,13 +5,8 @@ This module tests the newly implemented format_no_data_stat functionality
 for additional statistics like wtsd, wmsd, 4bet, etc.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     cfour_B,

--- a/test/test_stats_no_data_feature.py
+++ b/test/test_stats_no_data_feature.py
@@ -5,13 +5,8 @@ This module tests the distinction between 0 (real value) and "-" (no data availa
 in HUD statistics display, ensuring proper user experience.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     a_freq1,

--- a/test/test_stats_postflop_3bet.py
+++ b/test/test_stats_postflop_3bet.py
@@ -3,11 +3,6 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import fpdb_3_legacy.Stats as Stats
 
 

--- a/test/test_stats_postflop_new.py
+++ b/test/test_stats_postflop_new.py
@@ -6,13 +6,8 @@ This module tests the newly implemented postflop statistics:
 - Probe Bet (probe)
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     float_bet,

--- a/test/test_stats_regression.py
+++ b/test/test_stats_regression.py
@@ -5,13 +5,8 @@ This module tests potential regressions introduced by the "no data" feature
 modifications to ensure compatibility with existing functionality.
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     a_freq1,

--- a/test/test_stats_squeeze_limpers.py
+++ b/test/test_stats_squeeze_limpers.py
@@ -3,11 +3,6 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import fpdb_3_legacy.Stats as Stats
 
 

--- a/test/test_stats_winrate_frequency.py
+++ b/test/test_stats_winrate_frequency.py
@@ -8,13 +8,8 @@ This module tests the newly implemented statistics:
 - Raise Frequency (Flop, Turn)
 """
 
-import os
-import sys
 
 import pytest
-
-# Add the project root to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Stats import (
     bet_frequency_flop,

--- a/test/test_stud_34bet.py
+++ b/test/test_stud_34bet.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python
 """Test suite for Stud 3/4-bet functionality in DerivedStats."""
 
-import os
-import sys
 from decimal import Decimal
 from unittest.mock import Mock
 
 import pytest
 
 # Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 import fpdb_3_legacy.Card as Card
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_stud_positions.py
+++ b/test/test_stud_positions.py
@@ -2,15 +2,11 @@
 
 """Test suite for Stud positions and bring-in handling in DerivedStats."""
 
-import os
 
 # Add parent directory to path
-import sys
 from unittest.mock import Mock
 
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fpdb_3_legacy.DerivedStats import _INIT_STATS, DerivedStats
 

--- a/test/test_stud_steals.py
+++ b/test/test_stud_steals.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python
 """Test suite for Stud steal functionality in DerivedStats."""
 
-import os
-import sys
 from decimal import Decimal
 from unittest.mock import Mock
 
 import pytest
 
 # Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 import fpdb_3_legacy.Card as Card
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_swc_capture_gate.py
+++ b/test/test_swc_capture_gate.py
@@ -24,7 +24,6 @@ import pytest
 # GuiAutoImport uses legacy-style bare imports, so the package directory itself
 # must be importable (same as test_guiautoimport_headless).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def _make_config(swc_parameters):

--- a/test/test_swc_partial_message.py
+++ b/test/test_swc_partial_message.py
@@ -13,13 +13,9 @@ report through HandHistoryConverter.raise_summary_partial().
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.Exceptions import FpdbHandPartial
 from fpdb_3_legacy.HandHistoryConverter import HandHistoryConverter

--- a/test/test_tab_opening_ui_responsiveness.py
+++ b/test/test_tab_opening_ui_responsiveness.py
@@ -21,11 +21,8 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import Configuration
 from fpdb_3_legacy.ui_instrumentation import UI_STALL_BUDGET_MS, TabOpenProfiler, UiStallMonitor

--- a/test/test_table_window.py
+++ b/test/test_table_window.py
@@ -9,15 +9,12 @@ HUD.
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Light Qt stubs so the module imports without a real display.
 sys.modules.setdefault("PySide6", Mock())

--- a/test/test_theme_config_integration.py
+++ b/test/test_theme_config_integration.py
@@ -6,14 +6,10 @@ Integration tests for theme functionality with ConfigurationManager and ConfigOb
 Tests the complete configuration change workflow for themes.
 """
 
-import os
-import sys
 import unittest
 from unittest.mock import Mock, patch
 
 # Add the parent directory to the path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from fpdb_3_legacy.ConfigObservers import GuiPrefsObserver
 from fpdb_3_legacy.ConfigurationManager import ChangeType, ConfigChange, ConfigurationManager
 from fpdb_3_legacy.ThemeManager import ThemeManager

--- a/test/test_theme_creator_dialog.py
+++ b/test/test_theme_creator_dialog.py
@@ -7,7 +7,6 @@ Tests the UI components and theme creation functionality.
 """
 
 import os
-import sys
 import unittest
 from unittest.mock import Mock, patch
 
@@ -18,7 +17,6 @@ pytestmark = pytest.mark.qt
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 # Add the parent directory to the path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Only run GUI tests if we're in a GUI environment
 try:

--- a/test/test_theme_manager.py
+++ b/test/test_theme_manager.py
@@ -6,14 +6,10 @@ Unit tests for the ThemeManager class.
 Tests theme persistence, synchronization, and configuration integration.
 """
 
-import os
 
 # Add the parent directory to the path to import our modules
-import sys
 import unittest
 from unittest.mock import Mock, patch
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fpdb_3_legacy.ThemeManager import ThemeManager
 

--- a/test/test_translations.py
+++ b/test/test_translations.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
 
 import menu_layout

--- a/test/test_ui_instrumentation.py
+++ b/test/test_ui_instrumentation.py
@@ -8,13 +8,9 @@ is none.
 
 from __future__ import annotations
 
-import os
-import sys
 import time
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.ui_instrumentation import (
     UI_STALL_BUDGET_MS,

--- a/test/test_unibet_action_suffix.py
+++ b/test/test_unibet_action_suffix.py
@@ -12,12 +12,7 @@ negative.
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.UnibetToFpdb import Unibet
 

--- a/test/test_unibet_collect_pot.py
+++ b/test/test_unibet_collect_pot.py
@@ -16,12 +16,7 @@ add up to the pot, and they are what re_CollectPot reads.
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.UnibetToFpdb import Unibet
 

--- a/test/test_unibet_uncalled_bet.py
+++ b/test/test_unibet_uncalled_bet.py
@@ -11,12 +11,7 @@ came out negative.
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy.UnibetToFpdb import Unibet
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,13 +2,10 @@
 
 """Final test suite for utility methods in DerivedStats.py."""
 
-import os
-import sys
+
+from unittest.mock import Mock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from unittest.mock import Mock
 
 from fpdb_3_legacy.DerivedStats import DerivedStats
 

--- a/test/test_winamax_ax_seats_macos.py
+++ b/test/test_winamax_ax_seats_macos.py
@@ -17,13 +17,10 @@ macOS path with it.
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import winamax_ax_seats as ax
 from fpdb_3_legacy.winamax_ax_seats import AXSeat, AXTableWindow, WinamaxAXSeatReader

--- a/test/test_winamax_ax_seats_windows.py
+++ b/test/test_winamax_ax_seats_windows.py
@@ -18,14 +18,11 @@ regression without a Windows machine.
 
 from __future__ import annotations
 
-import os
 import sys
 import types
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import winamax_ax_seats as ax
 from fpdb_3_legacy.winamax_ax_seats import WinamaxAXSeatReader

--- a/test/test_winamax_live_log_reader_tailing.py
+++ b/test/test_winamax_live_log_reader_tailing.py
@@ -15,14 +15,11 @@ after the reader started, a read that fails midway, and shutdown.
 from __future__ import annotations
 
 import os
-import sys
 import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fpdb_3_legacy import winamax_live_log_reader as reader_module
 from fpdb_3_legacy.winamax_live_log_reader import (

--- a/test/test_winamax_parser_errors.py
+++ b/test/test_winamax_parser_errors.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 
 from fpdb_3_legacy.Exceptions import FpdbHandPartial, FpdbParseError
 from fpdb_3_legacy.WinamaxToFpdb import Winamax

--- a/test/test_winamax_summary.py
+++ b/test/test_winamax_summary.py
@@ -1,16 +1,11 @@
 """Tests for WinamaxSummary parser."""
 
 import datetime
-import sys
 from decimal import Decimal
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from bs4 import BeautifulSoup
-
-# Add project path for imports
-sys.path.insert(0, str((Path(__file__).parent / "..").resolve()))
 
 from fpdb_3_legacy.Exceptions import FpdbParseError
 from fpdb_3_legacy.WinamaxSummary import WinamaxSummary

--- a/test/test_wintables_coinpoker.py
+++ b/test/test_wintables_coinpoker.py
@@ -6,15 +6,12 @@ sites never finds the table. These tests lock in the special case: broaden the
 search to the client name and keep only the Unity render window.
 """
 
-import os
 import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Light Qt stubs so WinTables imports without a real display.
 sys.modules.setdefault("PySide6", Mock())

--- a/test/test_xml_theme_persistence.py
+++ b/test/test_xml_theme_persistence.py
@@ -7,14 +7,11 @@ This test verifies the complete XML persistence workflow.
 """
 
 import os
-import sys
 import tempfile
 import unittest
 import xml.dom.minidom
 
 # Add the parent directory to the path to import our modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 import fpdb_3_legacy.Configuration as Configuration
 from fpdb_3_legacy.ThemeManager import ThemeManager
 

--- a/test/unit_legacy/test_card_legacy.py
+++ b/test/unit_legacy/test_card_legacy.py
@@ -7,12 +7,7 @@ characterization tests matching current behaviour.
 """
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import Card
 

--- a/test/unit_legacy/test_chipev_graph_sql.py
+++ b/test/unit_legacy/test_chipev_graph_sql.py
@@ -7,11 +7,6 @@ executable-looking SQL.
 """
 from __future__ import annotations
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 from fpdb_3_legacy import SQL
 from fpdb_3_legacy import stat_registry as sr
 from fpdb_3_legacy.stat_adapters import GraphAdapter

--- a/test/unit_legacy/test_deck.py
+++ b/test/unit_legacy/test_deck.py
@@ -6,15 +6,11 @@ QPixmaps are simply blank, which is fine for exercising the pure-logic paths.
 """
 from __future__ import annotations
 
-import os
-import sys
 import types
 
 import pytest
 
 pytestmark = pytest.mark.qt
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 
 @pytest.fixture(scope="module")

--- a/test/unit_legacy/test_exceptions.py
+++ b/test/unit_legacy/test_exceptions.py
@@ -1,12 +1,7 @@
 """Unit tests for fpdb_3_legacy.Exceptions."""
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import Exceptions
 

--- a/test/unit_legacy/test_hud_adapter.py
+++ b/test/unit_legacy/test_hud_adapter.py
@@ -1,12 +1,7 @@
 """Unit tests for the HUD adapter and its do_stat integration."""
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import stat_registry as sr
 from fpdb_3_legacy.stat_adapters import HudAdapter

--- a/test/unit_legacy/test_pt4_import.py
+++ b/test/unit_legacy/test_pt4_import.py
@@ -7,13 +7,9 @@ is tested only when the sample directory is present.
 
 from __future__ import annotations
 
-import os
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import pt4_import as pt4
 from fpdb_3_legacy import stat_registry as sr

--- a/test/unit_legacy/test_pt4_standard_stats.py
+++ b/test/unit_legacy/test_pt4_standard_stats.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import stat_registry as sr
 

--- a/test/unit_legacy/test_stat_adapters_graph.py
+++ b/test/unit_legacy/test_stat_adapters_graph.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import stat_registry as sr
 from fpdb_3_legacy.stat_adapters import GraphAdapter

--- a/test/unit_legacy/test_stat_adapters_grid.py
+++ b/test/unit_legacy/test_stat_adapters_grid.py
@@ -6,12 +6,7 @@ derived-value computation from a fetched row, without touching a database.
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import stat_registry as sr
 from fpdb_3_legacy.stat_adapters import GridAdapter, dimension_predicate

--- a/test/unit_legacy/test_stat_registry.py
+++ b/test/unit_legacy/test_stat_registry.py
@@ -7,13 +7,9 @@ that loads descriptor files (including the bundled ChipEV-by-position stats).
 
 from __future__ import annotations
 
-import os
-import sys
 from decimal import Decimal
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy import stat_registry as sr
 

--- a/test/unit_legacy/test_tourneysummary.py
+++ b/test/unit_legacy/test_tourneysummary.py
@@ -8,13 +8,9 @@ config provides ``get_import_parameters``.
 from __future__ import annotations
 
 import io
-import os
-import sys
 import types
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from fpdb_3_legacy.TourneySummary import TourneySummary
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# Ensure root is in path
-sys.path.append(os.getcwd())
-
-
 # Mock GUI dependencies only if not installed
 try:
     import PySide6  # noqa: F401 -- availability probe

--- a/tests/test_autoimport_db_outage.py
+++ b/tests/test_autoimport_db_outage.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, patch
 # GuiAutoImport uses legacy-style bare imports, so the package directory must be
 # importable directly.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fpdb_3_legacy")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def _make_gui():


### PR DESCRIPTION
Follow-up to the landmine found while verifying #277. Rebased onto `development`
after #276 merged.

## They were always redundant

`pytest.ini` has set `pythonpath = .` for as long as these lines have existed,
and `python -m pytest` puts the working directory on `sys.path` besides. All 171
files re-added a path that was already there.

## And not free

With the repo root inserted **ahead of site-packages**, `fpdb_3_legacy` can
resolve either from the source tree or from the installed package. A session
that ends up with both identities for the `QObject` subclasses in
`ui_instrumentation` takes pytest-qt's `_process_events` down:

```
test/test_tab_open_reporting.py ....Windows fatal exception: access violation
  File "pytestqt/plugin.py", line 220 in _process_events
```

Reproducible on `development` with no source change, by adding one more test
module that inserts the root and imports from that module. Latent today only
because CI keeps the `qt` and non-`qt` marker sets in separate runs — running
them together now passes (52 passed, where it used to die on the fifth test).

## What went, what stayed

**Removed** — 171 files, 655 lines: nine spellings of "the repo root", the
comments that introduced them (`# Add the project root to the Python path` and
friends), and the `os` / `sys` / `Path` imports left unused. Two `BovadaToFpdb`
files wrapped their imports in a `try/except ImportError` whose only fallback was
such an insert; the plain import is what remains. The rebase picked up one more:
`test_swc_capture_gate.py`, added by #276, had copied the same redundant line.

**Kept**, because they do something:

- `.../fpdb_3_legacy` — `GuiAutoImport` and friends use legacy bare imports
  (`import interlocks`), so that directory has to be importable directly
- `ROOT / "tools"`
- the roots written into generated code that runs in a subprocess

## Verification

Both modes CI runs, re-measured after the rebase, against the current
`development` (whose tree is identical to the run these baselines come from):

| | `-m "not qt and not perf"` | `-m qt` |
|---|---|---|
| `development` | 8293 passed, 6 failed, 42 skipped | 722 passed, 3 failed |
| this branch | 8293 passed, 6 failed, 42 skipped | 722 passed, 3 failed |

Same counts, same test names. Those pre-existing failures are environmental in
this Windows checkout — `os.symlink` without the privilege, four order-dependent
`test_stats_100_coverage` cases that pass in isolation, and two COM-dependent
`test_wintables_coinpoker` ones. None of them are touched by this change.

`ruff` clean across all 171 files.
