### PR TITLE
fix(fastfold): read the whole table at hand start on Windows

### DIFF
--- a/HUD_config.xml.example
+++ b/HUD_config.xml.example
@@ -157,7 +157,14 @@
           16.7 (50 divided by 3) to big blind of 150 (50 times 3) are included
         - To include all levels, use a value of "10000"
 -->
-    <hud_ui stat_range="A" stat_days="90" aggregation_level_multiplier="3" seats_style="A" seats_cust_nums_low="6" seats_cust_nums_high="10" hero_stat_range="A" hero_stat_days="30" hero_aggregation_level_multiplier="1" hero_seats_style="A" hero_seats_cust_nums_low="6" hero_seats_cust_nums_high="10" label="FPDBmenu" card_ht="39" card_wd="28" deck_type="colour" card_back="back04"/>
+    <hud_ui stat_range="A" stat_days="90" aggregation_level_multiplier="3" seats_style="A" seats_cust_nums_low="6" seats_cust_nums_high="10" hero_stat_range="A" hero_stat_days="30" hero_aggregation_level_multiplier="1" hero_seats_style="A" hero_seats_cust_nums_low="6" hero_seats_cust_nums_high="10" label="FPDBmenu" card_ht="39" card_wd="28" deck_type="colour" card_back="back04"
+             fast_fold_seat_wait_ms="500"/>
+    <!-- fast_fold_seat_wait_ms: how long a Fast-Fold table waits for the client
+         log to finish naming its players before showing the ones it has. The log
+         names a player only once they have acted, so a six-handed table is named
+         over several seconds. 500 (the default) shows them as they arrive, one
+         block at a time; a larger value, say 5000, shows them together but later.
+         0 shows the first player the moment there is one. -->
 
 
     <supported_sites>

--- a/HUD_config.xml.example
+++ b/HUD_config.xml.example
@@ -158,7 +158,14 @@
         - To include all levels, use a value of "10000"
 -->
     <hud_ui stat_range="A" stat_days="90" aggregation_level_multiplier="3" seats_style="A" seats_cust_nums_low="6" seats_cust_nums_high="10" hero_stat_range="A" hero_stat_days="30" hero_aggregation_level_multiplier="1" hero_seats_style="A" hero_seats_cust_nums_low="6" hero_seats_cust_nums_high="10" label="FPDBmenu" card_ht="39" card_wd="28" deck_type="colour" card_back="back04"
-             fast_fold_seat_wait_ms="500"/>
+             fast_fold_seat_wait_ms="500"
+             fast_fold_window_seats="auto"/>
+    <!-- fast_fold_window_seats: "auto" reads a Fast-Fold table's chairs off its
+         window, giving up per table once the client has shown it will not answer
+         usefully; "off" never reads. Each read is a synchronous walk of another
+         process's accessibility tree on the GUI thread (94-218ms on a client
+         that answers), so set it off if your client does not publish its table.
+         The seats then come from the client log, as they already do. -->
     <!-- fast_fold_seat_wait_ms: how long a Fast-Fold table waits for the client
          log to finish naming its players before showing the ones it has. The log
          names a player only once they have acted, so a six-handed table is named

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -1053,6 +1053,8 @@ class HudUI:
     def __init__(self, node) -> None:
         self.node = node
         self.label = node.getAttribute("label")
+        if node.hasAttribute("fast_fold_seat_wait_ms"):
+            self.fast_fold_seat_wait_ms = node.getAttribute("fast_fold_seat_wait_ms")
         if node.hasAttribute("card_ht"):
             self.card_ht = node.getAttribute("card_ht")
         if node.hasAttribute("card_wd"):
@@ -3027,6 +3029,18 @@ class Config:
             hui["aggregate_ring"] = getattr(self.ui, "aggregate_ring", "True")
         except AttributeError:
             hui["aggregate_ring"] = "True"
+
+        # How long a Fast-Fold table waits for the client log to finish naming
+        # its players before it shows the ones it has. The log names a player
+        # only once they have acted, so a six-handed table is named over several
+        # seconds: showing at once means blocks appearing one at a time, waiting
+        # means they appear together but later. Neither is right for everyone,
+        # so it is a number rather than a decision. The default is what the HUD
+        # has always done.
+        try:
+            hui["fast_fold_seat_wait_ms"] = max(0, int(getattr(self.ui, "fast_fold_seat_wait_ms", 500)))
+        except (AttributeError, TypeError, ValueError):
+            hui["fast_fold_seat_wait_ms"] = 500
 
         try:
             hui["aggregate_tour"] = getattr(self.ui, "aggregate_tour", "True")

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -1055,6 +1055,8 @@ class HudUI:
         self.label = node.getAttribute("label")
         if node.hasAttribute("fast_fold_seat_wait_ms"):
             self.fast_fold_seat_wait_ms = node.getAttribute("fast_fold_seat_wait_ms")
+        if node.hasAttribute("fast_fold_window_seats"):
+            self.fast_fold_window_seats = node.getAttribute("fast_fold_window_seats")
         if node.hasAttribute("card_ht"):
             self.card_ht = node.getAttribute("card_ht")
         if node.hasAttribute("card_wd"):
@@ -3041,6 +3043,18 @@ class Config:
             hui["fast_fold_seat_wait_ms"] = max(0, int(getattr(self.ui, "fast_fold_seat_wait_ms", 500)))
         except (AttributeError, TypeError, ValueError):
             hui["fast_fold_seat_wait_ms"] = 500
+
+        # Whether to read a Fast-Fold table's chairs off its window at all.
+        # "auto" tries, and gives up per table once the client has shown it will
+        # not answer usefully; "off" never tries. Each read is a synchronous
+        # walk of another process's accessibility tree on the GUI thread, 94 to
+        # 218ms on a client that answers, so a player whose client has never
+        # published its felt is paying for it in stutter and nothing else.
+        try:
+            value = str(getattr(self.ui, "fast_fold_window_seats", "auto")).strip().lower()
+        except (AttributeError, TypeError, ValueError):
+            value = "auto"
+        hui["fast_fold_window_seats"] = value if value in ("auto", "off") else "auto"
 
         try:
             hui["aggregate_tour"] = getattr(self.ui, "aggregate_tour", "True")

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -589,6 +589,12 @@ class HudMain(QObject):
     winamax_table_update = Signal(object)
 
     AX_READS_PER_HAND = 6
+
+    #: Consecutive window reads that may come back with nobody on them before
+    #: the reader is given up on for the session. Six per hand, so this is five
+    #: hands of a client that never names a single player -- enough to tell a
+    #: table being redrawn from one whose content is simply not published.
+    AX_FRUITLESS_READS_BEFORE_GIVING_UP = AX_READS_PER_HAND * 5
     """How many times a table's window may be re-read within one hand.
 
     A read costs ~20ms through the macOS accessibility API and 100-300ms
@@ -873,6 +879,10 @@ class HudMain(QObject):
             # per window so two tables do not evict each other, and per hand
             # because each read walks another process's accessibility tree.
             self._ax_rings: dict[str, tuple[str, dict[int, str], int]] = {}
+            # Window reads in a row that found nobody, and whether that has gone
+            # on long enough to stop trying. See AX_FRUITLESS_READS_BEFORE_GIVING_UP.
+            self._ax_fruitless_reads = 0
+            self._ax_reader_gave_up = False
             # Timeline bookkeeping: when each hand's first log line arrived, and
             # which hand/table request is currently allowed to update the HUD.
             self._ff_started: dict[str, float] = {}
@@ -1871,7 +1881,7 @@ class HudMain(QObject):
         reader = getattr(self, "winamax_ax_seats", None)
         table = getattr(hud, "table", None)
         title = getattr(table, "title", "") or ""
-        if reader is None or not title:
+        if reader is None or not title or self._ax_reader_gave_up:
             return {}
 
         table_key = getattr(table, "key", None) or title
@@ -1918,6 +1928,24 @@ class HudMain(QObject):
         # nothing, even with FPDB_HUD_TRACE=1. The seats then come from the log
         # ring, which names a player only once they have acted, and the blocks
         # arrive one at a time; that is what gets reported, with no trace of why.
+        # A client that publishes nothing publishes nothing every time, and each
+        # read is a synchronous walk of another process's tree on the GUI
+        # thread, at hand-start, which is exactly when the HUD is trying to
+        # draw. Measured on a live session: six reads a hand, on two tables,
+        # 15-62ms each, every one of them players=0. Stop paying for it.
+        if best:
+            self._ax_fruitless_reads = 0
+        else:
+            self._ax_fruitless_reads += 1
+            if self._ax_fruitless_reads >= self.AX_FRUITLESS_READS_BEFORE_GIVING_UP:
+                self._ax_reader_gave_up = True
+                log.warning(
+                    "Giving up on the window seat reader after %d reads that found nobody: this client "
+                    "does not publish its table through the accessibility API. Fast-Fold seats come from "
+                    "the client log, which names a player only once they have acted.",
+                    self._ax_fruitless_reads,
+                )
+
         empty = sorted(set(range(max_seats)) - set(best))
         self._ff_trace(
             hand_id,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -25,7 +25,7 @@ if sys.platform.startswith("linux") and os.getenv("FPDB_FORCE_X11") == "1":
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from optparse import Values
 from pathlib import Path
 from queue import Empty, Queue
@@ -136,6 +136,40 @@ class FastFoldQualification:
     info: TableInfo
     table_no: str | None
     site_hand_no: Any
+
+
+@dataclass
+class TableReadState:
+    """What has been learned about reading one table's window.
+
+    Three dictionaries held this, keyed by the table's name, each read and
+    written in a different place and each forgotten -- or not -- on its own. The
+    one that was not forgotten cost a restarted client its seats for a whole
+    session: a pool hands the same name to the next table it opens, so a new HUD
+    inherited "this client will not answer" from a client that had exited.
+
+    One object with one lifetime. Created when a table is first read, dropped
+    whole when it retires, so nothing can be left behind by being overlooked.
+    """
+
+    #: The hand the ring below was read for, the ring itself, and how many reads
+    #: it took. Reset when the hand changes: the seats cannot change within one.
+    hand_id: str | None = None
+    ring: dict[int, str] = field(default_factory=dict)
+    reads: int = 0
+
+    #: Reads in a row that could not seat anyone -- not reads that came back
+    #: empty. A client answering with the hero and one neighbour answers
+    #: non-empty every time and can never be acted on.
+    fruitless: int = 0
+
+    #: Whether the reader has been given up on for this table.
+    gave_up: bool = False
+
+    def start_hand(self, hand_id: str) -> None:
+        """Forget the previous hand's ring, keeping what was learned about the client."""
+        if self.hand_id != hand_id:
+            self.hand_id, self.ring, self.reads = hand_id, {}, 0
 
 
 class ZMQWorker(QThread):
@@ -937,7 +971,6 @@ class HudMain(QObject):
             # window title -> (hand id, slot -> login read off that window). Kept
             # per window so two tables do not evict each other, and per hand
             # because each read walks another process's accessibility tree.
-            self._ax_rings: dict[str, tuple[str, dict[int, str], int]] = {}
             # Window reads in a row that found nobody, and whether that has gone
             # on long enough to stop trying -- both per table. A single counter
             # for the whole session reached its threshold in half the hands with
@@ -953,8 +986,11 @@ class HudMain(QObject):
                 log.debug("Could not read fast_fold_seat_wait_ms; using the default", exc_info=True)
                 self._fast_fold_seat_wait_ms = 500
             self._ff_seat_wait_scheduled: set[tuple[str, str]] = set()
-            self._ax_fruitless_reads: dict[str, int] = {}
-            self._ax_reader_gave_up: dict[str, bool] = {}
+            # What has been learned about reading each table's window: the
+            # per-hand ring, how many reads in a row could not seat anyone, and
+            # whether the reader has been given up on for it. One object with one
+            # lifetime -- see TableReadState.
+            self._table_reads: dict[str, TableReadState] = {}
             # "off" skips the window reader outright. On a client that never
             # publishes its felt, the reads are pure stutter -- and the player
             # who has established that should not have to re-establish it every
@@ -1702,7 +1738,8 @@ class HudMain(QObject):
         # clients the breaker exists to stop reading -- and for a table nobody
         # was even playing. Reported by Codex on the pull request.
         table_key = getattr(table, "key", None) or title
-        if not getattr(self, "_ax_reader_enabled", True) or getattr(self, "_ax_reader_gave_up", {}).get(table_key):
+        reads = getattr(self, "_table_reads", {}).get(table_key)
+        if not getattr(self, "_ax_reader_enabled", True) or (reads is not None and reads.gave_up):
             return None
         try:
             return reader.read_window(
@@ -1990,10 +2027,9 @@ class HudMain(QObject):
         these were safe because they are keyed by name rather than by handle.
         That was the reason they are not. Reported by Codex on the pull request.
         """
-        for name in ("_ax_reader_gave_up", "_ax_fruitless_reads", "_ax_rings"):
-            learned = getattr(self, name, None)
-            if learned is not None:
-                learned.pop(table_key, None)
+        learned = getattr(self, "_table_reads", None)
+        if learned is not None:
+            learned.pop(table_key, None)
 
     def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
         """Drop anything held for a table that is going away.
@@ -2117,11 +2153,13 @@ class HudMain(QObject):
             return {}
 
         table_key = getattr(table, "key", None) or title
-        if self._ax_reader_gave_up.get(table_key):
+        state = self._table_reads.get(table_key)
+        if state is not None and state.gave_up:
             return {}
-        cached_hand, cached_slots, reads = self._ax_rings.get(table_key, (None, {}, 0))
-        if cached_hand != hand_id:
-            cached_slots, reads = {}, 0
+        if state is None:
+            state = self._table_reads.setdefault(table_key, TableReadState())
+        state.start_hand(hand_id)
+        cached_slots, reads = state.ring, state.reads
 
         # The hand-start line beats the client to the draw: read then and only
         # the hero is on the table yet. So keep re-reading on later lines of the
@@ -2153,7 +2191,7 @@ class HudMain(QObject):
             (cached_slots, slots),
             key=lambda answer: (self.HERO_SLOT in answer, len(answer)),
         )
-        self._ax_rings[table_key] = (hand_id, best, reads + 1)
+        state.ring, state.reads = best, reads + 1
 
         # Traced on every read, not only when the answer changed. A reader that
         # returns nothing returns the same nothing every time, so the one case
@@ -2176,12 +2214,12 @@ class HudMain(QObject):
         # a seat map the caller discards. The test is the caller's own.
         usable = self.HERO_SLOT in best and len(best) >= self.MIN_PLAYERS_TO_SHOW
         if usable:
-            self._ax_fruitless_reads[table_key] = 0
+            state.fruitless = 0
         else:
-            fruitless = self._ax_fruitless_reads.get(table_key, 0) + 1
-            self._ax_fruitless_reads[table_key] = fruitless
+            state.fruitless += 1
+            fruitless = state.fruitless
             if fruitless >= self.AX_FRUITLESS_READS_BEFORE_GIVING_UP:
-                self._ax_reader_gave_up[table_key] = True
+                state.gave_up = True
                 log.warning(
                     "Giving up on the window seat reader for %s after %d reads that could not seat "
                     "anyone: this client is not publishing enough of that table through the "
@@ -2213,8 +2251,8 @@ class HudMain(QObject):
         """
         table = getattr(hud, "table", None)
         table_key = getattr(table, "key", None) or getattr(table, "title", "") or ""
-        cached_hand, _cached_slots, reads = self._ax_rings.get(table_key, (None, {}, 0))
-        return cached_hand == hand_id and reads >= self.AX_READS_PER_HAND
+        state = self._table_reads.get(table_key)
+        return state is not None and state.hand_id == hand_id and state.reads >= self.AX_READS_PER_HAND
 
     def _on_fast_fold_stats(self, result: FastFoldStatsResult) -> None:
         """Apply stats the worker read for a Fast-Fold table. Runs on the GUI thread."""

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -935,6 +935,14 @@ class HudMain(QObject):
             # two tables open, and a quarter with four, so multitabling gave up
             # on the reader before it had the evidence a single table needed.
             # See AX_FRUITLESS_READS_BEFORE_GIVING_UP.
+            # How long to let the client log finish naming a table's players
+            # before showing the ones it has. Read once: it is a preference, not
+            # something that changes within a session.
+            try:
+                self._fast_fold_seat_wait_ms = int(self.config.get_hud_ui_parameters().get("fast_fold_seat_wait_ms", 500))
+            except Exception:
+                log.debug("Could not read fast_fold_seat_wait_ms; using the default", exc_info=True)
+                self._fast_fold_seat_wait_ms = 500
             self._ax_fruitless_reads: dict[str, int] = {}
             self._ax_reader_gave_up: dict[str, bool] = {}
             # Timeline bookkeeping: when each hand's first log line arrived, and
@@ -1817,8 +1825,12 @@ class HudMain(QObject):
         elif update.ring and update.hero:
             hand_start_time = self._ff_started.get(update.hand_id, 0)
             elapsed = time.monotonic() - hand_start_time if hand_start_time else 1.0
-            if len(update.ring) < max_seats and elapsed < 0.5:
-                # Wait for the full ring to accumulate in log buffer so all 6 player HUDs appear simultaneously
+            if len(update.ring) < max_seats and elapsed * 1000 < self._fast_fold_seat_wait_ms:
+                # The client log names a player only once they have acted, so a
+                # six-handed table is named over several seconds. Showing what is
+                # known so far means blocks appearing one at a time; waiting means
+                # they appear together, later. Which of the two is worse is the
+                # player's call, not ours -- hud_ui/@fast_fold_seat_wait_ms.
                 return
             seat_map = build_seat_map(update.ring, update.hero, max_seats=max_seats, hero_seat=hero_seat)
             source = "log-ring"

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1925,10 +1925,18 @@ class HudMain(QObject):
         self._request_fast_fold_stats(temp_key, current, seat_map, hand_id)
 
     def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
-        """Drop anything held for a table that is going away."""
-        self._ff_coalesced.pop(temp_key, None)
-        self._ff_last_request_at.pop(temp_key, None)
-        timer = self._ff_coalesce_timers.pop(temp_key, None)
+        """Drop anything held for a table that is going away.
+
+        Reached through _clear_fast_fold_table, which is called on HUDs built
+        without the full constructor -- so the state is asked for the same
+        defensive way its neighbours in that method are, rather than assumed.
+        """
+        for name in ("_ff_coalesced", "_ff_last_request_at"):
+            held = getattr(self, name, None)
+            if held is not None:
+                held.pop(temp_key, None)
+        timers = getattr(self, "_ff_coalesce_timers", None)
+        timer = None if timers is None else timers.pop(temp_key, None)
         if timer is not None:
             with contextlib.suppress(RuntimeError):
                 timer.stop()

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -625,6 +625,14 @@ class HudMain(QObject):
     """
 
     MIN_PLAYERS_TO_SHOW = 2
+
+    #: How long after asking for a table's statistics further ring growth is
+    #: coalesced instead of asking again. The client log names players one at a
+    #: time, so a six-handed table produced a request, a database round trip and
+    #: a redraw per name -- fourteen in one hand, across two tables, in a
+    #: measured session. The first answer is never delayed by this; only the
+    #: ones chasing it are merged.
+    FF_STATS_COALESCE_MS = 400
     """Players a window must be drawing before its blocks are worth showing.
 
     The hero alone means the table is between hands or waiting for players, and
@@ -872,6 +880,12 @@ class HudMain(QObject):
             # hud_dict key -> the seat map last sent to the worker, so an
             # unchanged table does not queue a read on every log line.
             self._fast_fold_pending: dict[str, dict[int, str]] = {}
+            # Coalescing of stats requests: when the last one went out per
+            # table, the newest seat map waiting behind it, and the timer that
+            # will send that one. See FF_STATS_COALESCE_MS.
+            self._ff_last_request_at: dict[str, float] = {}
+            self._ff_coalesced: dict[str, tuple[Any, dict[int, str], Any]] = {}
+            self._ff_coalesce_timers: dict[str, QTimer] = {}
             # Pools reported once as having no HUD of their own, so the warning
             # is not repeated on every log line.
             self._unpaired_pools: set[str] = set()
@@ -1543,6 +1557,7 @@ class HudMain(QObject):
         pending_generations = getattr(self, "_ff_pending_generation", None)
         if pending_generations is not None:
             pending_generations.pop(temp_key, None)
+        self._forget_coalesced_fast_fold_stats(temp_key)
         if pending is None and not getattr(hud, "stat_dict", None) and not getattr(hud, "seat_players", None):
             return  # already down
         FastFoldEngine.clear_seats(hud)
@@ -1779,7 +1794,72 @@ class HudMain(QObject):
             f"table={temp_key} source={source} hero_seat={hero_seat} "
             f"seats={ {s: seat_map[s] for s in sorted(seat_map)} }",
         )
-        self._request_fast_fold_stats(temp_key, hud, seat_map, update.hand_id)
+        self._request_fast_fold_stats_coalesced(temp_key, hud, seat_map, update.hand_id)
+
+    def _request_fast_fold_stats_coalesced(
+        self,
+        temp_key: str,
+        hud: Hud.Hud,
+        seat_map: dict[int, str],
+        hand_id: Any,
+    ) -> None:
+        """Ask now if nothing was asked recently, otherwise merge into one later ask.
+
+        The client log names a player only once they have acted, so a six-handed
+        table grows its ring a name at a time. Every growth used to be its own
+        request, database round trip and redraw -- fourteen of them in a single
+        hand across two tables, in a measured session, each one repainting
+        blocks the player was already reading.
+
+        Leading edge, then trailing: the first seat map of a burst goes out
+        immediately, so the blocks appear as early as they ever did. The ones
+        chasing it inside FF_STATS_COALESCE_MS are held, and only the newest
+        survives to be sent when the window closes -- an intermediate ring that
+        was already superseded is not worth a round trip.
+        """
+        now = time.monotonic()
+        last = self._ff_last_request_at.get(temp_key)
+        elapsed_ms = float("inf") if last is None else (now - last) * 1000
+
+        if elapsed_ms >= self.FF_STATS_COALESCE_MS:
+            self._ff_last_request_at[temp_key] = now
+            self._ff_coalesced.pop(temp_key, None)
+            self._request_fast_fold_stats(temp_key, hud, seat_map, hand_id)
+            return
+
+        self._ff_coalesced[temp_key] = (hud, seat_map, hand_id)
+        timer = self._ff_coalesce_timers.get(temp_key)
+        if timer is None:
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.timeout.connect(lambda key=temp_key: self._flush_coalesced_fast_fold_stats(key))
+            self._ff_coalesce_timers[temp_key] = timer
+        if not timer.isActive():
+            timer.start(max(0, int(self.FF_STATS_COALESCE_MS - elapsed_ms)))
+        self._ff_trace(hand_id, "stats-coalesced", f"table={temp_key} seats={len(seat_map)}")
+
+    def _flush_coalesced_fast_fold_stats(self, temp_key: str) -> None:
+        """Send the newest seat map held back for this table, if it still applies."""
+        held = self._ff_coalesced.pop(temp_key, None)
+        if held is None:
+            return
+        hud, seat_map, hand_id = held
+        if self.hud_dict.get(temp_key) is not hud:
+            # The table was cleared or rebuilt while the map waited; the request
+            # would be answered against a HUD nobody is looking at.
+            return
+        self._ff_last_request_at[temp_key] = time.monotonic()
+        self._request_fast_fold_stats(temp_key, hud, seat_map, hand_id)
+
+    def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
+        """Drop anything held for a table that is going away."""
+        self._ff_coalesced.pop(temp_key, None)
+        self._ff_last_request_at.pop(temp_key, None)
+        timer = self._ff_coalesce_timers.pop(temp_key, None)
+        if timer is not None:
+            with contextlib.suppress(RuntimeError):
+                timer.stop()
+                timer.deleteLater()
 
     def _request_fast_fold_stats(
         self,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1691,6 +1691,14 @@ class HudMain(QObject):
         title = getattr(table, "title", "") or ""
         if reader is None or not title:
             return None
+        # The same two answers the per-hand path respects. Without them the idle
+        # sweep kept walking another process's accessibility tree every
+        # FF_IDLE_RECHECK_SECONDS, for the life of the session, on exactly the
+        # clients the breaker exists to stop reading -- and for a table nobody
+        # was even playing. Reported by Codex on the pull request.
+        table_key = getattr(table, "key", None) or title
+        if not getattr(self, "_ax_reader_enabled", True) or getattr(self, "_ax_reader_gave_up", {}).get(table_key):
+            return None
         try:
             return reader.read_window(
                 title,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -227,11 +227,37 @@ class HudReadWorker(QThread):
         self.config = config
         self.db_factory = db_factory
         self._requests: Queue[HudBatchReadRequest | None] = Queue()
+        # Newest queued Fast-Fold request id per table, so the worker can drop
+        # the ones already superseded instead of reading for them. See submit().
+        self._latest_fast_fold: dict[str, int] = {}
+        self._latest_lock = threading.Lock()
         self._stopping = threading.Event()
 
     def submit(self, request: HudBatchReadRequest) -> None:
-        """Queue one immutable request from the Qt thread."""
+        """Queue one immutable request from the Qt thread.
+
+        A Fast-Fold request also records itself as its table's newest. The ring
+        grows a player at a time, so several reads for one table can be waiting
+        at once, and every one of them but the last describes a table that has
+        already changed. They used to be executed in full and discarded on
+        arrival by request id -- the database did the work, the GUI threw the
+        answer away. Now the worker drops them before reading.
+        """
+        if isinstance(request, FastFoldStatsRequest):
+            with self._latest_lock:
+                self._latest_fast_fold[request.temp_key] = request.request_id
         self._requests.put(request)
+
+    def _is_superseded(self, request: FastFoldStatsRequest) -> bool:
+        """Whether a newer read for the same table is already queued behind this one."""
+        with self._latest_lock:
+            latest = self._latest_fast_fold.get(request.temp_key)
+        return latest is not None and latest != request.request_id
+
+    def forget_fast_fold_table(self, temp_key: str) -> None:
+        """Drop what is remembered about a table nobody is watching any more."""
+        with self._latest_lock:
+            self._latest_fast_fold.pop(temp_key, None)
 
     @staticmethod
     def _configure_session(database: Database.Database) -> None:
@@ -338,6 +364,16 @@ class HudReadWorker(QThread):
 
             assert service is not None
             fast_fold = isinstance(pending, FastFoldStatsRequest)
+            if fast_fold and self._is_superseded(pending):
+                # The table has moved on while this waited its turn. Reading for
+                # it would spend a round trip on an answer the GUI discards.
+                log.debug(
+                    "Fast-Fold stats request %s for %s superseded before it ran",
+                    pending.request_id,
+                    pending.temp_key,
+                )
+                pending = None
+                continue
             try:
                 if fast_fold:
                     result = self._read_fast_fold_stats(database, pending)
@@ -894,9 +930,13 @@ class HudMain(QObject):
             # because each read walks another process's accessibility tree.
             self._ax_rings: dict[str, tuple[str, dict[int, str], int]] = {}
             # Window reads in a row that found nobody, and whether that has gone
-            # on long enough to stop trying. See AX_FRUITLESS_READS_BEFORE_GIVING_UP.
-            self._ax_fruitless_reads = 0
-            self._ax_reader_gave_up = False
+            # on long enough to stop trying -- both per table. A single counter
+            # for the whole session reached its threshold in half the hands with
+            # two tables open, and a quarter with four, so multitabling gave up
+            # on the reader before it had the evidence a single table needed.
+            # See AX_FRUITLESS_READS_BEFORE_GIVING_UP.
+            self._ax_fruitless_reads: dict[str, int] = {}
+            self._ax_reader_gave_up: dict[str, bool] = {}
             # Timeline bookkeeping: when each hand's first log line arrived, and
             # which hand/table request is currently allowed to update the HUD.
             self._ff_started: dict[str, float] = {}
@@ -1558,6 +1598,10 @@ class HudMain(QObject):
         if pending_generations is not None:
             pending_generations.pop(temp_key, None)
         self._forget_coalesced_fast_fold_stats(temp_key)
+        worker = getattr(self, "_db_worker", None)
+        if worker is not None:
+            with contextlib.suppress(Exception):
+                worker.forget_fast_fold_table(temp_key)
         if pending is None and not getattr(hud, "stat_dict", None) and not getattr(hud, "seat_players", None):
             return  # already down
         FastFoldEngine.clear_seats(hud)
@@ -1961,10 +2005,12 @@ class HudMain(QObject):
         reader = getattr(self, "winamax_ax_seats", None)
         table = getattr(hud, "table", None)
         title = getattr(table, "title", "") or ""
-        if reader is None or not title or self._ax_reader_gave_up:
+        if reader is None or not title:
             return {}
 
         table_key = getattr(table, "key", None) or title
+        if self._ax_reader_gave_up.get(table_key):
+            return {}
         cached_hand, cached_slots, reads = self._ax_rings.get(table_key, (None, {}, 0))
         if cached_hand != hand_id:
             cached_slots, reads = {}, 0
@@ -2014,16 +2060,18 @@ class HudMain(QObject):
         # draw. Measured on a live session: six reads a hand, on two tables,
         # 15-62ms each, every one of them players=0. Stop paying for it.
         if best:
-            self._ax_fruitless_reads = 0
+            self._ax_fruitless_reads[table_key] = 0
         else:
-            self._ax_fruitless_reads += 1
-            if self._ax_fruitless_reads >= self.AX_FRUITLESS_READS_BEFORE_GIVING_UP:
-                self._ax_reader_gave_up = True
+            fruitless = self._ax_fruitless_reads.get(table_key, 0) + 1
+            self._ax_fruitless_reads[table_key] = fruitless
+            if fruitless >= self.AX_FRUITLESS_READS_BEFORE_GIVING_UP:
+                self._ax_reader_gave_up[table_key] = True
                 log.warning(
-                    "Giving up on the window seat reader after %d reads that found nobody: this client "
-                    "does not publish its table through the accessibility API. Fast-Fold seats come from "
-                    "the client log, which names a player only once they have acted.",
-                    self._ax_fruitless_reads,
+                    "Giving up on the window seat reader for %s after %d reads that found nobody: this "
+                    "client is not publishing that table through the accessibility API. Its Fast-Fold "
+                    "seats come from the client log, which names a player only once they have acted.",
+                    table_key,
+                    fruitless,
                 )
 
         empty = sorted(set(range(max_seats)) - set(best))

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1916,12 +1916,13 @@ class HudMain(QObject):
         if held is None:
             return
         hud, seat_map, hand_id = held
-        if self.hud_dict.get(temp_key) is not hud:
+        current = self.hud_dict.get(temp_key)
+        if current is None or current is not hud:
             # The table was cleared or rebuilt while the map waited; the request
             # would be answered against a HUD nobody is looking at.
             return
         self._ff_last_request_at[temp_key] = time.monotonic()
-        self._request_fast_fold_stats(temp_key, hud, seat_map, hand_id)
+        self._request_fast_fold_stats(temp_key, current, seat_map, hand_id)
 
     def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
         """Drop anything held for a table that is going away."""

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -626,11 +626,16 @@ class HudMain(QObject):
 
     AX_READS_PER_HAND = 6
 
-    #: Consecutive window reads that may come back with nobody on them before
-    #: the reader is given up on for the session. Six per hand, so this is five
-    #: hands of a client that never names a single player -- enough to tell a
-    #: table being redrawn from one whose content is simply not published.
-    AX_FRUITLESS_READS_BEFORE_GIVING_UP = AX_READS_PER_HAND * 5
+    #: Consecutive window reads that may fail to seat anyone before the reader
+    #: is given up on for that table. Two hands' worth.
+    #:
+    #: It was five, and five is what the evidence costs rather than what it is
+    #: worth: a read of a client that answers takes 94-218ms, synchronously, on
+    #: the GUI thread, six times a hand, per table. Thirty of them is four and a
+    #: half seconds of frozen HUD spent proving something a table caught
+    #: mid-redraw proves in one hand -- and a client that does not publish its
+    #: felt proves immediately. Two hands is still twice what it takes.
+    AX_FRUITLESS_READS_BEFORE_GIVING_UP = AX_READS_PER_HAND * 2
     """How many times a table's window may be re-read within one hand.
 
     A read costs ~20ms through the macOS accessibility API and 100-300ms
@@ -945,6 +950,17 @@ class HudMain(QObject):
                 self._fast_fold_seat_wait_ms = 500
             self._ax_fruitless_reads: dict[str, int] = {}
             self._ax_reader_gave_up: dict[str, bool] = {}
+            # "off" skips the window reader outright. On a client that never
+            # publishes its felt, the reads are pure stutter -- and the player
+            # who has established that should not have to re-establish it every
+            # session, two hands at a time.
+            try:
+                self._ax_reader_enabled = (
+                    str(self.config.get_hud_ui_parameters().get("fast_fold_window_seats", "auto")) != "off"
+                )
+            except Exception:
+                log.debug("Could not read fast_fold_window_seats; leaving the reader on", exc_info=True)
+                self._ax_reader_enabled = True
             # Timeline bookkeeping: when each hand's first log line arrived, and
             # which hand/table request is currently allowed to update the HUD.
             self._ff_started: dict[str, float] = {}
@@ -2017,7 +2033,7 @@ class HudMain(QObject):
         reader = getattr(self, "winamax_ax_seats", None)
         table = getattr(hud, "table", None)
         title = getattr(table, "title", "") or ""
-        if reader is None or not title:
+        if reader is None or not title or not self._ax_reader_enabled:
             return {}
 
         table_key = getattr(table, "key", None) or title

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -688,6 +688,10 @@ class HudMain(QObject):
     """
 
     AX_RECHECK_DELAYS_MS = (250, 700, 1500)
+
+    #: Hands remembered as having a seat-wait recheck already scheduled. Bounded
+    #: because a session plays thousands of them and nothing else prunes it.
+    FF_SEAT_WAIT_MEMO_LIMIT = 200
     """When to look at the window again after a hand starts.
 
     Every log line of a new hand -- the hand id, both blinds, the hole cards --
@@ -948,6 +952,7 @@ class HudMain(QObject):
             except Exception:
                 log.debug("Could not read fast_fold_seat_wait_ms; using the default", exc_info=True)
                 self._fast_fold_seat_wait_ms = 500
+            self._ff_seat_wait_scheduled: set[tuple[str, str]] = set()
             self._ax_fruitless_reads: dict[str, int] = {}
             self._ax_reader_gave_up: dict[str, bool] = {}
             # "off" skips the window reader outright. On a client that never
@@ -1745,6 +1750,26 @@ class HudMain(QObject):
                     if live_key == temp_key:
                         aliases.pop(alias, None)
 
+    def _schedule_seat_wait_recheck(self, update: Any, elapsed: float) -> None:
+        """Come back when the seat wait is up, once per hand and table.
+
+        Only needed when the wait outlasts AX_RECHECK_DELAYS_MS; below that the
+        rechecks already scheduled at hand start arrive after the deadline and
+        this would be a second timer saying the same thing.
+        """
+        remaining_ms = int(self._fast_fold_seat_wait_ms - elapsed * 1000)
+        if remaining_ms <= max(self.AX_RECHECK_DELAYS_MS):
+            return
+        pending = self._ff_seat_wait_scheduled
+        key = (update.pool, update.hand_id)
+        if key in pending:
+            return
+        pending.add(key)
+        if len(pending) > self.FF_SEAT_WAIT_MEMO_LIMIT:
+            pending.clear()
+            pending.add(key)
+        QTimer.singleShot(remaining_ms, lambda pool=update.pool: self._recheck_window(pool))
+
     def _recheck_window(self, pool: str) -> None:
         """Re-run a table's live update once the client has had time to draw it."""
         reader = getattr(self, "winamax_log_reader", None)
@@ -1855,6 +1880,15 @@ class HudMain(QObject):
                 # known so far means blocks appearing one at a time; waiting means
                 # they appear together, later. Which of the two is worse is the
                 # player's call, not ours -- hud_ui/@fast_fold_seat_wait_ms.
+                #
+                # And something has to come back at the deadline. The only other
+                # rechecks of a hand are AX_RECHECK_DELAYS_MS, which stop at
+                # 1500ms: with the wait set beyond that, as the setting documents,
+                # a short-handed table whose last ring update lands before the
+                # deadline would never be drawn at all -- nothing would look
+                # again until the hand was over, and then it is cleared.
+                # Reported by Codex on the pull request.
+                self._schedule_seat_wait_recheck(update, elapsed)
                 return
             seat_map = build_seat_map(update.ring, update.hero, max_seats=max_seats, hero_seat=hero_seat)
             source = "log-ring"

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1753,13 +1753,21 @@ class HudMain(QObject):
     def _schedule_seat_wait_recheck(self, update: Any, elapsed: float) -> None:
         """Come back when the seat wait is up, once per hand and table.
 
-        Only needed when the wait outlasts AX_RECHECK_DELAYS_MS; below that the
-        rechecks already scheduled at hand start arrive after the deadline and
-        this would be a second timer saying the same thing.
+        Only needed when the configured wait outlasts AX_RECHECK_DELAYS_MS. Below
+        that, the rechecks already scheduled at hand start arrive after the
+        deadline and this would be a second timer saying the same thing.
+
+        The test is on the setting, not on what is left of it. Comparing the
+        remaining time instead left a band just above the last recheck with no
+        wakeup at all: at a 2000ms wait, a ring arriving at 600ms leaves 1400,
+        which reads as "the rechecks have this" -- and they do not, because they
+        all fire before 2000ms. Every later call inside the hand makes the same
+        wrong judgement, so nothing looked again until the hand ended. Reported
+        by Codex on the pull request.
         """
-        remaining_ms = int(self._fast_fold_seat_wait_ms - elapsed * 1000)
-        if remaining_ms <= max(self.AX_RECHECK_DELAYS_MS):
+        if self._fast_fold_seat_wait_ms <= max(self.AX_RECHECK_DELAYS_MS):
             return
+        remaining_ms = max(0, int(self._fast_fold_seat_wait_ms - elapsed * 1000))
         pending = self._ff_seat_wait_scheduled
         key = (update.pool, update.hand_id)
         if key in pending:

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1743,6 +1743,7 @@ class HudMain(QObject):
             self.hud_dict.pop(temp_key, None)
             # This path bypasses idle_kill, so the window it held has to be
             # given back explicitly or the next HUD on it reads as a duplicate.
+            self._forget_window_seat_state(temp_key)
             self._window_registry.release(temp_key)
             aliases = getattr(self, "_fast_fold_aliases", None)
             if aliases is not None:
@@ -1973,6 +1974,26 @@ class HudMain(QObject):
             return
         self._ff_last_request_at[temp_key] = time.monotonic()
         self._request_fast_fold_stats(temp_key, current, seat_map, hand_id)
+
+    def _forget_window_seat_state(self, table_key: str) -> None:
+        """Drop what was learned about reading a table, when that table retires.
+
+        The breaker's verdict, the fruitless count and the per-hand ring are all
+        keyed by the table's name, which a pool hands back: close a table and
+        Winamax gives the next one the same "Colorado 3", so a HUD built after a
+        restart inherited "this client will not answer" from a client that is no
+        longer running. It never read its window, never asked for accessibility,
+        and went straight to the log-derived seats for the rest of the session.
+
+        The accessibility cache was taught the same lesson one round earlier, by
+        the owning process rather than by the key -- and I said in reply that
+        these were safe because they are keyed by name rather than by handle.
+        That was the reason they are not. Reported by Codex on the pull request.
+        """
+        for name in ("_ax_reader_gave_up", "_ax_fruitless_reads", "_ax_rings"):
+            learned = getattr(self, name, None)
+            if learned is not None:
+                learned.pop(table_key, None)
 
     def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
         """Drop anything held for a table that is going away.
@@ -4164,6 +4185,7 @@ class HudMain(QObject):
                 overlays = self._describe_overlay_win_ids(hud)
                 self.hud_dict[table].kill()
                 del self.hud_dict[table]
+                self._forget_window_seat_state(table)
                 released = self._window_registry.release(table)
                 log.warning(
                     "HUD destroyed: session=%s pid=%s generation=%s table=%r window_id=%s overlays=%s",

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1780,7 +1780,7 @@ class HudMain(QObject):
             self.hud_dict.pop(temp_key, None)
             # This path bypasses idle_kill, so the window it held has to be
             # given back explicitly or the next HUD on it reads as a duplicate.
-            self._forget_window_seat_state(temp_key)
+            self._forget_window_seat_state(temp_key, getattr(getattr(hud, "table", None), "number", None))
             self._window_registry.release(temp_key)
             aliases = getattr(self, "_fast_fold_aliases", None)
             if aliases is not None:
@@ -2012,7 +2012,7 @@ class HudMain(QObject):
         self._ff_last_request_at[temp_key] = time.monotonic()
         self._request_fast_fold_stats(temp_key, current, seat_map, hand_id)
 
-    def _forget_window_seat_state(self, table_key: str) -> None:
+    def _forget_window_seat_state(self, table_key: str, hwnd: int | None = None) -> None:
         """Drop what was learned about reading a table, when that table retires.
 
         The breaker's verdict, the fruitless count and the per-hand ring are all
@@ -2030,6 +2030,19 @@ class HudMain(QObject):
         learned = getattr(self, "_table_reads", None)
         if learned is not None:
             learned.pop(table_key, None)
+
+        # And the window's own: whether its accessibility request was accepted,
+        # whether one is in the air, and where its table's centre was measured.
+        # Nothing released that in production, so a handle Winamax handed to
+        # another of its tables -- same process, so the owner check says nothing
+        # -- inherited an accepted request it never received, an outstanding one
+        # nobody would ever clear, and a centre belonging to a table that had
+        # closed. Reported by Codex on the pull request.
+        if hwnd:
+            with contextlib.suppress(Exception):
+                from fpdb_3_legacy.winamax_ax_seats import forget_window_state
+
+                forget_window_state(int(hwnd))
 
     def _forget_coalesced_fast_fold_stats(self, temp_key: str) -> None:
         """Drop anything held for a table that is going away.
@@ -4222,8 +4235,9 @@ class HudMain(QObject):
                 self.hud_dict[table].tablehudlabel = None
                 overlays = self._describe_overlay_win_ids(hud)
                 self.hud_dict[table].kill()
+                retiring_hwnd = getattr(getattr(hud, "table", None), "number", None)
                 del self.hud_dict[table]
-                self._forget_window_seat_state(table)
+                self._forget_window_seat_state(table, retiring_hwnd)
                 released = self._window_registry.release(table)
                 log.warning(
                     "HUD destroyed: session=%s pid=%s generation=%s table=%r window_id=%s overlays=%s",

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -1911,14 +1911,20 @@ class HudMain(QObject):
         )
         self._ax_rings[table_key] = (hand_id, best, reads + 1)
 
-        if slots != cached_slots:
-            empty = sorted(set(range(max_seats)) - set(best))
-            self._ff_trace(
-                hand_id,
-                "window-read",
-                f"{title!r} (key={table_key}) {took:.0f}ms read#{reads + 1} players={len(best)} "
-                f"slots={ {s: best[s] for s in sorted(best)} } empty={empty}",
-            )
+        # Traced on every read, not only when the answer changed. A reader that
+        # returns nothing returns the same nothing every time, so the one case
+        # worth reporting -- the window telling us about no players at all, for
+        # every hand of a session -- was the one case that logged absolutely
+        # nothing, even with FPDB_HUD_TRACE=1. The seats then come from the log
+        # ring, which names a player only once they have acted, and the blocks
+        # arrive one at a time; that is what gets reported, with no trace of why.
+        empty = sorted(set(range(max_seats)) - set(best))
+        self._ff_trace(
+            hand_id,
+            "window-read",
+            f"{title!r} (key={table_key}) {took:.0f}ms read#{reads + 1} players={len(best)} "
+            f"slots={ {s: best[s] for s in sorted(best)} } empty={empty}",
+        )
         return best
 
     def _ax_reads_spent(self, hud: Hud.Hud, hand_id: str) -> bool:

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -2071,7 +2071,15 @@ class HudMain(QObject):
         # thread, at hand-start, which is exactly when the HUD is trying to
         # draw. Measured on a live session: six reads a hand, on two tables,
         # 15-62ms each, every one of them players=0. Stop paying for it.
-        if best:
+        # Fruitless means "could not be acted on", not "came back empty". This
+        # counted empty reads, and a client that answers with the hero and one
+        # neighbour -- never the bottom-centre chair, never enough of the ring --
+        # answers non-empty every single time. The counter reset on every read,
+        # the breaker never tripped, and six reads a hand went on being paid for
+        # on two tables at 94-172ms each: about 1.5s of GUI thread per hand, for
+        # a seat map the caller discards. The test is the caller's own.
+        usable = self.HERO_SLOT in best and len(best) >= self.MIN_PLAYERS_TO_SHOW
+        if usable:
             self._ax_fruitless_reads[table_key] = 0
         else:
             fruitless = self._ax_fruitless_reads.get(table_key, 0) + 1
@@ -2079,9 +2087,10 @@ class HudMain(QObject):
             if fruitless >= self.AX_FRUITLESS_READS_BEFORE_GIVING_UP:
                 self._ax_reader_gave_up[table_key] = True
                 log.warning(
-                    "Giving up on the window seat reader for %s after %d reads that found nobody: this "
-                    "client is not publishing that table through the accessibility API. Its Fast-Fold "
-                    "seats come from the client log, which names a player only once they have acted.",
+                    "Giving up on the window seat reader for %s after %d reads that could not seat "
+                    "anyone: this client is not publishing enough of that table through the "
+                    "accessibility API to place the hero. Its Fast-Fold seats come from the client "
+                    "log, which names a player only once they have acted.",
                     table_key,
                     fruitless,
                 )

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -249,7 +249,19 @@ def _windows_uia() -> _WindowsUIAClient | None:
         log.info("UIAutomation seat reader ready")
     except Exception:
         _windows_uia_unavailable = True
-        log.info("No UIAutomation seat reader on this machine; Fast-Fold seats come from the client log", exc_info=True)
+        # WARNING, not INFO: this is the difference between a Fast-Fold table's
+        # blocks appearing together and appearing one at a time over the first
+        # betting round, and it was invisible. The root logger is pinned to
+        # WARNING (loggingFpdb.DIAGNOSTIC_LEVEL_CAP) and "hud_main" is persisted
+        # lower still, so the INFO line this used to be reached no user's log --
+        # the HUD lost the window reader and said nothing about it. Once per
+        # process: the failure is remembered just above.
+        log.warning(
+            "No UIAutomation seat reader: Fast-Fold seats will come from the client log, which names a "
+            "player only once they have acted, so the stat blocks appear one at a time over the first "
+            "betting round.",
+            exc_info=True,
+        )
     return _windows_uia_client
 
 
@@ -670,6 +682,16 @@ class WinamaxAXSeatReader:
         Paid here, at startup, it is not paid on the GUI thread while a table is
         being dealt. Failure is not an error: the log-derived ring still works.
         """
-        if platform.system() != "Windows" or not is_ax_available():
+        if platform.system() != "Windows":
+            return
+        if not is_ax_available():
+            # comtypes is not importable. The win32 dependency in pyproject and
+            # the PyInstaller hook exist to stop exactly this, so a build that
+            # arrives here has lost them somewhere -- and it degraded in
+            # silence, because this branch simply returned.
+            log.warning(
+                "Fast-Fold seats will come from the client log: comtypes is not importable, so this "
+                "build cannot read a table's chairs from its window.",
+            )
             return
         _windows_uia()

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -325,10 +325,19 @@ def _request_windows_accessibility_now(hwnd: int) -> None:
 
     with _accessibility_lock:
         _accessibility_in_flight.discard(hwnd)
-        if delivered or asked_ia2:
+        if asked_ia2:
+            # Only an accepted IAccessible2 query counts as asked. A delivered
+            # WM_GETOBJECT gets Chromium as far as its native widgets -- the
+            # frame, the Views controls, the dialogs -- and no further; the felt
+            # is web content, and the IA2 query is what unlocks it. Recording
+            # the window on the WM_GETOBJECT alone left a table whose IA2 query
+            # failed transiently without opponents for the rest of the session,
+            # until the circuit breaker gave up on it: the exact failure this
+            # branch exists to fix, reached through a partial success. Reported
+            # by Codex on the pull request.
             _accessibility_asked.add(hwnd)
 
-    if not delivered and not asked_ia2:
+    if not asked_ia2:
         # Nothing got through. SendMessageTimeoutW reports a hung or
         # still-starting client by returning zero rather than raising, and
         # _ask_for_complete_tree turns every COM failure into False, so an
@@ -337,7 +346,11 @@ def _request_windows_accessibility_now(hwnd: int) -> None:
         # work -- wrote it off for the whole session on one badly timed try.
         # Reported by Codex on the pull request, twice: the exception path alone
         # was not enough.
-        log.debug("Window %s answered none of the accessibility requests; will ask again", hwnd)
+        log.debug(
+            "Window %s accepted no IAccessible2 query (%d WM_GETOBJECT delivered); will ask again",
+            hwnd,
+            delivered,
+        )
         return
 
     log.info(

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -248,6 +248,10 @@ class _WindowsUIAClient:
 _windows_uia_client: _WindowsUIAClient | None = None
 _windows_uia_unavailable = False
 
+#: No process could ever own a window, so it can stand for "never asked" in a
+#: comparison against one that could be None because the handle was unreadable.
+_UNASKED = object()
+
 #: WM_GETOBJECT / OBJID_CLIENT: what an assistive technology sends a window, and
 #: what a Chromium client watches for before it builds its accessibility tree.
 _WM_GETOBJECT = 0x003D
@@ -255,11 +259,13 @@ _OBJID_CLIENT = -4
 _SMTO_ABORTIFHUNG = 0x0002
 _GETOBJECT_TIMEOUT_MS = 200
 
-#: Windows already asked, so a table is nudged once rather than on every read,
-#: and the ones being asked right now, so a second read does not ask again while
-#: the first request is still in the air. Both are touched from the reading
-#: thread and from the request threads, hence the lock.
-_accessibility_asked: set[int] = set()
+#: Windows already asked, mapped to the process that owned them at the time, so
+#: a table is nudged once rather than on every read -- and a handle Windows has
+#: since recycled to a restarted client is asked again. Alongside, the ones being
+#: asked right now, so a second read does not start a second request while the
+#: first is still in the air. Both are touched from the reading thread and from
+#: the request threads, hence the lock.
+_accessibility_asked: dict[int, int | None] = {}
 _accessibility_in_flight: set[int] = set()
 _accessibility_lock = threading.Lock()
 
@@ -269,6 +275,21 @@ def forget_accessibility_requests() -> None:
     with _accessibility_lock:
         _accessibility_asked.clear()
         _accessibility_in_flight.clear()
+
+
+def _window_pid(hwnd: int) -> int | None:  # pragma: no cover - Win32 call
+    """The process owning a window, or None when it cannot be asked.
+
+    A local call that returns from kernel data, not a message to another
+    process's queue: unlike the accessibility requests, it cannot block on a
+    client that has stopped answering, so it is safe on the GUI thread.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    pid = wintypes.DWORD()
+    ctypes.windll.user32.GetWindowThreadProcessId(wintypes.HWND(hwnd), ctypes.byref(pid))
+    return pid.value or None
 
 
 def request_windows_accessibility(hwnd: int) -> None:
@@ -299,19 +320,26 @@ def request_windows_accessibility(hwnd: int) -> None:
     """
     if platform.system() != "Windows" or not hwnd:
         return
+    # Asked once per window *and per client*. Windows recycles a closed table's
+    # handle, and a Winamax restarted while the HUD stays alive gets a new
+    # process for the same numbers -- a handle remembered by its digits alone
+    # would tell that new Chromium it had already been asked, and it would never
+    # publish its felt. The centre cache learned the same lesson from its frame.
+    # Reported by Codex on the pull request.
+    pid = _window_pid(hwnd)
     with _accessibility_lock:
-        if hwnd in _accessibility_asked or hwnd in _accessibility_in_flight:
+        if _accessibility_asked.get(hwnd, _UNASKED) == pid or hwnd in _accessibility_in_flight:
             return
         _accessibility_in_flight.add(hwnd)
     threading.Thread(
         target=_request_windows_accessibility_now,
-        args=(hwnd,),
+        args=(hwnd, pid),
         name=f"fpdb-ax-request-{hwnd}",
         daemon=True,
     ).start()
 
 
-def _request_windows_accessibility_now(hwnd: int) -> None:
+def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> None:
     """Do the asking, on a thread of its own. See request_windows_accessibility."""
     try:
         targets, delivered = _send_get_object(hwnd)
@@ -335,7 +363,7 @@ def _request_windows_accessibility_now(hwnd: int) -> None:
             # until the circuit breaker gave up on it: the exact failure this
             # branch exists to fix, reached through a partial success. Reported
             # by Codex on the pull request.
-            _accessibility_asked.add(hwnd)
+            _accessibility_asked[hwnd] = pid
 
     if not asked_ia2:
         # Nothing got through. SendMessageTimeoutW reports a hung or

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import platform
 import re
 from dataclasses import dataclass
@@ -201,13 +202,37 @@ class _WindowsUIAClient:
         self._condition = condition
 
     def collect_labels(self, element: Any) -> list[AXSeat]:
-        """Every short text label under ``element``, with its screen position."""
+        """Every short text label under ``element``, with its screen position.
+
+        Labels belonging to this process are skipped. The HUD's own stat blocks
+        are top-level windows made transient children of the table they sit on,
+        which puts them inside the subtree searched here -- so a walk of a table
+        window came back holding the HUD's own text:
+
+            'HUD - stats'  'MonXt.'  'H 2'  'VP 0.0'  'PR 0.0'  '3B -'  'CB -'
+
+        Those are stat abbreviations, not players, and feeding them to
+        seats_from_labels can only produce nonsense or nothing. The HUD reading
+        its own output back is a loop worth cutting whatever else the client
+        does or does not expose.
+        """
         found = element.FindAll(self.TREE_SCOPE_SUBTREE, self._condition)
         if not found or not found.Length:
             return []
         labels: list[AXSeat] = []
+        own_pid = os.getpid()
         for index in range(min(found.Length, self.MAX_ELEMENTS)):
             item = found.GetElement(index)
+            # Fail open: only an element positively identified as ours is
+            # dropped. Losing a real player's label because one attribute read
+            # hiccuped would cost the whole seat map, which is the failure this
+            # reader exists to avoid.
+            try:
+                is_ours = item.CurrentProcessId == own_pid
+            except Exception:  # noqa: BLE001 - unreadable pid is not proof of anything
+                is_ours = False
+            if is_ours:
+                continue
             name = item.CurrentName
             if not isinstance(name, str) or not name or len(name) > self.MAX_LABEL_LEN:
                 continue

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -296,7 +296,12 @@ def request_windows_accessibility(hwnd: int) -> None:
             asked_ia2,
         )
     except Exception:
-        # Never fatal: without it the reader is exactly as blind as it was.
+        # Never fatal: without it the reader is exactly as blind as it was. The
+        # window is forgotten so a later read asks again -- a client still
+        # starting up, or momentarily hung, would otherwise be written off for
+        # the whole session by one badly timed attempt. Reported by Codex on the
+        # pull request.
+        _accessibility_asked.discard(hwnd)
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
 
 
@@ -478,8 +483,22 @@ def is_hud_label(text: str) -> bool:
     return False
 
 
-def _table_centre(players: list[AXSeat], win_rect: Any) -> tuple[float, float]:
-    """The point the seats are arranged around, in the players' own coordinates.
+#: Table centres learned from a full ring, keyed by window. See _table_centre.
+_table_centres: dict[int, tuple[float, float]] = {}
+
+
+def forget_table_centres() -> None:
+    """Drop the learned centres, so the next full ring is measured afresh."""
+    _table_centres.clear()
+
+
+def _table_centre(
+    players: list[AXSeat],
+    win_rect: Any,
+    max_seats: int,
+    hwnd: int,
+) -> tuple[float, float] | None:
+    """The point the seats are arranged around, or None when it is not known.
 
     The window rectangle is the obvious answer and it is the wrong one here. The
     client reports its content in a different space from its frame -- a window
@@ -490,24 +509,39 @@ def _table_centre(players: list[AXSeat], win_rect: Any) -> tuple[float, float]:
         centre from the window rect : {2: 'CTroPinJust'}
         centre from the players     : {0: 'jejellyroll', 1: 'depor81', ...}
 
-    Whatever the reason for the mismatch -- the HUD process is DPI-unaware, and
-    the client is not -- the players are all in one space as each other, which is
-    the only space the angles have to agree in. So the ring's own bounding box
-    is used whenever the players are not inside the frame, and the frame when
-    they are, which is what a client reporting one consistent space gives.
+    But the ring's own bounding box is only the table's centre when the ring is
+    complete. Read the hero and the two chairs beside them and that box is a
+    band across the bottom of the felt, whose centre sits well below the true
+    one -- the hero still lands on slot 0, so the caller accepts the answer, and
+    the two neighbours land on slots 2 and 4 instead of 1 and 5. Statistics over
+    the wrong opponents is worse than no statistics at all, which is what makes
+    this worth a measurement rather than an estimate. Reported by Codex on the
+    pull request.
+
+    So a centre is measured only from a ring with every chair in it, remembered
+    against the window, and reused for the partial reads that follow. Until one
+    full ring has been seen there is no answer, and the caller falls back to the
+    client log. A client that reports its content in the frame's own space needs
+    none of this and keeps the frame's centre.
     """
+    if not players:
+        return None
     inside = all(
         win_rect.left <= player.x <= win_rect.right and win_rect.top <= player.y <= win_rect.bottom
         for player in players
     )
-    if players and not inside:
+    if inside:
+        return (
+            win_rect.left + (win_rect.right - win_rect.left) / 2,
+            win_rect.top + (win_rect.bottom - win_rect.top) / 2,
+        )
+    if len(players) >= max_seats:
         xs = [player.x for player in players]
         ys = [player.y for player in players]
-        return ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
-    return (
-        win_rect.left + (win_rect.right - win_rect.left) / 2,
-        win_rect.top + (win_rect.bottom - win_rect.top) / 2,
-    )
+        centre = ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+        _table_centres[hwnd] = centre
+        return centre
+    return _table_centres.get(hwnd)
 
 
 def seats_from_labels(labels: list[AXSeat]) -> list[AXSeat]:
@@ -876,7 +910,13 @@ class WinamaxAXSeatReader:
             win_rect = elem.CurrentBoundingRectangle
             if not win_rect:
                 return {}
-            return seat_slots_from_positions(players, _table_centre(players, win_rect), max_seats)
+            centre = _table_centre(players, win_rect, max_seats, hwnd)
+            if centre is None:
+                # A partial ring on a client whose coordinates do not match its
+                # frame, before any full ring has been measured: no centre can
+                # be trusted, so say nothing rather than seat people wrongly.
+                return {}
+            return seat_slots_from_positions(players, centre, max_seats)
         except Exception:
             log.debug("Error reading Winamax UIAutomation seats on Windows for HWND %s:", hwnd, exc_info=True)
             return {}

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -283,12 +283,21 @@ def _window_pid(hwnd: int) -> int | None:  # pragma: no cover - Win32 call
     A local call that returns from kernel data, not a message to another
     process's queue: unlike the accessibility requests, it cannot block on a
     client that has stopped answering, so it is safe on the GUI thread.
-    """
-    import ctypes
-    from ctypes import wintypes
 
-    pid = wintypes.DWORD()
-    ctypes.windll.user32.GetWindowThreadProcessId(wintypes.HWND(hwnd), ctypes.byref(pid))
+    Never raises. It is asked outside the request's own error handling, and a
+    caller that has been told the platform is Windows when it is not -- which is
+    what the cross-platform contract test does -- must get an answer rather than
+    an AttributeError from a ctypes.windll that is not there.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        pid = wintypes.DWORD()
+        ctypes.windll.user32.GetWindowThreadProcessId(wintypes.HWND(hwnd), ctypes.byref(pid))
+    except Exception:
+        log.debug("Could not read the process owning window %s", hwnd, exc_info=True)
+        return None
     return pid.value or None
 
 

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -32,6 +32,7 @@ import math
 import os
 import platform
 import re
+import threading
 from dataclasses import dataclass
 from typing import Any
 
@@ -254,13 +255,20 @@ _OBJID_CLIENT = -4
 _SMTO_ABORTIFHUNG = 0x0002
 _GETOBJECT_TIMEOUT_MS = 200
 
-#: Windows already asked, so a table is nudged once rather than on every read.
+#: Windows already asked, so a table is nudged once rather than on every read,
+#: and the ones being asked right now, so a second read does not ask again while
+#: the first request is still in the air. Both are touched from the reading
+#: thread and from the request threads, hence the lock.
 _accessibility_asked: set[int] = set()
+_accessibility_in_flight: set[int] = set()
+_accessibility_lock = threading.Lock()
 
 
 def forget_accessibility_requests() -> None:
     """Forget which windows have been asked, so the next read asks again."""
-    _accessibility_asked.clear()
+    with _accessibility_lock:
+        _accessibility_asked.clear()
+        _accessibility_in_flight.clear()
 
 
 def request_windows_accessibility(hwnd: int) -> None:
@@ -278,20 +286,47 @@ def request_windows_accessibility(hwnd: int) -> None:
     table window and to each of its children, because the content is drawn in a
     child render surface rather than the frame the HUD attached to.
 
-    SendMessageTimeout, never SendMessage: the client is another process, and a
-    blocked or busy one must not be able to hang the HUD's GUI thread. The tree
-    is built asynchronously, so the read that triggers this one will usually
-    still come back empty; the rechecks within the hand are what pick it up.
+    Asked from a background thread, and nothing waits for it. SendMessageTimeout
+    is bounded, but AccessibleObjectFromWindow and QueryService are not: they
+    send their own WM_GETOBJECT and wait for the client to answer, with no
+    timeout to give up at. A hung or still-starting client could therefore hold
+    the HUD's GUI thread for as long as it liked, which is the failure this
+    reader exists inside a circuit breaker to avoid. Nothing here returns a value
+    the caller needs -- the effect is on the client, and the tree it builds is
+    built asynchronously anyway -- so the request is fired and forgotten, and the
+    rechecks within the hand pick up whatever it produced. Reported by Codex on
+    the pull request.
     """
-    if platform.system() != "Windows" or not hwnd or hwnd in _accessibility_asked:
+    if platform.system() != "Windows" or not hwnd:
         return
+    with _accessibility_lock:
+        if hwnd in _accessibility_asked or hwnd in _accessibility_in_flight:
+            return
+        _accessibility_in_flight.add(hwnd)
+    threading.Thread(
+        target=_request_windows_accessibility_now,
+        args=(hwnd,),
+        name=f"fpdb-ax-request-{hwnd}",
+        daemon=True,
+    ).start()
+
+
+def _request_windows_accessibility_now(hwnd: int) -> None:
+    """Do the asking, on a thread of its own. See request_windows_accessibility."""
     try:
         targets, delivered = _send_get_object(hwnd)
         asked_ia2 = sum(_ask_for_complete_tree(target) for target in targets)
     except Exception:
         # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
+        with _accessibility_lock:
+            _accessibility_in_flight.discard(hwnd)
         return
+
+    with _accessibility_lock:
+        _accessibility_in_flight.discard(hwnd)
+        if delivered or asked_ia2:
+            _accessibility_asked.add(hwnd)
 
     if not delivered and not asked_ia2:
         # Nothing got through. SendMessageTimeoutW reports a hung or
@@ -305,7 +340,6 @@ def request_windows_accessibility(hwnd: int) -> None:
         log.debug("Window %s answered none of the accessibility requests; will ask again", hwnd)
         return
 
-    _accessibility_asked.add(hwnd)
     log.info(
         "Asked %d window(s) of %s to publish their accessibility tree (%d delivered, %d accepted IAccessible2)",
         len(targets),
@@ -380,7 +414,13 @@ def _ask_for_complete_tree(hwnd: int) -> bool:  # pragma: no cover - COM calls
         import ctypes
         from ctypes import POINTER, byref, c_void_p, wintypes
 
+        import comtypes
         from comtypes import COMMETHOD, GUID, HRESULT, IUnknown
+
+        # This runs on a thread of its own, and COM is per-thread: comtypes
+        # initialises the thread that imports it, not this one. The thread is
+        # short-lived and dies with the request, so nothing uninitialises it.
+        comtypes.CoInitialize()
 
         class _IServiceProvider(IUnknown):
             _iid_ = GUID("{6D5140C1-7436-11CE-8034-00AA006009FA}")

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -405,6 +405,26 @@ def request_windows_accessibility(hwnd: int) -> None:
     ).start()
 
 
+def _owned_window_state(hwnd: int, pid: int | None | object) -> _WindowState | None:
+    """This window's state if it still belongs to ``pid``, else None.
+
+    For a request coming back, never for one starting. The COM calls have no
+    timeout, so a request can outlive the client it was sent to and return to a
+    handle Windows has since given to another one. Asking for the state by owner
+    then rebuilt it around the *old* pid -- throwing away a successful request or
+    a measured centre that belonged to the new client, and marking the dead one
+    as asked. The error path did the same to in_flight, clearing a flag it did
+    not set and letting a second request start. Reported by Codex on the pull
+    request, against the fix for the opposite half of this.
+
+    A completion that no longer owns the window has nothing to say about it.
+    """
+    state = _windows.get(hwnd)
+    if state is None or state.owner_pid != pid:
+        return None
+    return state
+
+
 def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> None:
     """Do the asking, on a thread of its own. See request_windows_accessibility."""
     try:
@@ -414,11 +434,16 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
         # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
         with _windows_lock:
-            _window_state(hwnd).in_flight = False
+            stale = _owned_window_state(hwnd, pid)
+            if stale is not None:
+                stale.in_flight = False
         return
 
     with _windows_lock:
-        state = _window_state(hwnd, pid)
+        state = _owned_window_state(hwnd, pid)
+        if state is None:
+            log.debug("Window %s changed hands while it was being asked; dropping the answer", hwnd)
+            return
         state.in_flight = False
         if asked_ia2:
             # Only an accepted IAccessible2 query counts as asked. A delivered

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -26,6 +26,7 @@ appear one at a time over the first betting round instead of all at once.
 
 from __future__ import annotations
 
+import ctypes
 import logging
 import math
 import os
@@ -245,6 +246,73 @@ class _WindowsUIAClient:
 
 _windows_uia_client: _WindowsUIAClient | None = None
 _windows_uia_unavailable = False
+
+#: WM_GETOBJECT / OBJID_CLIENT: what an assistive technology sends a window, and
+#: what a Chromium client watches for before it builds its accessibility tree.
+_WM_GETOBJECT = 0x003D
+_OBJID_CLIENT = -4
+_SMTO_ABORTIFHUNG = 0x0002
+_GETOBJECT_TIMEOUT_MS = 200
+
+#: Windows already asked, so a table is nudged once rather than on every read.
+_accessibility_asked: set[int] = set()
+
+
+def forget_accessibility_requests() -> None:
+    """Forget which windows have been asked, so the next read asks again."""
+    _accessibility_asked.clear()
+
+
+def request_windows_accessibility(hwnd: int) -> None:
+    """Ask a Chromium client to build its accessibility tree, once per window.
+
+    The macOS reader does this explicitly -- ``AXManualAccessibility`` on the
+    application -- and says why: "Chromium only builds its web accessibility
+    tree when an assistive client asks for it; without this the windows expose
+    nothing but their titles." Windows had no equivalent, and measured exactly
+    the symptom that note predicts: six nodes under a whole poker table, the
+    window title among them, and not one player. Every hand then fell back to
+    the client log, which names a player only once they have acted.
+
+    The Windows way of asking is WM_GETOBJECT with OBJID_CLIENT. It goes to the
+    table window and to each of its children, because the content is drawn in a
+    child render surface rather than the frame the HUD attached to.
+
+    SendMessageTimeout, never SendMessage: the client is another process, and a
+    blocked or busy one must not be able to hang the HUD's GUI thread. The tree
+    is built asynchronously, so the read that triggers this one will usually
+    still come back empty; the rechecks within the hand are what pick it up.
+    """
+    if platform.system() != "Windows" or not hwnd or hwnd in _accessibility_asked:
+        return
+    _accessibility_asked.add(hwnd)
+    try:
+        from ctypes import wintypes
+
+        user32 = ctypes.windll.user32
+        targets = [hwnd]
+
+        @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+        def _collect(child: int, _param: int) -> bool:
+            targets.append(child)
+            return True
+
+        user32.EnumChildWindows(wintypes.HWND(hwnd), _collect, 0)
+        result = ctypes.c_void_p()
+        for target in targets:
+            user32.SendMessageTimeoutW(
+                wintypes.HWND(target),
+                _WM_GETOBJECT,
+                0,
+                wintypes.LPARAM(_OBJID_CLIENT),
+                _SMTO_ABORTIFHUNG,
+                _GETOBJECT_TIMEOUT_MS,
+                ctypes.byref(result),
+            )
+        log.info("Asked %d window(s) of %s to publish their accessibility tree", len(targets), hwnd)
+    except Exception:
+        # Never fatal: without it the reader is exactly as blind as it was.
+        log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
 
 
 def reset_windows_uia() -> None:
@@ -680,6 +748,10 @@ class WinamaxAXSeatReader:
             if client is None:
                 return {}
 
+            # Ask before looking: a Chromium client publishes nothing until an
+            # assistive client asks, which is what the macOS reader does with
+            # AXManualAccessibility.
+            request_windows_accessibility(hwnd)
             elem = client.automation.ElementFromHandle(hwnd)
             if elem is None:
                 return {}

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -399,33 +399,32 @@ def request_windows_accessibility(hwnd: int) -> None:
         state.in_flight = True
     threading.Thread(
         target=_request_windows_accessibility_now,
-        args=(hwnd, pid),
+        args=(hwnd, state),
         name=f"fpdb-ax-request-{hwnd}",
         daemon=True,
     ).start()
 
 
-def _owned_window_state(hwnd: int, pid: int | None | object) -> _WindowState | None:
-    """This window's state if it still belongs to ``pid``, else None.
+def _still_current(hwnd: int, state: _WindowState) -> bool:
+    """Whether this is still the state the window is being tracked by.
 
     For a request coming back, never for one starting. The COM calls have no
-    timeout, so a request can outlive the client it was sent to and return to a
-    handle Windows has since given to another one. Asking for the state by owner
-    then rebuilt it around the *old* pid -- throwing away a successful request or
-    a measured centre that belonged to the new client, and marking the dead one
-    as asked. The error path did the same to in_flight, clearing a flag it did
-    not set and letting a second request start. Reported by Codex on the pull
-    request, against the fix for the opposite half of this.
+    timeout, so a request can outlive the window it was sent to and return to a
+    handle that has since been given to something else -- another client, or,
+    with Winamax still running, another table of the same one. The owner's pid
+    tells those two apart only in the first case; the object's identity tells
+    them apart in both, because the state is replaced whenever the window
+    behind the handle is not the one it was learned about.
 
-    A completion that no longer owns the window has nothing to say about it.
+    A completion that is not about the window being tracked now has nothing to
+    say about it. Reported by Codex on the pull request, twice: once for the
+    answer overwriting the new client's state, once for the same handle inside
+    one process.
     """
-    state = _windows.get(hwnd)
-    if state is None or state.owner_pid != pid:
-        return None
-    return state
+    return _windows.get(hwnd) is state
 
 
-def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> None:
+def _request_windows_accessibility_now(hwnd: int, state: _WindowState) -> None:
     """Do the asking, on a thread of its own. See request_windows_accessibility."""
     try:
         targets, delivered = _send_get_object(hwnd)
@@ -434,14 +433,12 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
         # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
         with _windows_lock:
-            stale = _owned_window_state(hwnd, pid)
-            if stale is not None:
-                stale.in_flight = False
+            if _still_current(hwnd, state):
+                state.in_flight = False
         return
 
     with _windows_lock:
-        state = _owned_window_state(hwnd, pid)
-        if state is None:
+        if not _still_current(hwnd, state):
             log.debug("Window %s changed hands while it was being asked; dropping the answer", hwnd)
             return
         state.in_flight = False

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -285,28 +285,43 @@ def request_windows_accessibility(hwnd: int) -> None:
     """
     if platform.system() != "Windows" or not hwnd or hwnd in _accessibility_asked:
         return
-    _accessibility_asked.add(hwnd)
     try:
-        targets = _send_get_object(hwnd)
+        targets, delivered = _send_get_object(hwnd)
         asked_ia2 = sum(_ask_for_complete_tree(target) for target in targets)
-        log.info(
-            "Asked %d window(s) of %s to publish their accessibility tree (%d accepted IAccessible2)",
-            len(targets),
-            hwnd,
-            asked_ia2,
-        )
     except Exception:
-        # Never fatal: without it the reader is exactly as blind as it was. The
-        # window is forgotten so a later read asks again -- a client still
-        # starting up, or momentarily hung, would otherwise be written off for
-        # the whole session by one badly timed attempt. Reported by Codex on the
-        # pull request.
-        _accessibility_asked.discard(hwnd)
+        # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
+        return
+
+    if not delivered and not asked_ia2:
+        # Nothing got through. SendMessageTimeoutW reports a hung or
+        # still-starting client by returning zero rather than raising, and
+        # _ask_for_complete_tree turns every COM failure into False, so an
+        # attempt can fail completely without anything being thrown. Recording
+        # the window here -- which is what the first version did, before the
+        # work -- wrote it off for the whole session on one badly timed try.
+        # Reported by Codex on the pull request, twice: the exception path alone
+        # was not enough.
+        log.debug("Window %s answered none of the accessibility requests; will ask again", hwnd)
+        return
+
+    _accessibility_asked.add(hwnd)
+    log.info(
+        "Asked %d window(s) of %s to publish their accessibility tree (%d delivered, %d accepted IAccessible2)",
+        len(targets),
+        hwnd,
+        delivered,
+        asked_ia2,
+    )
 
 
-def _send_get_object(hwnd: int) -> list[int]:  # pragma: no cover - Win32 calls
-    """Post WM_GETOBJECT to a window and its children; return the windows asked.
+def _send_get_object(hwnd: int) -> tuple[list[int], int]:  # pragma: no cover - Win32 calls
+    """Post WM_GETOBJECT to a window and its children.
+
+    Returns the windows asked and how many answered. SendMessageTimeoutW reports
+    a hung or still-starting client by returning zero rather than raising, so the
+    count is the only way the caller can tell a delivered request from one that
+    quietly went nowhere.
 
     Split out so the decision above it -- platform, once per window, what to do
     when the client will not answer -- is testable on any platform, while this
@@ -328,17 +343,20 @@ def _send_get_object(hwnd: int) -> list[int]:  # pragma: no cover - Win32 calls
 
     user32.EnumChildWindows(wintypes.HWND(hwnd), _collect, 0)
     result = ctypes.c_void_p()
+    delivered = 0
     for target in targets:
-        user32.SendMessageTimeoutW(
-            wintypes.HWND(target),
-            _WM_GETOBJECT,
-            0,
-            wintypes.LPARAM(_OBJID_CLIENT),
-            _SMTO_ABORTIFHUNG,
-            _GETOBJECT_TIMEOUT_MS,
-            ctypes.byref(result),
+        delivered += bool(
+            user32.SendMessageTimeoutW(
+                wintypes.HWND(target),
+                _WM_GETOBJECT,
+                0,
+                wintypes.LPARAM(_OBJID_CLIENT),
+                _SMTO_ABORTIFHUNG,
+                _GETOBJECT_TIMEOUT_MS,
+                ctypes.byref(result),
+            ),
         )
-    return targets
+    return targets, delivered
 
 
 def _ask_for_complete_tree(hwnd: int) -> bool:  # pragma: no cover - COM calls
@@ -483,8 +501,10 @@ def is_hud_label(text: str) -> bool:
     return False
 
 
-#: Table centres learned from a full ring, keyed by window. See _table_centre.
-_table_centres: dict[int, tuple[float, float]] = {}
+#: Table centres learned from a full ring: window -> (frame, centre). The frame
+#: is kept so a centre measured at one position is not reused at another. See
+#: _table_centre.
+_table_centres: dict[int, tuple[tuple[int, int, int, int], tuple[float, float]]] = {}
 
 
 def forget_table_centres() -> None:
@@ -535,13 +555,27 @@ def _table_centre(
             win_rect.left + (win_rect.right - win_rect.left) / 2,
             win_rect.top + (win_rect.bottom - win_rect.top) / 2,
         )
+    frame = (win_rect.left, win_rect.top, win_rect.right, win_rect.bottom)
     if len(players) >= max_seats:
         xs = [player.x for player in players]
         ys = [player.y for player in players]
         centre = ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
-        _table_centres[hwnd] = centre
+        _table_centres[hwnd] = (frame, centre)
         return centre
-    return _table_centres.get(hwnd)
+    # Only for the window it was measured on, where it was measured. A table
+    # moved or resized between hands puts its chairs somewhere else, and Windows
+    # hands a closed table's HWND to the next one -- either way the remembered
+    # point is somewhere on the desktop the seats no longer surround, and seats
+    # arranged around it land on the wrong chairs while still passing the
+    # caller's hero check. Reported by Codex on the pull request.
+    remembered = _table_centres.get(hwnd)
+    if remembered is None:
+        return None
+    known_frame, centre = remembered
+    if known_frame != frame:
+        del _table_centres[hwnd]
+        return None
+    return centre
 
 
 def seats_from_labels(labels: list[AXSeat]) -> list[AXSeat]:

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -259,22 +259,58 @@ _OBJID_CLIENT = -4
 _SMTO_ABORTIFHUNG = 0x0002
 _GETOBJECT_TIMEOUT_MS = 200
 
-#: Windows already asked, mapped to the process that owned them at the time, so
-#: a table is nudged once rather than on every read -- and a handle Windows has
-#: since recycled to a restarted client is asked again. Alongside, the ones being
-#: asked right now, so a second read does not start a second request while the
-#: first is still in the air. Both are touched from the reading thread and from
-#: the request threads, hence the lock.
-_accessibility_asked: dict[int, int | None] = {}
-_accessibility_in_flight: set[int] = set()
-_accessibility_lock = threading.Lock()
+@dataclass
+class _WindowState:
+    """Everything learned about reading one client window.
+
+    Three separate caches lived here, keyed by handle, each with its own
+    invalidation rule and each forgotten separately -- or, three times over,
+    not forgotten at all. Windows recycles a handle to whatever opens next, so
+    every one of them needed to know when the thing behind the numbers had
+    changed, and each learned that the hard way in turn.
+
+    One object, one lifetime. It is dropped whole when the client behind the
+    handle changes, which is the only event any of these three cared about.
+    """
+
+    #: The process the accessibility request was accepted for. A different owner
+    #: means a restarted client behind a recycled handle, which has not been
+    #: asked for anything. _UNASKED distinguishes "never asked" from "asked for a
+    #: window whose owner could not be read", which is a real answer.
+    asked_pid: int | None | object = None
+
+    #: A request is in the air. The reads are far faster than the request, so
+    #: without this a table starts one on every read until the first returns.
+    in_flight: bool = False
+
+    #: The table centre, and the window frame it was measured against. A frame
+    #: that has moved or been handed to another table puts the chairs elsewhere,
+    #: and seats arranged around the old point land on the wrong ones.
+    centre: tuple[float, float] | None = None
+    centre_frame: tuple[int, int, int, int] | None = None
 
 
-def forget_accessibility_requests() -> None:
-    """Forget which windows have been asked, so the next read asks again."""
-    with _accessibility_lock:
-        _accessibility_asked.clear()
-        _accessibility_in_flight.clear()
+#: Per window, and touched from the reading thread and the request threads.
+_windows: dict[int, _WindowState] = {}
+_windows_lock = threading.Lock()
+
+
+def _window_state(hwnd: int) -> _WindowState:
+    """The state for this window, created on first sight. Call under the lock."""
+    state = _windows.get(hwnd)
+    if state is None:
+        state = _WindowState(asked_pid=_UNASKED)
+        _windows[hwnd] = state
+    return state
+
+
+def forget_window_state(hwnd: int | None = None) -> None:
+    """Forget one window, or all of them, so the next read starts over."""
+    with _windows_lock:
+        if hwnd is None:
+            _windows.clear()
+        else:
+            _windows.pop(hwnd, None)
 
 
 def _window_pid(hwnd: int) -> int | None:  # pragma: no cover - Win32 call
@@ -336,10 +372,11 @@ def request_windows_accessibility(hwnd: int) -> None:
     # publish its felt. The centre cache learned the same lesson from its frame.
     # Reported by Codex on the pull request.
     pid = _window_pid(hwnd)
-    with _accessibility_lock:
-        if _accessibility_asked.get(hwnd, _UNASKED) == pid or hwnd in _accessibility_in_flight:
+    with _windows_lock:
+        state = _window_state(hwnd)
+        if state.asked_pid == pid or state.in_flight:
             return
-        _accessibility_in_flight.add(hwnd)
+        state.in_flight = True
     threading.Thread(
         target=_request_windows_accessibility_now,
         args=(hwnd, pid),
@@ -356,12 +393,13 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
     except Exception:
         # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
-        with _accessibility_lock:
-            _accessibility_in_flight.discard(hwnd)
+        with _windows_lock:
+            _window_state(hwnd).in_flight = False
         return
 
-    with _accessibility_lock:
-        _accessibility_in_flight.discard(hwnd)
+    with _windows_lock:
+        state = _window_state(hwnd)
+        state.in_flight = False
         if asked_ia2:
             # Only an accepted IAccessible2 query counts as asked. A delivered
             # WM_GETOBJECT gets Chromium as far as its native widgets -- the
@@ -372,7 +410,7 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
             # until the circuit breaker gave up on it: the exact failure this
             # branch exists to fix, reached through a partial success. Reported
             # by Codex on the pull request.
-            _accessibility_asked[hwnd] = pid
+            state.asked_pid = pid
 
     if not asked_ia2:
         # Nothing got through. SendMessageTimeoutW reports a hung or
@@ -591,17 +629,6 @@ def is_hud_label(text: str) -> bool:
     return False
 
 
-#: Table centres learned from a full ring: window -> (frame, centre). The frame
-#: is kept so a centre measured at one position is not reused at another. See
-#: _table_centre.
-_table_centres: dict[int, tuple[tuple[int, int, int, int], tuple[float, float]]] = {}
-
-
-def forget_table_centres() -> None:
-    """Drop the learned centres, so the next full ring is measured afresh."""
-    _table_centres.clear()
-
-
 def _table_centre(
     players: list[AXSeat],
     win_rect: Any,
@@ -646,26 +673,27 @@ def _table_centre(
             win_rect.top + (win_rect.bottom - win_rect.top) / 2,
         )
     frame = (win_rect.left, win_rect.top, win_rect.right, win_rect.bottom)
-    if len(players) >= max_seats:
-        xs = [player.x for player in players]
-        ys = [player.y for player in players]
-        centre = ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
-        _table_centres[hwnd] = (frame, centre)
-        return centre
+    with _windows_lock:
+        state = _window_state(hwnd)
+        if len(players) >= max_seats:
+            xs = [player.x for player in players]
+            ys = [player.y for player in players]
+            state.centre = ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+            state.centre_frame = frame
+            return state.centre
     # Only for the window it was measured on, where it was measured. A table
     # moved or resized between hands puts its chairs somewhere else, and Windows
     # hands a closed table's HWND to the next one -- either way the remembered
     # point is somewhere on the desktop the seats no longer surround, and seats
     # arranged around it land on the wrong chairs while still passing the
     # caller's hero check. Reported by Codex on the pull request.
-    remembered = _table_centres.get(hwnd)
-    if remembered is None:
-        return None
-    known_frame, centre = remembered
-    if known_frame != frame:
-        del _table_centres[hwnd]
-        return None
-    return centre
+        if state.centre is None:
+            return None
+        if state.centre_frame != frame:
+            state.centre = None
+            state.centre_frame = None
+            return None
+        return state.centre
 
 
 def seats_from_labels(labels: list[AXSeat]) -> list[AXSeat]:

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -358,6 +358,11 @@ def _windows_uia() -> _WindowsUIAClient | None:
     return _windows_uia_client
 
 
+def read_window_for(hwnd: int, title: str = "", max_seats: int = 6) -> dict[int, str]:
+    """One window read by handle, for diagnostics that hold a HWND and no reader."""
+    return WinamaxAXSeatReader().read_window(title, max_seats, window_id=hwnd)
+
+
 def is_stack_label(text: str) -> bool:
     """Whether a text node is a chip count rather than anything else."""
     return bool(_STACK.match(text.strip()))

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -248,9 +248,9 @@ class _WindowsUIAClient:
 _windows_uia_client: _WindowsUIAClient | None = None
 _windows_uia_unavailable = False
 
-#: No process could ever own a window, so it can stand for "never asked" in a
-#: comparison against one that could be None because the handle was unreadable.
-_UNASKED = object()
+#: No process could ever own a window, so it can stand for "not yet known" in a
+#: comparison against an owner that could be None because the handle was gone.
+_UNKNOWN = object()
 
 #: WM_GETOBJECT / OBJID_CLIENT: what an assistive technology sends a window, and
 #: what a Chromium client watches for before it builds its accessibility tree.
@@ -273,11 +273,17 @@ class _WindowState:
     handle changes, which is the only event any of these three cared about.
     """
 
-    #: The process the accessibility request was accepted for. A different owner
-    #: means a restarted client behind a recycled handle, which has not been
-    #: asked for anything. _UNASKED distinguishes "never asked" from "asked for a
-    #: window whose owner could not be read", which is a real answer.
-    asked_pid: int | None | object = None
+    #: The process this state belongs to, once one has been read. A handle whose
+    #: owner has changed is a restarted client behind recycled numbers, and
+    #: nothing learned about the old one applies -- so the state is replaced
+    #: rather than carried over. _UNKNOWN, not None: None is a real answer from
+    #: GetWindowThreadProcessId for a window that has gone.
+    owner_pid: int | None | object = _UNKNOWN
+
+    #: Whether this owner accepted an IAccessible2 query. A delivered
+    #: WM_GETOBJECT does not count: it gets Chromium as far as its native
+    #: widgets, and the felt is web content.
+    asked: bool = False
 
     #: A request is in the air. The reads are far faster than the request, so
     #: without this a table starts one on every read until the first returns.
@@ -295,12 +301,26 @@ _windows: dict[int, _WindowState] = {}
 _windows_lock = threading.Lock()
 
 
-def _window_state(hwnd: int) -> _WindowState:
-    """The state for this window, created on first sight. Call under the lock."""
+def _window_state(hwnd: int, owner_pid: int | None | object = _UNKNOWN) -> _WindowState:
+    """The state for this window, created on first sight. Call under the lock.
+
+    Given an owner, a state belonging to a different one is replaced rather than
+    returned: Windows recycles a handle to whatever opens next, and a Winamax
+    restarted while the HUD lives gets a new process behind the same numbers.
+    Everything here was learned about the old one -- whether it had been asked,
+    where its table's centre was, and whether a request it never answered is
+    still counted as in the air. Reported by Codex on the pull request, against
+    the refactor that says in its own docstring that this is what it does.
+    """
     state = _windows.get(hwnd)
+    if state is not None and owner_pid is not _UNKNOWN and state.owner_pid is not _UNKNOWN and state.owner_pid != owner_pid:
+        log.info("Window %s has a new owner; forgetting what was learned about the old one", hwnd)
+        state = None
     if state is None:
-        state = _WindowState(asked_pid=_UNASKED)
+        state = _WindowState()
         _windows[hwnd] = state
+    if owner_pid is not _UNKNOWN:
+        state.owner_pid = owner_pid
     return state
 
 
@@ -373,8 +393,8 @@ def request_windows_accessibility(hwnd: int) -> None:
     # Reported by Codex on the pull request.
     pid = _window_pid(hwnd)
     with _windows_lock:
-        state = _window_state(hwnd)
-        if state.asked_pid == pid or state.in_flight:
+        state = _window_state(hwnd, pid)
+        if state.asked or state.in_flight:
             return
         state.in_flight = True
     threading.Thread(
@@ -398,7 +418,7 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
         return
 
     with _windows_lock:
-        state = _window_state(hwnd)
+        state = _window_state(hwnd, pid)
         state.in_flight = False
         if asked_ia2:
             # Only an accepted IAccessible2 query counts as asked. A delivered
@@ -410,7 +430,7 @@ def _request_windows_accessibility_now(hwnd: int, pid: int | None = None) -> Non
             # until the circuit breaker gave up on it: the exact failure this
             # branch exists to fix, reached through a partial success. Reported
             # by Codex on the pull request.
-            state.asked_pid = pid
+            state.asked = True
 
     if not asked_ia2:
         # Nothing got through. SendMessageTimeoutW reports a hung or

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -287,28 +287,7 @@ def request_windows_accessibility(hwnd: int) -> None:
         return
     _accessibility_asked.add(hwnd)
     try:
-        from ctypes import wintypes
-
-        user32 = ctypes.windll.user32
-        targets = [hwnd]
-
-        @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
-        def _collect(child: int, _param: int) -> bool:
-            targets.append(child)
-            return True
-
-        user32.EnumChildWindows(wintypes.HWND(hwnd), _collect, 0)
-        result = ctypes.c_void_p()
-        for target in targets:
-            user32.SendMessageTimeoutW(
-                wintypes.HWND(target),
-                _WM_GETOBJECT,
-                0,
-                wintypes.LPARAM(_OBJID_CLIENT),
-                _SMTO_ABORTIFHUNG,
-                _GETOBJECT_TIMEOUT_MS,
-                ctypes.byref(result),
-            )
+        targets = _send_get_object(hwnd)
         asked_ia2 = sum(_ask_for_complete_tree(target) for target in targets)
         log.info(
             "Asked %d window(s) of %s to publish their accessibility tree (%d accepted IAccessible2)",
@@ -321,7 +300,43 @@ def request_windows_accessibility(hwnd: int) -> None:
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
 
 
-def _ask_for_complete_tree(hwnd: int) -> bool:
+def _send_get_object(hwnd: int) -> list[int]:  # pragma: no cover - Win32 calls
+    """Post WM_GETOBJECT to a window and its children; return the windows asked.
+
+    Split out so the decision above it -- platform, once per window, what to do
+    when the client will not answer -- is testable on any platform, while this
+    reaches ctypes.windll and ctypes.WINFUNCTYPE, neither of which exists off
+    Windows to be stood in for.
+
+    SendMessageTimeout, never SendMessage: the client is another process, and a
+    blocked or busy one must not be able to hang the HUD's GUI thread.
+    """
+    from ctypes import wintypes
+
+    user32 = ctypes.windll.user32
+    targets = [hwnd]
+
+    @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+    def _collect(child: int, _param: int) -> bool:
+        targets.append(child)
+        return True
+
+    user32.EnumChildWindows(wintypes.HWND(hwnd), _collect, 0)
+    result = ctypes.c_void_p()
+    for target in targets:
+        user32.SendMessageTimeoutW(
+            wintypes.HWND(target),
+            _WM_GETOBJECT,
+            0,
+            wintypes.LPARAM(_OBJID_CLIENT),
+            _SMTO_ABORTIFHUNG,
+            _GETOBJECT_TIMEOUT_MS,
+            ctypes.byref(result),
+        )
+    return targets
+
+
+def _ask_for_complete_tree(hwnd: int) -> bool:  # pragma: no cover - COM calls
     """Ask one window for IAccessible2, which is what unlocks the felt.
 
     WM_GETOBJECT alone buys Chromium's "native APIs" mode: the frame, the Views

--- a/fpdb_3_legacy/winamax_ax_seats.py
+++ b/fpdb_3_legacy/winamax_ax_seats.py
@@ -309,10 +309,70 @@ def request_windows_accessibility(hwnd: int) -> None:
                 _GETOBJECT_TIMEOUT_MS,
                 ctypes.byref(result),
             )
-        log.info("Asked %d window(s) of %s to publish their accessibility tree", len(targets), hwnd)
+        asked_ia2 = sum(_ask_for_complete_tree(target) for target in targets)
+        log.info(
+            "Asked %d window(s) of %s to publish their accessibility tree (%d accepted IAccessible2)",
+            len(targets),
+            hwnd,
+            asked_ia2,
+        )
     except Exception:
         # Never fatal: without it the reader is exactly as blind as it was.
         log.debug("Could not ask window %s for its accessibility tree", hwnd, exc_info=True)
+
+
+def _ask_for_complete_tree(hwnd: int) -> bool:
+    """Ask one window for IAccessible2, which is what unlocks the felt.
+
+    WM_GETOBJECT alone buys Chromium's "native APIs" mode: the frame, the Views
+    widgets and the dialogs. Measured on a table mid-hand, that is exactly what
+    came back -- 'Autorebuy', 'Confirmer', the hero's own seat -- and not one
+    opponent, because the felt is web content and web content needs the complete
+    mode.
+
+    Querying IAccessible2 through IServiceProvider is what a screen reader does,
+    and what Chromium watches for before it builds that tree. Measured on the
+    same table, immediately after: 32 labels became 54, and seats_from_labels
+    went from the hero alone to all six players with their stacks.
+
+    Per process and reversible, unlike the SPI_SETSCREENREADER system flag,
+    which would change how every application on the desktop behaves.
+    """
+    try:
+        import ctypes
+        from ctypes import POINTER, byref, c_void_p, wintypes
+
+        from comtypes import COMMETHOD, GUID, HRESULT, IUnknown
+
+        class _IServiceProvider(IUnknown):
+            _iid_ = GUID("{6D5140C1-7436-11CE-8034-00AA006009FA}")
+            _methods_ = [
+                COMMETHOD(
+                    [],
+                    HRESULT,
+                    "QueryService",
+                    (["in"], POINTER(GUID), "guidService"),
+                    (["in"], POINTER(GUID), "riid"),
+                    (["out"], POINTER(c_void_p), "ppvObject"),
+                ),
+            ]
+
+        iid_accessible = GUID("{618736E0-3C3D-11CF-810C-00AA00389B71}")
+        iid_accessible2 = GUID("{E89F726E-C4F4-4C19-BB19-B647D7FA8478}")
+        accessible = POINTER(IUnknown)()
+        ctypes.oledll.oleacc.AccessibleObjectFromWindow(
+            wintypes.HWND(hwnd),
+            ctypes.c_ulong(_OBJID_CLIENT & 0xFFFFFFFF),
+            byref(iid_accessible),
+            byref(accessible),
+        )
+        provider = accessible.QueryInterface(_IServiceProvider)
+        return bool(provider.QueryService(byref(iid_accessible2), byref(iid_accessible2)))
+    except Exception:
+        # A window with no accessible object, or one that declines: the others
+        # are still worth asking, and the reader is no worse off than before.
+        log.debug("Window %s did not answer an IAccessible2 query", hwnd, exc_info=True)
+        return False
 
 
 def reset_windows_uia() -> None:
@@ -401,6 +461,38 @@ def is_hud_label(text: str) -> bool:
         return True
 
     return False
+
+
+def _table_centre(players: list[AXSeat], win_rect: Any) -> tuple[float, float]:
+    """The point the seats are arranged around, in the players' own coordinates.
+
+    The window rectangle is the obvious answer and it is the wrong one here. The
+    client reports its content in a different space from its frame -- a window
+    at x 3840..4800 whose six players sit at x 1767..2259 -- so a centre taken
+    from the frame is off to one side of every player, they all read as lying in
+    one direction from it, and the whole ring collapses into a single slot:
+
+        centre from the window rect : {2: 'CTroPinJust'}
+        centre from the players     : {0: 'jejellyroll', 1: 'depor81', ...}
+
+    Whatever the reason for the mismatch -- the HUD process is DPI-unaware, and
+    the client is not -- the players are all in one space as each other, which is
+    the only space the angles have to agree in. So the ring's own bounding box
+    is used whenever the players are not inside the frame, and the frame when
+    they are, which is what a client reporting one consistent space gives.
+    """
+    inside = all(
+        win_rect.left <= player.x <= win_rect.right and win_rect.top <= player.y <= win_rect.bottom
+        for player in players
+    )
+    if players and not inside:
+        xs = [player.x for player in players]
+        ys = [player.y for player in players]
+        return ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+    return (
+        win_rect.left + (win_rect.right - win_rect.left) / 2,
+        win_rect.top + (win_rect.bottom - win_rect.top) / 2,
+    )
 
 
 def seats_from_labels(labels: list[AXSeat]) -> list[AXSeat]:
@@ -769,8 +861,7 @@ class WinamaxAXSeatReader:
             win_rect = elem.CurrentBoundingRectangle
             if not win_rect:
                 return {}
-            centre = (win_rect.left + (win_rect.right - win_rect.left) / 2, win_rect.top + (win_rect.bottom - win_rect.top) / 2)
-            return seat_slots_from_positions(players, centre, max_seats)
+            return seat_slots_from_positions(players, _table_centre(players, win_rect), max_seats)
         except Exception:
             log.debug("Error reading Winamax UIAutomation seats on Windows for HWND %s:", hwnd, exc_info=True)
             return {}

--- a/test/test_HUD_main.py
+++ b/test/test_HUD_main.py
@@ -2867,7 +2867,11 @@ def test_the_log_ring_takes_over_when_the_window_never_shows_a_dealt_table(hud_m
     # A read that names one player and never the hero's chair.
     hud_main.winamax_ax_seats = SimpleNamespace(read_window=lambda t, max_seats=6, **_kwargs: {3: "Player01"})
     # This hand's reads are already spent (the table is keyed by its title here).
-    hud_main._ax_rings["Winamax Casablanca 6"] = ("h1", {3: "Player01"}, hud_main.AX_READS_PER_HAND)
+    hud_main._table_reads["Winamax Casablanca 6"] = HUD_main.TableReadState(
+        hand_id="h1",
+        ring={3: "Player01"},
+        reads=hud_main.AX_READS_PER_HAND,
+    )
     # A log line from later in the hand: the ring has had its chance to fill.
     hud_main._ff_started["h1"] = time.monotonic() - 1.0
     try:

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -31,9 +31,7 @@ def _hud_main(slots_per_read):
     reader.read_window.side_effect = slots_per_read
     return SimpleNamespace(
         winamax_ax_seats=reader,
-        _ax_rings={},
-        _ax_fruitless_reads={},
-        _ax_reader_gave_up={},
+        _table_reads={},
         _ax_reader_enabled=True,
         _ff_trace=MagicMock(),
         AX_READS_PER_HAND=HUD_main.HudMain.AX_READS_PER_HAND,
@@ -58,7 +56,7 @@ def test_the_reader_is_given_up_on_after_enough_empty_reads() -> None:
     for hand in range(GIVE_UP_AT):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is True
 
 
 def test_no_further_reads_are_paid_for_once_it_has_given_up() -> None:
@@ -85,8 +83,8 @@ def test_a_reader_that_works_is_never_given_up_on() -> None:
     for hand in range(GIVE_UP_AT + 2):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
-    assert app._ax_fruitless_reads.get("Colorado 11 #3477872") == 0
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is False
+    assert app._table_reads["Colorado 11 #3477872"].fruitless == 0
 
 
 def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
@@ -96,7 +94,7 @@ def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
     for hand in range(GIVE_UP_AT + 4):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is False
 
 
 def test_one_table_giving_up_does_not_silence_another() -> None:
@@ -111,8 +109,8 @@ def test_one_table_giving_up_does_not_silence_another() -> None:
     for hand in range(GIVE_UP_AT):
         _read(app, f"hand-{hand}", table_key="Colorado 11 #3477872")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
-    assert app._ax_reader_gave_up.get("Colorado 12 #463544") is None
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is True
+    assert "Colorado 12 #463544" not in app._table_reads
 
     reads_before = app.winamax_ax_seats.read_window.call_count
     _read(app, "another", table_key="Colorado 12 #463544")
@@ -135,7 +133,7 @@ def test_reads_that_never_seat_anyone_are_given_up_on() -> None:
     for hand in range(GIVE_UP_AT):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is True
 
 
 def test_a_read_holding_the_hero_but_too_few_players_is_fruitless() -> None:
@@ -145,7 +143,7 @@ def test_a_read_holding_the_hero_but_too_few_players_is_fruitless() -> None:
     for hand in range(GIVE_UP_AT):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is True
 
 
 def test_one_usable_read_forgives_the_useless_ones_before_it() -> None:
@@ -158,7 +156,7 @@ def test_one_usable_read_forgives_the_useless_ones_before_it() -> None:
     for hand in range(GIVE_UP_AT + 4):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
+    assert app._table_reads["Colorado 11 #3477872"].gave_up is False
 
 
 def test_the_reader_can_be_switched_off_outright() -> None:
@@ -170,7 +168,7 @@ def test_the_reader_can_be_switched_off_outright() -> None:
     app.winamax_ax_seats.read_window.assert_not_called()
 
 
-def _sweeper(gave_up: dict, enabled: bool = True):
+def _sweeper(gave_up: bool = False, enabled: bool = True):
     """A HudMain stub carrying only what _read_window_slots touches."""
     reader = MagicMock()
     reader.read_window.return_value = {0: "jejellyroll", 1: "Bussy67"}
@@ -178,7 +176,7 @@ def _sweeper(gave_up: dict, enabled: bool = True):
     return (
         SimpleNamespace(
             winamax_ax_seats=reader,
-            _ax_reader_gave_up=gave_up,
+            _table_reads=({"Colorado 11 #3477872": HUD_main.TableReadState(gave_up=True)} if gave_up else {}),
             _ax_reader_enabled=enabled,
         ),
         SimpleNamespace(table=table, max=6),
@@ -186,7 +184,7 @@ def _sweeper(gave_up: dict, enabled: bool = True):
 
 
 def test_the_idle_sweep_reads_a_table_that_still_answers() -> None:
-    app, hud = _sweeper({})
+    app, hud = _sweeper()
 
     assert HUD_main.HudMain._read_window_slots(app, hud) == {0: "jejellyroll", 1: "Bussy67"}
 
@@ -198,14 +196,14 @@ def test_the_idle_sweep_stops_reading_a_table_given_up_on() -> None:
     walking another process's accessibility tree -- on exactly the clients the
     breaker exists to stop reading, and for a table nobody was playing.
     """
-    app, hud = _sweeper({"Colorado 11 #3477872": True})
+    app, hud = _sweeper(gave_up=True)
 
     assert HUD_main.HudMain._read_window_slots(app, hud) is None
     app.winamax_ax_seats.read_window.assert_not_called()
 
 
 def test_the_idle_sweep_respects_the_reader_being_switched_off() -> None:
-    app, hud = _sweeper({}, enabled=False)
+    app, hud = _sweeper(enabled=False)
 
     assert HUD_main.HudMain._read_window_slots(app, hud) is None
     app.winamax_ax_seats.read_window.assert_not_called()
@@ -220,28 +218,25 @@ def test_a_retiring_table_takes_the_breaker_s_verdict_with_it() -> None:
     accessibility, and went straight to the log-derived seats for the session.
     """
     app = SimpleNamespace(
-        _ax_reader_gave_up={"Colorado 3": True},
-        _ax_fruitless_reads={"Colorado 3": 12},
-        _ax_rings={"Colorado 3": ("hand-1", {}, 12)},
+        _table_reads={"Colorado 3": HUD_main.TableReadState(gave_up=True, fruitless=12, reads=12)},
     )
 
     HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3")
 
-    assert app._ax_reader_gave_up == {}
-    assert app._ax_fruitless_reads == {}
-    assert app._ax_rings == {}
+    assert app._table_reads == {}
 
 
 def test_forgetting_one_table_leaves_the_others_alone() -> None:
     app = SimpleNamespace(
-        _ax_reader_gave_up={"Colorado 3": True, "Colorado 4": True},
-        _ax_fruitless_reads={},
-        _ax_rings={},
+        _table_reads={
+            "Colorado 3": HUD_main.TableReadState(gave_up=True),
+            "Colorado 4": HUD_main.TableReadState(gave_up=True),
+        },
     )
 
     HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3")
 
-    assert app._ax_reader_gave_up == {"Colorado 4": True}
+    assert list(app._table_reads) == ["Colorado 4"]
 
 
 def test_forgetting_survives_a_hud_built_without_the_full_constructor() -> None:

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -38,6 +38,7 @@ def _hud_main(slots_per_read):
         AX_READS_PER_HAND=HUD_main.HudMain.AX_READS_PER_HAND,
         AX_FRUITLESS_READS_BEFORE_GIVING_UP=GIVE_UP_AT,
         HERO_SLOT=HUD_main.HudMain.HERO_SLOT,
+        MIN_PLAYERS_TO_SHOW=HUD_main.HudMain.MIN_PLAYERS_TO_SHOW,
     )
 
 
@@ -73,7 +74,11 @@ def test_no_further_reads_are_paid_for_once_it_has_given_up() -> None:
 
 
 def test_a_reader_that_works_is_never_given_up_on() -> None:
-    """A client that does publish its table must keep the fast path forever."""
+    """A client that does publish its table must keep the fast path forever.
+
+    Slot 0 is the bottom-centre chair the hero is always drawn in; a read
+    holding it, with enough players, is one the caller can act on.
+    """
     app = _hud_main([{0: "jejellyroll", 1: "Bussy67"}] * (GIVE_UP_AT + 5))
 
     for hand in range(GIVE_UP_AT + 2):
@@ -85,7 +90,7 @@ def test_a_reader_that_works_is_never_given_up_on() -> None:
 
 def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
     """A table being redrawn is not a client that publishes nothing."""
-    app = _hud_main([{}] * (GIVE_UP_AT - 1) + [{0: "jejellyroll"}] + [{}] * 5)
+    app = _hud_main([{}] * (GIVE_UP_AT - 1) + [{0: "jejellyroll", 1: "Bussy67"}] + [{}] * 5)
 
     for hand in range(GIVE_UP_AT + 4):
         _read(app, f"hand-{hand}")
@@ -112,3 +117,44 @@ def test_one_table_giving_up_does_not_silence_another() -> None:
     _read(app, "another", table_key="Colorado 12 #463544")
 
     assert app.winamax_ax_seats.read_window.call_count == reads_before + 1
+
+
+def test_reads_that_never_seat_anyone_are_given_up_on() -> None:
+    """Measured on a live session, every read of every hand, on both tables:
+
+        window-read ... 172ms read#1 players=2 slots={1: 'jejellyroll', 2: 'cr-scot'}
+
+    Non-empty, so the old counter reset on every one of them and the breaker
+    never tripped -- but slot 0 is missing, so the caller cannot place the hero
+    and throws the answer away. Six reads a hand at 94-172ms, on two tables,
+    for nothing. "Fruitless" has to mean "could not be acted on".
+    """
+    app = _hud_main([{1: "jejellyroll", 2: "cr-scot"}] * (GIVE_UP_AT + 5))
+
+    for hand in range(GIVE_UP_AT):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+
+
+def test_a_read_holding_the_hero_but_too_few_players_is_fruitless() -> None:
+    """The caller needs MIN_PLAYERS_TO_SHOW as well as the hero's chair."""
+    app = _hud_main([{0: "jejellyroll"}] * (GIVE_UP_AT + 5))
+
+    for hand in range(GIVE_UP_AT):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+
+
+def test_one_usable_read_forgives_the_useless_ones_before_it() -> None:
+    app = _hud_main(
+        [{1: "jejellyroll", 2: "x"}] * (GIVE_UP_AT - 1)
+        + [{0: "jejellyroll", 1: "x"}]
+        + [{1: "jejellyroll", 2: "x"}] * 5,
+    )
+
+    for hand in range(GIVE_UP_AT + 4):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -168,3 +168,44 @@ def test_the_reader_can_be_switched_off_outright() -> None:
 
     assert _read(app, "hand-1") == {}
     app.winamax_ax_seats.read_window.assert_not_called()
+
+
+def _sweeper(gave_up: dict, enabled: bool = True):
+    """A HudMain stub carrying only what _read_window_slots touches."""
+    reader = MagicMock()
+    reader.read_window.return_value = {0: "jejellyroll", 1: "Bussy67"}
+    table = SimpleNamespace(title="Winamax Colorado 11", key="Colorado 11 #3477872", number=3477872)
+    return (
+        SimpleNamespace(
+            winamax_ax_seats=reader,
+            _ax_reader_gave_up=gave_up,
+            _ax_reader_enabled=enabled,
+        ),
+        SimpleNamespace(table=table, max=6),
+    )
+
+
+def test_the_idle_sweep_reads_a_table_that_still_answers() -> None:
+    app, hud = _sweeper({})
+
+    assert HUD_main.HudMain._read_window_slots(app, hud) == {0: "jejellyroll", 1: "Bussy67"}
+
+
+def test_the_idle_sweep_stops_reading_a_table_given_up_on() -> None:
+    """It ran every FF_IDLE_RECHECK_SECONDS regardless, for the whole session.
+
+    The per-hand path stopped and this one did not, so an abandoned table went on
+    walking another process's accessibility tree -- on exactly the clients the
+    breaker exists to stop reading, and for a table nobody was playing.
+    """
+    app, hud = _sweeper({"Colorado 11 #3477872": True})
+
+    assert HUD_main.HudMain._read_window_slots(app, hud) is None
+    app.winamax_ax_seats.read_window.assert_not_called()
+
+
+def test_the_idle_sweep_respects_the_reader_being_switched_off() -> None:
+    app, hud = _sweeper({}, enabled=False)
+
+    assert HUD_main.HudMain._read_window_slots(app, hud) is None
+    app.winamax_ax_seats.read_window.assert_not_called()

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -209,3 +209,41 @@ def test_the_idle_sweep_respects_the_reader_being_switched_off() -> None:
 
     assert HUD_main.HudMain._read_window_slots(app, hud) is None
     app.winamax_ax_seats.read_window.assert_not_called()
+
+
+def test_a_retiring_table_takes_the_breaker_s_verdict_with_it() -> None:
+    """A pool hands the same name back to the next table it opens.
+
+    Close a table and Winamax gives the next one the same "Colorado 3", so a HUD
+    built after a restart inherited "this client will not answer" from a client
+    that is no longer running: it never read its window, never asked for
+    accessibility, and went straight to the log-derived seats for the session.
+    """
+    app = SimpleNamespace(
+        _ax_reader_gave_up={"Colorado 3": True},
+        _ax_fruitless_reads={"Colorado 3": 12},
+        _ax_rings={"Colorado 3": ("hand-1", {}, 12)},
+    )
+
+    HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3")
+
+    assert app._ax_reader_gave_up == {}
+    assert app._ax_fruitless_reads == {}
+    assert app._ax_rings == {}
+
+
+def test_forgetting_one_table_leaves_the_others_alone() -> None:
+    app = SimpleNamespace(
+        _ax_reader_gave_up={"Colorado 3": True, "Colorado 4": True},
+        _ax_fruitless_reads={},
+        _ax_rings={},
+    )
+
+    HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3")
+
+    assert app._ax_reader_gave_up == {"Colorado 4": True}
+
+
+def test_forgetting_survives_a_hud_built_without_the_full_constructor() -> None:
+    """The same shape _clear_fast_fold_table's neighbours guard against."""
+    HUD_main.HudMain._forget_window_seat_state(SimpleNamespace(), "Colorado 3")

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -34,6 +34,7 @@ def _hud_main(slots_per_read):
         _ax_rings={},
         _ax_fruitless_reads={},
         _ax_reader_gave_up={},
+        _ax_reader_enabled=True,
         _ff_trace=MagicMock(),
         AX_READS_PER_HAND=HUD_main.HudMain.AX_READS_PER_HAND,
         AX_FRUITLESS_READS_BEFORE_GIVING_UP=GIVE_UP_AT,
@@ -158,3 +159,12 @@ def test_one_usable_read_forgives_the_useless_ones_before_it() -> None:
         _read(app, f"hand-{hand}")
 
     assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
+
+
+def test_the_reader_can_be_switched_off_outright() -> None:
+    """A player whose client never publishes its felt should not pay two hands a session."""
+    app = _hud_main([{0: "jejellyroll", 1: "Bussy67"}] * 5)
+    app._ax_reader_enabled = False
+
+    assert _read(app, "hand-1") == {}
+    app.winamax_ax_seats.read_window.assert_not_called()

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -242,3 +242,35 @@ def test_forgetting_one_table_leaves_the_others_alone() -> None:
 def test_forgetting_survives_a_hud_built_without_the_full_constructor() -> None:
     """The same shape _clear_fast_fold_table's neighbours guard against."""
     HUD_main.HudMain._forget_window_seat_state(SimpleNamespace(), "Colorado 3")
+
+
+def test_retiring_a_table_releases_its_window_state_too(monkeypatch) -> None:
+    """Nothing released it in production, which is how a handle carried its past.
+
+    Winamax hands one table's HWND to another of its own, so the owner's pid is
+    identical and says nothing; only the HUD knows the table has gone.
+    """
+    from fpdb_3_legacy import winamax_ax_seats
+
+    forgotten = []
+    monkeypatch.setattr(winamax_ax_seats, "forget_window_state", forgotten.append)
+    app = SimpleNamespace(_table_reads={"Colorado 3": HUD_main.TableReadState()})
+
+    HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3", 3477872)
+
+    assert forgotten == [3477872]
+    assert app._table_reads == {}
+
+
+def test_retiring_a_table_with_no_window_forgets_only_what_it_has(monkeypatch) -> None:
+    """A HUD torn down before its window resolved has no handle to release."""
+    from fpdb_3_legacy import winamax_ax_seats
+
+    forgotten = []
+    monkeypatch.setattr(winamax_ax_seats, "forget_window_state", forgotten.append)
+    app = SimpleNamespace(_table_reads={"Colorado 3": HUD_main.TableReadState()})
+
+    HUD_main.HudMain._forget_window_seat_state(app, "Colorado 3", None)
+
+    assert forgotten == []
+    assert app._table_reads == {}

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -32,8 +32,8 @@ def _hud_main(slots_per_read):
     return SimpleNamespace(
         winamax_ax_seats=reader,
         _ax_rings={},
-        _ax_fruitless_reads=0,
-        _ax_reader_gave_up=False,
+        _ax_fruitless_reads={},
+        _ax_reader_gave_up={},
         _ff_trace=MagicMock(),
         AX_READS_PER_HAND=HUD_main.HudMain.AX_READS_PER_HAND,
         AX_FRUITLESS_READS_BEFORE_GIVING_UP=GIVE_UP_AT,
@@ -46,8 +46,8 @@ def _hud(table_key: str = "Colorado 11 #3477872"):
     return SimpleNamespace(table=table)
 
 
-def _read(app, hand_id: str) -> dict:
-    return HUD_main.HudMain._ax_slots(app, _hud(), hand_id, 6)
+def _read(app, hand_id: str, table_key: str = "Colorado 11 #3477872") -> dict:
+    return HUD_main.HudMain._ax_slots(app, _hud(table_key), hand_id, 6)
 
 
 def test_the_reader_is_given_up_on_after_enough_empty_reads() -> None:
@@ -56,7 +56,7 @@ def test_the_reader_is_given_up_on_after_enough_empty_reads() -> None:
     for hand in range(GIVE_UP_AT):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up is True
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
 
 
 def test_no_further_reads_are_paid_for_once_it_has_given_up() -> None:
@@ -79,8 +79,8 @@ def test_a_reader_that_works_is_never_given_up_on() -> None:
     for hand in range(GIVE_UP_AT + 2):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up is False
-    assert app._ax_fruitless_reads == 0
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
+    assert app._ax_fruitless_reads.get("Colorado 11 #3477872") == 0
 
 
 def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
@@ -90,4 +90,25 @@ def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
     for hand in range(GIVE_UP_AT + 4):
         _read(app, f"hand-{hand}")
 
-    assert app._ax_reader_gave_up is False
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is None
+
+
+def test_one_table_giving_up_does_not_silence_another() -> None:
+    """A single counter reached its threshold in half the hands with two tables.
+
+    The evidence for "this client publishes nothing" has to be gathered per
+    table, or multitabling gives up before one table has been asked five hands'
+    worth of times.
+    """
+    app = _hud_main([{}] * (GIVE_UP_AT * 2 + 5))
+
+    for hand in range(GIVE_UP_AT):
+        _read(app, f"hand-{hand}", table_key="Colorado 11 #3477872")
+
+    assert app._ax_reader_gave_up.get("Colorado 11 #3477872") is True
+    assert app._ax_reader_gave_up.get("Colorado 12 #463544") is None
+
+    reads_before = app.winamax_ax_seats.read_window.call_count
+    _read(app, "another", table_key="Colorado 12 #463544")
+
+    assert app.winamax_ax_seats.read_window.call_count == reads_before + 1

--- a/test/test_fast_fold_ax_circuit_breaker.py
+++ b/test/test_fast_fold_ax_circuit_breaker.py
@@ -1,0 +1,93 @@
+"""A window reader that never finds anyone must stop being paid for.
+
+Measured on a live 3.8.1 session against the Winamax client, with the trace on:
+
+    window-read 'Winamax Colorado 11' 47ms read#1 players=0 slots={} empty=[0..5]
+    window-read 'Winamax Colorado 11' 16ms read#2 players=0 slots={} empty=[0..5]
+    ... six a hand, on both tables, every one of them players=0
+
+The client does not publish its table content through UIAutomation, so the read
+can only ever come back empty. Each one is a synchronous walk of another
+process's tree on the GUI thread, at hand-start -- exactly when the HUD is
+trying to draw. The seats then come from the client log either way.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from fpdb_3_legacy import HUD_main  # noqa: E402
+
+GIVE_UP_AT = HUD_main.HudMain.AX_FRUITLESS_READS_BEFORE_GIVING_UP
+
+
+def _hud_main(slots_per_read):
+    """A HudMain stub carrying only what _ax_slots touches."""
+    reader = MagicMock()
+    reader.read_window.side_effect = slots_per_read
+    return SimpleNamespace(
+        winamax_ax_seats=reader,
+        _ax_rings={},
+        _ax_fruitless_reads=0,
+        _ax_reader_gave_up=False,
+        _ff_trace=MagicMock(),
+        AX_READS_PER_HAND=HUD_main.HudMain.AX_READS_PER_HAND,
+        AX_FRUITLESS_READS_BEFORE_GIVING_UP=GIVE_UP_AT,
+        HERO_SLOT=HUD_main.HudMain.HERO_SLOT,
+    )
+
+
+def _hud(table_key: str = "Colorado 11 #3477872"):
+    table = SimpleNamespace(title="Winamax Colorado 11", key=table_key, x=3845, y=39, number=3477872)
+    return SimpleNamespace(table=table)
+
+
+def _read(app, hand_id: str) -> dict:
+    return HUD_main.HudMain._ax_slots(app, _hud(), hand_id, 6)
+
+
+def test_the_reader_is_given_up_on_after_enough_empty_reads() -> None:
+    app = _hud_main([{}] * (GIVE_UP_AT + 5))
+
+    for hand in range(GIVE_UP_AT):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up is True
+
+
+def test_no_further_reads_are_paid_for_once_it_has_given_up() -> None:
+    """The point of the change: the GUI thread stops walking another process."""
+    app = _hud_main([{}] * (GIVE_UP_AT + 5))
+    for hand in range(GIVE_UP_AT):
+        _read(app, f"hand-{hand}")
+    calls_when_it_gave_up = app.winamax_ax_seats.read_window.call_count
+
+    _read(app, "later-hand")
+    _read(app, "later-hand-2")
+
+    assert app.winamax_ax_seats.read_window.call_count == calls_when_it_gave_up
+
+
+def test_a_reader_that_works_is_never_given_up_on() -> None:
+    """A client that does publish its table must keep the fast path forever."""
+    app = _hud_main([{0: "jejellyroll", 1: "Bussy67"}] * (GIVE_UP_AT + 5))
+
+    for hand in range(GIVE_UP_AT + 2):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up is False
+    assert app._ax_fruitless_reads == 0
+
+
+def test_one_good_read_forgives_the_empty_ones_before_it() -> None:
+    """A table being redrawn is not a client that publishes nothing."""
+    app = _hud_main([{}] * (GIVE_UP_AT - 1) + [{0: "jejellyroll"}] + [{}] * 5)
+
+    for hand in range(GIVE_UP_AT + 4):
+        _read(app, f"hand-{hand}")
+
+    assert app._ax_reader_gave_up is False

--- a/test/test_fast_fold_latest_only_queue.py
+++ b/test/test_fast_fold_latest_only_queue.py
@@ -14,9 +14,13 @@ import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from fpdb_3_legacy.HUD_main import HudReadWorker  # noqa: E402
-
+from fpdb_3_legacy import HUD_main  # noqa: E402
 from fpdb_3_legacy.fast_fold_engine import FastFoldStatsRequest  # noqa: E402
+
+# HUD_main is a .pyw, which only imports as a submodule on Windows. Every other
+# test reaches it as a package attribute, and so must this one, or Linux and
+# macOS fail to collect the file at all.
+HudReadWorker = HUD_main.HudReadWorker
 
 
 @pytest.fixture

--- a/test/test_fast_fold_latest_only_queue.py
+++ b/test/test_fast_fold_latest_only_queue.py
@@ -1,0 +1,82 @@
+"""A superseded seat map must be dropped before the database reads for it.
+
+The client log names a player at a time, so several reads for one table can be
+waiting at once and every one but the last describes a table that has already
+changed. They were executed in full and discarded on arrival by request id: the
+database did the work, the GUI threw the answer away.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from fpdb_3_legacy.HUD_main import HudReadWorker  # noqa: E402
+
+from fpdb_3_legacy.fast_fold_engine import FastFoldStatsRequest  # noqa: E402
+
+
+@pytest.fixture
+def worker() -> HudReadWorker:
+    return HudReadWorker.__new__(HudReadWorker)
+
+
+@pytest.fixture(autouse=True)
+def _bare_queue(worker):
+    import threading
+    from queue import Queue
+
+    worker._requests = Queue()
+    worker._latest_fast_fold = {}
+    worker._latest_lock = threading.Lock()
+
+
+def _request(temp_key: str, request_id: int) -> FastFoldStatsRequest:
+    return FastFoldStatsRequest(temp_key=temp_key, request_id=request_id)
+
+
+def test_the_newest_request_for_a_table_survives(worker) -> None:
+    worker.submit(_request("Colorado 11", 1))
+    worker.submit(_request("Colorado 11", 2))
+
+    assert worker._is_superseded(_request("Colorado 11", 2)) is False
+
+
+def test_an_overtaken_request_is_dropped(worker) -> None:
+    worker.submit(_request("Colorado 11", 1))
+    worker.submit(_request("Colorado 11", 2))
+
+    assert worker._is_superseded(_request("Colorado 11", 1)) is True
+
+
+def test_a_lone_request_is_never_dropped(worker) -> None:
+    worker.submit(_request("Colorado 11", 1))
+
+    assert worker._is_superseded(_request("Colorado 11", 1)) is False
+
+
+def test_tables_do_not_supersede_each_other(worker) -> None:
+    """Multitabling: a busy table must not cancel a quiet one's read."""
+    worker.submit(_request("Colorado 11", 1))
+    worker.submit(_request("Colorado 12", 2))
+    worker.submit(_request("Colorado 12", 3))
+
+    assert worker._is_superseded(_request("Colorado 11", 1)) is False
+    assert worker._is_superseded(_request("Colorado 12", 2)) is True
+
+
+def test_a_request_for_an_unknown_table_is_kept(worker) -> None:
+    """Nothing is known about it, which is not evidence that it is stale."""
+    assert worker._is_superseded(_request("Colorado 99", 7)) is False
+
+
+def test_forgetting_a_table_stops_it_superseding_anything(worker) -> None:
+    worker.submit(_request("Colorado 11", 1))
+    worker.submit(_request("Colorado 11", 2))
+
+    worker.forget_fast_fold_table("Colorado 11")
+
+    assert worker._is_superseded(_request("Colorado 11", 1)) is False

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -504,7 +504,7 @@ def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_
     winamax_ax_seats.request_windows_accessibility(1234)
 
     assert calls == [1234, 1234]
-    assert winamax_ax_seats._windows[1234].asked_pid is winamax_ax_seats._UNASKED
+    assert winamax_ax_seats._windows[1234].asked is False
 
 
 def test_a_handle_recycled_by_a_restarted_client_is_asked_again(monkeypatch, run_requests_here) -> None:
@@ -570,3 +570,59 @@ def test_one_window_can_be_forgotten_without_the_others(monkeypatch) -> None:
 
     assert 1 not in winamax_ax_seats._windows
     assert winamax_ax_seats._windows[2].centre is not None
+
+
+def test_a_new_owner_takes_the_old_client_s_state_with_it(monkeypatch, run_requests_here) -> None:
+    """The refactor's own promise: dropped whole when the client changes.
+
+    It detected the new owner and started a fresh request, but kept everything
+    the old client had taught it. A table reopening at the same geometry would
+    reuse the previous one's centre and seat its stats over the wrong opponents;
+    a request the exited process never answered would still read as in the air,
+    and the new client would never be asked at all.
+    """
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd], 1))
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats._windows[1234].centre = (1.0, 2.0)
+    winamax_ax_seats._windows[1234].centre_frame = (0, 0, 10, 10)
+    assert winamax_ax_seats._windows[1234].asked is True
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    state = winamax_ax_seats._windows[1234]
+    assert state.owner_pid == 2000
+    assert state.centre is None
+    assert state.centre_frame is None
+
+
+def test_a_request_the_old_process_never_answered_does_not_block_the_new_one(
+    monkeypatch,
+) -> None:
+    """An exited client can leave in_flight set with no thread left to clear it."""
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    started = []
+
+    class _NeverRuns:
+        def __init__(self, target, args=(), **_kwargs) -> None:
+            started.append(args)
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", _NeverRuns)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    assert winamax_ax_seats._windows[1234].in_flight is True
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert started == [(1234, 1000), (1234, 2000)]

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -179,7 +179,26 @@ def test_a_label_whose_owner_cannot_be_read_is_kept() -> None:
     assert [label.login for label in _client().collect_labels(_FakeRoot([_Unreadable()]))] == ["Bussy67"]
 
 
-def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
+@pytest.fixture
+def run_requests_here(monkeypatch):
+    """Run the request thread's work inline, so the tests stay deterministic.
+
+    The request is fired and forgotten in production -- AccessibleObjectFromWindow
+    and QueryService have no timeout, and a hung client must not hold the GUI
+    thread -- but a test that has to wait for a thread is a test that will flake.
+    """
+
+    class _Inline:
+        def __init__(self, target, args=(), **_kwargs) -> None:
+            self._target, self._args = target, args
+
+        def start(self) -> None:
+            self._target(*self._args)
+
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", _Inline)
+
+
+def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch, run_requests_here) -> None:
     """What the macOS reader does with AXManualAccessibility, on Windows.
 
     "Chromium only builds its web accessibility tree when an assistive client
@@ -199,12 +218,47 @@ def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
     assert asked == [1234, 4242]
 
 
-def test_a_window_is_only_asked_once(monkeypatch) -> None:
+def test_the_request_does_not_run_on_the_calling_thread(monkeypatch) -> None:
+    """AccessibleObjectFromWindow and QueryService have no timeout of their own.
+
+    SendMessageTimeoutW is bounded; those two are not -- they send their own
+    WM_GETOBJECT and wait. A hung client could hold the HUD's GUI thread for as
+    long as it liked, which is what the circuit breaker around this reader exists
+    to avoid.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    started = []
+
+    class _Recording:
+        def __init__(self, target, args=(), **kwargs) -> None:
+            started.append((target, args, kwargs.get("daemon")))
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", _Recording)
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda _h: pytest.fail("ran inline"))
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert len(started) == 1
+    target, args, daemon = started[0]
+    assert target is winamax_ax_seats._request_windows_accessibility_now
+    assert args == (1234,)
+    assert daemon is True
+
+
+def test_a_window_is_only_asked_once(monkeypatch, run_requests_here) -> None:
     """Once the client has built its tree, asking again buys nothing."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
-    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1])
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1],
+    )
     monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
 
     for _ in range(3):
@@ -213,7 +267,28 @@ def test_a_window_is_only_asked_once(monkeypatch) -> None:
     assert calls == [1234]
 
 
-def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch) -> None:
+def test_a_second_read_does_not_ask_while_the_first_request_is_in_the_air(monkeypatch) -> None:
+    """The thread makes the window between asking and knowing wide enough to matter."""
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    started = []
+
+    class _NeverRuns:
+        def __init__(self, target, args=(), **_kwargs) -> None:
+            started.append(args)
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", _NeverRuns)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert started == [(1234,)]
+
+
+def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch, run_requests_here) -> None:
     """A busy or blocked client must not take the HUD down with it."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
@@ -225,11 +300,13 @@ def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch) -> None:
     monkeypatch.setattr(winamax_ax_seats, "_send_get_object", _boom)
 
     winamax_ax_seats.request_windows_accessibility(1234)  # must not raise
+    # And it is not left in flight, so a later read tries again.
+    assert 1234 not in winamax_ax_seats._accessibility_in_flight
 
 
 def test_a_window_with_no_handle_is_not_asked(monkeypatch) -> None:
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
-    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda _h: pytest.fail("asked anyway"))
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", lambda **_k: pytest.fail("asked anyway"))
 
     winamax_ax_seats.request_windows_accessibility(0)
 
@@ -237,7 +314,7 @@ def test_a_window_with_no_handle_is_not_asked(monkeypatch) -> None:
 def test_nothing_is_asked_off_windows(monkeypatch) -> None:
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda _h: pytest.fail("asked anyway"))
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", lambda **_k: pytest.fail("asked anyway"))
 
     winamax_ax_seats.request_windows_accessibility(1234)
 
@@ -332,7 +409,7 @@ def test_read_window_for_reads_by_handle(monkeypatch) -> None:
     assert seen == {"title": "Winamax Colorado 1", "max_seats": 6, "window_id": 1234}
 
 
-def test_a_window_that_answered_nothing_is_asked_again(monkeypatch) -> None:
+def test_a_window_that_answered_nothing_is_asked_again(monkeypatch, run_requests_here) -> None:
     """SendMessageTimeoutW reports a hung client by returning zero, not by raising.
 
     _ask_for_complete_tree turns every COM failure into False the same way, so an
@@ -356,7 +433,7 @@ def test_a_window_that_answered_nothing_is_asked_again(monkeypatch) -> None:
     assert calls == [1234, 1234]
 
 
-def test_an_ia2_query_alone_is_enough_to_call_it_asked(monkeypatch) -> None:
+def test_an_ia2_query_alone_is_enough_to_call_it_asked(monkeypatch, run_requests_here) -> None:
     """The point is that something got through, not which of the two did."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -190,7 +190,7 @@ def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     asked = []
-    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: [hwnd, 4242])
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd, 4242], 2))
     monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda hwnd: asked.append(hwnd) or True)
 
     winamax_ax_seats.request_windows_accessibility(1234)
@@ -204,7 +204,7 @@ def test_a_window_is_only_asked_once(monkeypatch) -> None:
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
-    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: calls.append(hwnd) or [hwnd])
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1])
     monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
 
     for _ in range(3):
@@ -330,3 +330,68 @@ def test_read_window_for_reads_by_handle(monkeypatch) -> None:
 
     assert winamax_ax_seats.read_window_for(1234, "Winamax Colorado 1") == {0: "jejellyroll"}
     assert seen == {"title": "Winamax Colorado 1", "max_seats": 6, "window_id": 1234}
+
+
+def test_a_window_that_answered_nothing_is_asked_again(monkeypatch) -> None:
+    """SendMessageTimeoutW reports a hung client by returning zero, not by raising.
+
+    _ask_for_complete_tree turns every COM failure into False the same way, so an
+    attempt can fail completely with nothing thrown. Recording the window then
+    wrote it off for the whole session on one badly timed try -- a client still
+    starting up never gets asked again.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    calls = []
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 0))[1],
+    )
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: False)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert calls == [1234, 1234]
+
+
+def test_an_ia2_query_alone_is_enough_to_call_it_asked(monkeypatch) -> None:
+    """The point is that something got through, not which of the two did."""
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    calls = []
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 0))[1],
+    )
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert calls == [1234]
+
+
+def test_a_centre_is_not_reused_after_the_window_moved() -> None:
+    """A table moved between hands puts its chairs somewhere else.
+
+    The remembered point is then somewhere on the desktop the seats no longer
+    surround, and seats arranged around it land on the wrong chairs while still
+    passing the caller's hero check.
+    """
+    winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
+    moved = _Rect(0, 0, 960, 739)
+
+    assert winamax_ax_seats._table_centre([FULL_RING[3], FULL_RING[4]], moved, 6, hwnd=1) is None
+
+
+def test_a_recycled_handle_does_not_inherit_the_old_table_s_centre() -> None:
+    """Windows hands a closed table's HWND to the next one."""
+    winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
+    reused = _Rect(4800, 0, 5760, 739)
+
+    assert winamax_ax_seats._table_centre([FULL_RING[3]], reused, 6, hwnd=1) is None
+    # And the stale entry is gone rather than waiting to be asked again.
+    assert 1 not in winamax_ax_seats._table_centres

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -177,3 +177,97 @@ def test_a_label_whose_owner_cannot_be_read_is_kept() -> None:
             raise OSError(msg)
 
     assert [label.login for label in _client().collect_labels(_FakeRoot([_Unreadable()]))] == ["Bussy67"]
+
+
+#: ctypes.windll exists only on Windows, and these three drive it directly.
+needs_windll = pytest.mark.skipif(
+    not hasattr(winamax_ax_seats.ctypes, "windll"),
+    reason="ctypes.windll is Windows-only",
+)
+
+
+@needs_windll
+def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
+    """What the macOS reader does with AXManualAccessibility, on Windows.
+
+    "Chromium only builds its web accessibility tree when an assistive client
+    asks for it; without this the windows expose nothing but their titles" --
+    and that is exactly what a Winamax table measured on Windows: six nodes, the
+    window title among them, not one player.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    sent = []
+
+    class _User32:
+        @staticmethod
+        def EnumChildWindows(_parent, callback, _param):  # noqa: N802 - Win32 API
+            callback(4242, 0)
+            return True
+
+        @staticmethod
+        def SendMessageTimeoutW(hwnd, msg, _w, lparam, _flags, _timeout, _res):  # noqa: N802 - Win32 API
+            sent.append((hwnd.value, msg, lparam.value))
+            return 1
+
+    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert [s[0] for s in sent] == [1234, 4242]  # the frame and its render surface
+    assert {s[1] for s in sent} == {winamax_ax_seats._WM_GETOBJECT}
+    assert {s[2] for s in sent} == {winamax_ax_seats._OBJID_CLIENT}
+
+
+@needs_windll
+def test_a_window_is_only_asked_once(monkeypatch) -> None:
+    """Once the client has built its tree, asking again buys nothing."""
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    calls = []
+
+    class _User32:
+        @staticmethod
+        def EnumChildWindows(*_a):  # noqa: N802 - Win32 API
+            return True
+
+        @staticmethod
+        def SendMessageTimeoutW(*_a):  # noqa: N802 - Win32 API
+            calls.append(1)
+            return 1
+
+    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert len(calls) == 1
+
+
+@needs_windll
+def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch) -> None:
+    """A busy or blocked client must not take the HUD down with it."""
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+
+    class _User32:
+        @staticmethod
+        def EnumChildWindows(*_a):  # noqa: N802 - Win32 API
+            msg = "the desktop went away"
+            raise OSError(msg)
+
+    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
+
+    winamax_ax_seats.request_windows_accessibility(1234)  # must not raise
+
+
+def test_nothing_is_asked_off_windows(monkeypatch) -> None:
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
+    called = []
+    monkeypatch.setattr(winamax_ax_seats, "_accessibility_asked", called)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert called == []

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -434,7 +434,7 @@ def test_a_window_that_answered_nothing_is_asked_again(monkeypatch, run_requests
 
 
 def test_an_ia2_query_alone_is_enough_to_call_it_asked(monkeypatch, run_requests_here) -> None:
-    """The point is that something got through, not which of the two did."""
+    """IAccessible2 is the one that matters; WM_GETOBJECT need not have landed."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
@@ -472,3 +472,28 @@ def test_a_recycled_handle_does_not_inherit_the_old_table_s_centre() -> None:
     assert winamax_ax_seats._table_centre([FULL_RING[3]], reused, 6, hwnd=1) is None
     # And the stale entry is gone rather than waiting to be asked again.
     assert 1 not in winamax_ax_seats._table_centres
+
+
+def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_here) -> None:
+    """WM_GETOBJECT gets Chromium as far as its native widgets and no further.
+
+    The frame, the Views controls, the dialogs -- never the felt, which is web
+    content and needs the IAccessible2 query. Recording the window on the
+    WM_GETOBJECT alone left a table whose IA2 query failed transiently without
+    opponents for the rest of the session, until the breaker gave up on it.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    calls = []
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1],
+    )
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: False)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert calls == [1234, 1234]
+    assert 1234 not in winamax_ax_seats._accessibility_asked

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -626,3 +626,78 @@ def test_a_request_the_old_process_never_answered_does_not_block_the_new_one(
     winamax_ax_seats.request_windows_accessibility(1234)
 
     assert started == [(1234, 1000), (1234, 2000)]
+
+
+def _deferred_thread(monkeypatch, queue):
+    """Capture request threads so a test can run them in whatever order it likes."""
+
+    class _Deferred:
+        def __init__(self, target, args=(), **_kwargs) -> None:
+            self._run = lambda: target(*args)
+
+        def start(self) -> None:
+            queue.append(self._run)
+
+    monkeypatch.setattr(winamax_ax_seats.threading, "Thread", _Deferred)
+
+
+def test_a_request_that_outlived_its_client_does_not_touch_the_new_one(monkeypatch) -> None:
+    """The COM calls have no timeout, so a request can come back too late.
+
+    By then Windows may have given the handle to another client. Asking for the
+    state by owner rebuilt it around the old pid -- throwing away a successful
+    request or a measured centre belonging to the new client, and marking the
+    dead one as asked.
+    """
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd], 1))
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+    pending: list = []
+    _deferred_thread(monkeypatch, pending)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    winamax_ax_seats.request_windows_accessibility(1234)  # the old client's request
+
+    # The table closes, the handle is recycled, and the new client is asked and
+    # answers before the first request ever comes back.
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
+    winamax_ax_seats.forget_window_state(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    pending.pop()()
+    winamax_ax_seats._windows[1234].centre = (1.0, 2.0)
+
+    pending.pop()()  # the old client's request, arriving now
+
+    state = winamax_ax_seats._windows[1234]
+    assert state.owner_pid == 2000
+    assert state.asked is True
+    assert state.centre == (1.0, 2.0)
+
+
+def test_a_failure_from_a_client_that_is_gone_does_not_clear_the_new_one(monkeypatch) -> None:
+    """The error path cleared in_flight without checking whose it was.
+
+    A second request could then start for a window already being asked.
+    """
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+
+    def _boom(_hwnd):
+        msg = "the client went away"
+        raise OSError(msg)
+
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", _boom)
+    pending: list = []
+    _deferred_thread(monkeypatch, pending)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
+    winamax_ax_seats.forget_window_state(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    pending.pop(0)()  # the old client's request fails, late
+
+    assert winamax_ax_seats._windows[1234].in_flight is True

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -186,6 +186,18 @@ needs_windll = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_com(monkeypatch):
+    """Never let a unit test make a real COM call into an arbitrary handle.
+
+    _ask_for_complete_tree reaches oleacc and QueryInterface for real. Given the
+    invented handles these tests pass, that destabilised the interpreter: the
+    full suite aborted several hundred files later, inside an unrelated Qt
+    teardown test, and only when this file was collected.
+    """
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+
+
 @needs_windll
 def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
     """What the macOS reader does with AXManualAccessibility, on Windows.

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -247,34 +247,75 @@ class _Rect:
         self.left, self.top, self.right, self.bottom = left, top, right, bottom
 
 
-def test_the_ring_is_centred_on_the_players_when_they_are_not_in_the_frame() -> None:
+#: A whole ring, in the coordinate space the client actually reports.
+FULL_RING = [
+    winamax_ax_seats.AXSeat("CTroPinJust", 1990, 81),
+    winamax_ax_seats.AXSeat("MuckEtMousse", 2200, 117),
+    winamax_ax_seats.AXSeat("ayuga1312", 2213, 329),
+    winamax_ax_seats.AXSeat("jejellyroll", 2000, 365),
+    winamax_ax_seats.AXSeat("depor81", 1783, 329),
+    winamax_ax_seats.AXSeat("BluffTesMots", 1767, 117),
+]
+OFF_FRAME = _Rect(3840, 0, 4800, 739)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_centres():
+    winamax_ax_seats.forget_table_centres()
+    yield
+    winamax_ax_seats.forget_table_centres()
+
+
+def test_a_full_ring_is_measured_from_the_players() -> None:
     """The client reports its content in a different space from its frame.
 
     A window at x 3840..4800 whose players sit at x 1767..2259: a centre taken
     from the frame lies to one side of every player, they all read as lying in
     one direction from it, and the ring collapses into a single slot.
     """
-    players = [
-        winamax_ax_seats.AXSeat("CTroPinJust", 1990, 81),
-        winamax_ax_seats.AXSeat("jejellyroll", 2000, 365),
-    ]
+    centre = winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
 
-    centre = winamax_ax_seats._table_centre(players, _Rect(3840, 0, 4800, 739))
+    assert centre == (1990.0, 223.0)
 
-    assert centre == (1995.0, 223.0)
+
+def test_a_partial_ring_has_no_centre_until_a_full_one_was_seen() -> None:
+    """Statistics over the wrong opponents is worse than none at all.
+
+    The hero and the two chairs beside them make a band across the bottom of the
+    felt, whose bounding box centre sits well below the table's. The hero still
+    lands on slot 0, so the caller would accept it, and the neighbours would land
+    two chairs away from where they sit.
+    """
+    partial = [FULL_RING[3], FULL_RING[4], FULL_RING[2]]
+
+    assert winamax_ax_seats._table_centre(partial, OFF_FRAME, 6, hwnd=1) is None
+
+
+def test_a_partial_ring_reuses_the_centre_a_full_one_measured() -> None:
+    measured = winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
+    partial = [FULL_RING[3], FULL_RING[4]]
+
+    assert winamax_ax_seats._table_centre(partial, OFF_FRAME, 6, hwnd=1) == measured
+
+
+def test_each_window_learns_its_own_centre() -> None:
+    """Two tables, two coordinate spaces: one must not answer for the other."""
+    winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
+
+    assert winamax_ax_seats._table_centre([FULL_RING[3]], OFF_FRAME, 6, hwnd=2) is None
 
 
 def test_the_frame_is_used_when_the_players_are_inside_it() -> None:
-    """A client reporting one consistent space gives the frame's own centre."""
+    """A client reporting one consistent space needs none of this."""
     players = [winamax_ax_seats.AXSeat("jejellyroll", 400, 300)]
 
-    centre = winamax_ax_seats._table_centre(players, _Rect(0, 0, 960, 740))
+    centre = winamax_ax_seats._table_centre(players, _Rect(0, 0, 960, 740), 6, hwnd=1)
 
     assert centre == (480.0, 370.0)
 
 
-def test_no_players_leaves_the_frame_centre() -> None:
-    assert winamax_ax_seats._table_centre([], _Rect(0, 0, 100, 200)) == (50.0, 100.0)
+def test_no_players_has_no_centre() -> None:
+    assert winamax_ax_seats._table_centre([], _Rect(0, 0, 100, 200), 6, hwnd=1) is None
 
 
 def test_read_window_for_reads_by_handle(monkeypatch) -> None:

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -212,7 +212,7 @@ def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch, run_request
     and that is exactly what a Winamax table measured on Windows: six nodes, the
     window title among them, not one player.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     asked = []
     monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd, 4242], 2))
@@ -232,7 +232,7 @@ def test_the_request_does_not_run_on_the_calling_thread(monkeypatch) -> None:
     long as it liked, which is what the circuit breaker around this reader exists
     to avoid.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     started = []
 
@@ -259,7 +259,7 @@ def test_the_request_does_not_run_on_the_calling_thread(monkeypatch) -> None:
 
 def test_a_window_is_only_asked_once(monkeypatch, run_requests_here) -> None:
     """Once the client has built its tree, asking again buys nothing."""
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
     monkeypatch.setattr(
@@ -277,7 +277,7 @@ def test_a_window_is_only_asked_once(monkeypatch, run_requests_here) -> None:
 
 def test_a_second_read_does_not_ask_while_the_first_request_is_in_the_air(monkeypatch) -> None:
     """The thread makes the window between asking and knowing wide enough to matter."""
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     started = []
 
@@ -298,7 +298,7 @@ def test_a_second_read_does_not_ask_while_the_first_request_is_in_the_air(monkey
 
 def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch, run_requests_here) -> None:
     """A busy or blocked client must not take the HUD down with it."""
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
 
     def _boom(_hwnd):
@@ -309,7 +309,7 @@ def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch, run_requests_he
 
     winamax_ax_seats.request_windows_accessibility(1234)  # must not raise
     # And it is not left in flight, so a later read tries again.
-    assert 1234 not in winamax_ax_seats._accessibility_in_flight
+    assert winamax_ax_seats._windows[1234].in_flight is False
 
 
 def test_a_window_with_no_handle_is_not_asked(monkeypatch) -> None:
@@ -320,7 +320,7 @@ def test_a_window_with_no_handle_is_not_asked(monkeypatch) -> None:
 
 
 def test_nothing_is_asked_off_windows(monkeypatch) -> None:
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(winamax_ax_seats.threading, "Thread", lambda **_k: pytest.fail("asked anyway"))
 
@@ -346,9 +346,9 @@ OFF_FRAME = _Rect(3840, 0, 4800, 739)
 
 @pytest.fixture(autouse=True)
 def _fresh_centres():
-    winamax_ax_seats.forget_table_centres()
+    winamax_ax_seats.forget_window_state()
     yield
-    winamax_ax_seats.forget_table_centres()
+    winamax_ax_seats.forget_window_state()
 
 
 def test_a_full_ring_is_measured_from_the_players() -> None:
@@ -425,7 +425,7 @@ def test_a_window_that_answered_nothing_is_asked_again(monkeypatch, run_requests
     wrote it off for the whole session on one badly timed try -- a client still
     starting up never gets asked again.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
     monkeypatch.setattr(
@@ -443,7 +443,7 @@ def test_a_window_that_answered_nothing_is_asked_again(monkeypatch, run_requests
 
 def test_an_ia2_query_alone_is_enough_to_call_it_asked(monkeypatch, run_requests_here) -> None:
     """IAccessible2 is the one that matters; WM_GETOBJECT need not have landed."""
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
     monkeypatch.setattr(
@@ -479,7 +479,7 @@ def test_a_recycled_handle_does_not_inherit_the_old_table_s_centre() -> None:
 
     assert winamax_ax_seats._table_centre([FULL_RING[3]], reused, 6, hwnd=1) is None
     # And the stale entry is gone rather than waiting to be asked again.
-    assert 1 not in winamax_ax_seats._table_centres
+    assert winamax_ax_seats._windows[1].centre is None
 
 
 def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_here) -> None:
@@ -490,7 +490,7 @@ def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_
     WM_GETOBJECT alone left a table whose IA2 query failed transiently without
     opponents for the rest of the session, until the breaker gave up on it.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
     monkeypatch.setattr(
@@ -504,7 +504,7 @@ def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_
     winamax_ax_seats.request_windows_accessibility(1234)
 
     assert calls == [1234, 1234]
-    assert 1234 not in winamax_ax_seats._accessibility_asked
+    assert winamax_ax_seats._windows[1234].asked_pid is winamax_ax_seats._UNASKED
 
 
 def test_a_handle_recycled_by_a_restarted_client_is_asked_again(monkeypatch, run_requests_here) -> None:
@@ -515,7 +515,7 @@ def test_a_handle_recycled_by_a_restarted_client_is_asked_again(monkeypatch, run
     it had already been asked, and it would never publish its felt -- every hand
     back to the log-derived seats, then the breaker.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
     monkeypatch.setattr(
@@ -543,7 +543,7 @@ def test_an_unreadable_owner_does_not_read_as_already_asked(monkeypatch, run_req
     first read of a window whose owner could not be determined would skip the
     request outright.
     """
-    winamax_ax_seats.forget_accessibility_requests()
+    winamax_ax_seats.forget_window_state()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: None)
     calls = []
@@ -557,3 +557,16 @@ def test_an_unreadable_owner_does_not_read_as_already_asked(monkeypatch, run_req
     winamax_ax_seats.request_windows_accessibility(1234)
 
     assert calls == [1234]
+
+
+def test_one_window_can_be_forgotten_without_the_others(monkeypatch) -> None:
+    """A table retiring should not cost its neighbour what it learned."""
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=1)
+    winamax_ax_seats._table_centre(FULL_RING, OFF_FRAME, 6, hwnd=2)
+
+    winamax_ax_seats.forget_window_state(1)
+
+    assert 1 not in winamax_ax_seats._windows
+    assert winamax_ax_seats._windows[2].centre is not None

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -1,0 +1,106 @@
+"""Losing the window seat reader must not be silent.
+
+Fast-Fold seats are read from the table window; the client log can only name a
+player once they have acted, so falling back to it makes the stat blocks appear
+one at a time over the first betting round. That fallback is what a user
+reports as "the Fast-Fold HUD is slow again".
+
+Both ways of losing the reader were logged at INFO, or not logged at all. The
+root logger is pinned to WARNING (loggingFpdb.DIAGNOSTIC_LEVEL_CAP) and
+"hud_main" is persisted lower still, so neither line ever reached a user's log:
+the HUD degraded to exactly the reported symptom and said nothing about it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fpdb_3_legacy import winamax_ax_seats
+
+
+@pytest.fixture
+def _no_usable_com(monkeypatch):
+    """Make building the client fail, on any platform.
+
+    Where comtypes is installed (a Windows dev box) the real GetModule would
+    succeed, so it is made to raise; where it is not (Linux/macOS CI) the import
+    inside _windows_uia raises on its own and reaches the same branch. Either
+    way the test pins the behaviour rather than the machine it runs on.
+    """
+    try:
+        import comtypes.client
+    except ImportError:
+        return
+    monkeypatch.setattr(
+        comtypes.client,
+        "GetModule",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("COM is not available")),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_client():
+    """The client is process-wide state; a test must not leak it into the next."""
+    winamax_ax_seats.reset_windows_uia()
+    yield
+    winamax_ax_seats.reset_windows_uia()
+
+
+def test_a_reader_that_cannot_be_built_says_so(monkeypatch, caplog, _no_usable_com) -> None:
+    """COM refusing to start, or a frozen build that cannot generate the wrapper."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+
+    with caplog.at_level(logging.WARNING, logger=winamax_ax_seats.log.name):
+        assert winamax_ax_seats._windows_uia() is None
+
+    assert "Fast-Fold seats will come from the client log" in caplog.text
+
+
+def test_the_reader_is_not_re_reported_on_every_hand(monkeypatch, caplog, _no_usable_com) -> None:
+    """The failure is remembered, so the warning must be once per process."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+
+    with caplog.at_level(logging.WARNING, logger=winamax_ax_seats.log.name):
+        winamax_ax_seats._windows_uia()
+        winamax_ax_seats._windows_uia()
+        winamax_ax_seats._windows_uia()
+
+    assert caplog.text.count("Fast-Fold seats will come from the client log") == 1
+
+
+def test_a_build_without_comtypes_says_so_at_startup(monkeypatch, caplog) -> None:
+    """The packaging failure the PyInstaller hook exists to prevent.
+
+    prewarm() returned silently when is_ax_available() was False, so a build
+    that had lost comtypes looked exactly like a healthy one.
+    """
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "is_ax_available", lambda: False)
+
+    with caplog.at_level(logging.WARNING, logger=winamax_ax_seats.log.name):
+        winamax_ax_seats.WinamaxAXSeatReader().prewarm()
+
+    assert "comtypes is not importable" in caplog.text
+
+
+def test_a_healthy_reader_warns_about_nothing(monkeypatch, caplog) -> None:
+    """A working session must stay quiet, or the warning means nothing."""
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "is_ax_available", lambda: True)
+    monkeypatch.setattr(winamax_ax_seats, "_windows_uia", lambda: object())
+
+    with caplog.at_level(logging.WARNING, logger=winamax_ax_seats.log.name):
+        winamax_ax_seats.WinamaxAXSeatReader().prewarm()
+
+    assert caplog.text == ""
+
+
+def test_nothing_is_warned_off_windows(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
+
+    with caplog.at_level(logging.WARNING, logger=winamax_ax_seats.log.name):
+        winamax_ax_seats.WinamaxAXSeatReader().prewarm()
+
+    assert caplog.text == ""

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -14,6 +14,7 @@ the HUD degraded to exactly the reported symptom and said nothing about it.
 from __future__ import annotations
 
 import logging
+import os
 
 import pytest
 
@@ -104,3 +105,75 @@ def test_nothing_is_warned_off_windows(monkeypatch, caplog) -> None:
         winamax_ax_seats.WinamaxAXSeatReader().prewarm()
 
     assert caplog.text == ""
+
+
+class _FakeElement:
+    """The parts of an IUIAutomationElement collect_labels touches."""
+
+    def __init__(self, name: str, pid: int, x: int = 10, y: int = 20) -> None:
+        self.CurrentName = name
+        self.CurrentProcessId = pid
+        self.CurrentBoundingRectangle = type("R", (), {"left": x, "top": y})()
+
+
+class _FakeFound:
+    def __init__(self, elements) -> None:
+        self._elements = elements
+        self.Length = len(elements)
+
+    def GetElement(self, index):
+        return self._elements[index]
+
+
+class _FakeRoot:
+    def __init__(self, elements) -> None:
+        self._found = _FakeFound(elements)
+
+    def FindAll(self, _scope, _condition):
+        return self._found
+
+
+def _client() -> winamax_ax_seats._WindowsUIAClient:
+    return winamax_ax_seats._WindowsUIAClient(automation=object(), condition=object())
+
+
+def test_the_huds_own_stat_blocks_are_not_read_back_as_players() -> None:
+    """The HUD's blocks are transient children of the table, so they are in the subtree.
+
+    A real walk of a Winamax table came back holding 'HUD - stats', 'VP 0.0',
+    '3B -' and the rest of the HUD's own output. Those are stat abbreviations,
+    not players, and the reader must not feed them to seats_from_labels.
+    """
+    own = os.getpid()
+    root = _FakeRoot(
+        [
+            _FakeElement("Bussy67", pid=own + 1),
+            _FakeElement("HUD - stats", pid=own),
+            _FakeElement("VP 0.0", pid=own),
+            _FakeElement("3B -", pid=own),
+            _FakeElement("0newayticket", pid=own + 1),
+        ],
+    )
+
+    labels = _client().collect_labels(root)
+
+    assert [label.login for label in labels] == ["Bussy67", "0newayticket"]
+
+
+def test_a_label_whose_owner_cannot_be_read_is_kept() -> None:
+    """Fail open: an unreadable pid is not proof the label is ours.
+
+    Dropping it would cost a real player their block, which is the failure this
+    reader exists to avoid.
+    """
+
+    class _Unreadable:
+        CurrentName = "Bussy67"
+        CurrentBoundingRectangle = type("R", (), {"left": 10, "top": 20})()
+
+        @property
+        def CurrentProcessId(self):  # noqa: N802 - UIA API
+            msg = "element is gone"
+            raise OSError(msg)
+
+    assert [label.login for label in _client().collect_labels(_FakeRoot([_Unreadable()]))] == ["Bussy67"]

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -179,26 +179,6 @@ def test_a_label_whose_owner_cannot_be_read_is_kept() -> None:
     assert [label.login for label in _client().collect_labels(_FakeRoot([_Unreadable()]))] == ["Bussy67"]
 
 
-#: ctypes.windll exists only on Windows, and these three drive it directly.
-needs_windll = pytest.mark.skipif(
-    not hasattr(winamax_ax_seats.ctypes, "windll"),
-    reason="ctypes.windll is Windows-only",
-)
-
-
-@pytest.fixture(autouse=True)
-def _no_real_com(monkeypatch):
-    """Never let a unit test make a real COM call into an arbitrary handle.
-
-    _ask_for_complete_tree reaches oleacc and QueryInterface for real. Given the
-    invented handles these tests pass, that destabilised the interpreter: the
-    full suite aborted several hundred files later, inside an unrelated Qt
-    teardown test, and only when this file was collected.
-    """
-    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
-
-
-@needs_windll
 def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
     """What the macOS reader does with AXManualAccessibility, on Windows.
 
@@ -209,77 +189,103 @@ def test_a_chromium_client_is_asked_to_publish_its_tree(monkeypatch) -> None:
     """
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
-    sent = []
-
-    class _User32:
-        @staticmethod
-        def EnumChildWindows(_parent, callback, _param):  # noqa: N802 - Win32 API
-            callback(4242, 0)
-            return True
-
-        @staticmethod
-        def SendMessageTimeoutW(hwnd, msg, _w, lparam, _flags, _timeout, _res):  # noqa: N802 - Win32 API
-            sent.append((hwnd.value, msg, lparam.value))
-            return 1
-
-    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
+    asked = []
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: [hwnd, 4242])
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda hwnd: asked.append(hwnd) or True)
 
     winamax_ax_seats.request_windows_accessibility(1234)
 
-    assert [s[0] for s in sent] == [1234, 4242]  # the frame and its render surface
-    assert {s[1] for s in sent} == {winamax_ax_seats._WM_GETOBJECT}
-    assert {s[2] for s in sent} == {winamax_ax_seats._OBJID_CLIENT}
+    # The frame and its render surface: the felt is drawn in the child.
+    assert asked == [1234, 4242]
 
 
-@needs_windll
 def test_a_window_is_only_asked_once(monkeypatch) -> None:
     """Once the client has built its tree, asking again buys nothing."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
     calls = []
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: calls.append(hwnd) or [hwnd])
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
 
-    class _User32:
-        @staticmethod
-        def EnumChildWindows(*_a):  # noqa: N802 - Win32 API
-            return True
+    for _ in range(3):
+        winamax_ax_seats.request_windows_accessibility(1234)
 
-        @staticmethod
-        def SendMessageTimeoutW(*_a):  # noqa: N802 - Win32 API
-            calls.append(1)
-            return 1
-
-    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
-
-    winamax_ax_seats.request_windows_accessibility(1234)
-    winamax_ax_seats.request_windows_accessibility(1234)
-    winamax_ax_seats.request_windows_accessibility(1234)
-
-    assert len(calls) == 1
+    assert calls == [1234]
 
 
-@needs_windll
 def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch) -> None:
     """A busy or blocked client must not take the HUD down with it."""
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
 
-    class _User32:
-        @staticmethod
-        def EnumChildWindows(*_a):  # noqa: N802 - Win32 API
-            msg = "the desktop went away"
-            raise OSError(msg)
+    def _boom(_hwnd):
+        msg = "the desktop went away"
+        raise OSError(msg)
 
-    monkeypatch.setattr(winamax_ax_seats.ctypes.windll, "user32", _User32, raising=False)
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", _boom)
 
     winamax_ax_seats.request_windows_accessibility(1234)  # must not raise
+
+
+def test_a_window_with_no_handle_is_not_asked(monkeypatch) -> None:
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda _h: pytest.fail("asked anyway"))
+
+    winamax_ax_seats.request_windows_accessibility(0)
 
 
 def test_nothing_is_asked_off_windows(monkeypatch) -> None:
     winamax_ax_seats.forget_accessibility_requests()
     monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Darwin")
-    called = []
-    monkeypatch.setattr(winamax_ax_seats, "_accessibility_asked", called)
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda _h: pytest.fail("asked anyway"))
 
     winamax_ax_seats.request_windows_accessibility(1234)
 
-    assert called == []
+
+class _Rect:
+    def __init__(self, left, top, right, bottom) -> None:
+        self.left, self.top, self.right, self.bottom = left, top, right, bottom
+
+
+def test_the_ring_is_centred_on_the_players_when_they_are_not_in_the_frame() -> None:
+    """The client reports its content in a different space from its frame.
+
+    A window at x 3840..4800 whose players sit at x 1767..2259: a centre taken
+    from the frame lies to one side of every player, they all read as lying in
+    one direction from it, and the ring collapses into a single slot.
+    """
+    players = [
+        winamax_ax_seats.AXSeat("CTroPinJust", 1990, 81),
+        winamax_ax_seats.AXSeat("jejellyroll", 2000, 365),
+    ]
+
+    centre = winamax_ax_seats._table_centre(players, _Rect(3840, 0, 4800, 739))
+
+    assert centre == (1995.0, 223.0)
+
+
+def test_the_frame_is_used_when_the_players_are_inside_it() -> None:
+    """A client reporting one consistent space gives the frame's own centre."""
+    players = [winamax_ax_seats.AXSeat("jejellyroll", 400, 300)]
+
+    centre = winamax_ax_seats._table_centre(players, _Rect(0, 0, 960, 740))
+
+    assert centre == (480.0, 370.0)
+
+
+def test_no_players_leaves_the_frame_centre() -> None:
+    assert winamax_ax_seats._table_centre([], _Rect(0, 0, 100, 200)) == (50.0, 100.0)
+
+
+def test_read_window_for_reads_by_handle(monkeypatch) -> None:
+    """The diagnostic tool holds a HWND and no reader; this is its way in."""
+    seen = {}
+
+    def _read(self, title, max_seats, table_pos=None, window_id=None):
+        seen.update(title=title, max_seats=max_seats, window_id=window_id)
+        return {0: "jejellyroll"}
+
+    monkeypatch.setattr(winamax_ax_seats.WinamaxAXSeatReader, "read_window", _read)
+
+    assert winamax_ax_seats.read_window_for(1234, "Winamax Colorado 1") == {0: "jejellyroll"}
+    assert seen == {"title": "Winamax Colorado 1", "max_seats": 6, "window_id": 1234}

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -253,7 +253,11 @@ def test_the_request_does_not_run_on_the_calling_thread(monkeypatch) -> None:
     assert target is winamax_ax_seats._request_windows_accessibility_now
     # The owner is read on the calling thread -- a local call that cannot block --
     # and carried, so the worker records the window against the client it asked.
-    assert args == (1234, 4242)
+    assert args[0] == 1234
+    # The state object itself, so a completion can tell whether it is still the
+    # one the window is tracked by -- identity, not a pid that a second table of
+    # the same client would share.
+    assert args[1] is winamax_ax_seats._windows[1234]
     assert daemon is True
 
 
@@ -293,7 +297,7 @@ def test_a_second_read_does_not_ask_while_the_first_request_is_in_the_air(monkey
     winamax_ax_seats.request_windows_accessibility(1234)
     winamax_ax_seats.request_windows_accessibility(1234)
 
-    assert started == [(1234, 4242)]
+    assert [a[0] for a in started] == [1234]
 
 
 def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch, run_requests_here) -> None:
@@ -625,7 +629,7 @@ def test_a_request_the_old_process_never_answered_does_not_block_the_new_one(
     monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
     winamax_ax_seats.request_windows_accessibility(1234)
 
-    assert started == [(1234, 1000), (1234, 2000)]
+    assert [a[0] for a in started] == [1234, 1234]
 
 
 def _deferred_thread(monkeypatch, queue):
@@ -701,3 +705,57 @@ def test_a_failure_from_a_client_that_is_gone_does_not_clear_the_new_one(monkeyp
     pending.pop(0)()  # the old client's request fails, late
 
     assert winamax_ax_seats._windows[1234].in_flight is True
+
+
+def test_a_table_of_the_same_client_reusing_a_handle_starts_clean(monkeypatch) -> None:
+    """Winamax stays running and hands one table's HWND to another of its own.
+
+    The owner's pid is identical, so it says nothing. Nothing released the state
+    either, so the new render surface inherited an accepted request it never
+    received, an outstanding one nobody would clear, and a centre measured on a
+    table that had closed.
+    """
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd], 1))
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+    pending: list = []
+    _deferred_thread(monkeypatch, pending)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+    pending.pop()()
+    winamax_ax_seats._windows[1234].centre = (1.0, 2.0)
+    old_state = winamax_ax_seats._windows[1234]
+
+    # The table closes: this is what the HUD now does on teardown.
+    winamax_ax_seats.forget_window_state(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    state = winamax_ax_seats._windows[1234]
+    assert state is not old_state
+    assert state.centre is None
+    assert state.asked is False
+
+
+def test_an_answer_for_a_retired_window_is_dropped_even_within_one_client(
+    monkeypatch,
+) -> None:
+    """Same pid on both sides, so only the state's identity can tell them apart."""
+    winamax_ax_seats.forget_window_state()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    monkeypatch.setattr(winamax_ax_seats, "_send_get_object", lambda hwnd: ([hwnd], 1))
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+    pending: list = []
+    _deferred_thread(monkeypatch, pending)
+
+    winamax_ax_seats.request_windows_accessibility(1234)  # the closing table
+    winamax_ax_seats.forget_window_state(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)  # the new one
+    pending.pop()()
+    winamax_ax_seats._windows[1234].centre = (3.0, 4.0)
+
+    pending.pop()()  # the closed table's answer, arriving now
+
+    assert winamax_ax_seats._windows[1234].centre == (3.0, 4.0)

--- a/test/test_fast_fold_seat_reader_visibility.py
+++ b/test/test_fast_fold_seat_reader_visibility.py
@@ -179,6 +179,12 @@ def test_a_label_whose_owner_cannot_be_read_is_kept() -> None:
     assert [label.login for label in _client().collect_labels(_FakeRoot([_Unreadable()]))] == ["Bussy67"]
 
 
+@pytest.fixture(autouse=True)
+def _one_client(monkeypatch):
+    """A single, stable owning process, unless a test says otherwise."""
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 4242)
+
+
 @pytest.fixture
 def run_requests_here(monkeypatch):
     """Run the request thread's work inline, so the tests stay deterministic.
@@ -245,7 +251,9 @@ def test_the_request_does_not_run_on_the_calling_thread(monkeypatch) -> None:
     assert len(started) == 1
     target, args, daemon = started[0]
     assert target is winamax_ax_seats._request_windows_accessibility_now
-    assert args == (1234,)
+    # The owner is read on the calling thread -- a local call that cannot block --
+    # and carried, so the worker records the window against the client it asked.
+    assert args == (1234, 4242)
     assert daemon is True
 
 
@@ -285,7 +293,7 @@ def test_a_second_read_does_not_ask_while_the_first_request_is_in_the_air(monkey
     winamax_ax_seats.request_windows_accessibility(1234)
     winamax_ax_seats.request_windows_accessibility(1234)
 
-    assert started == [(1234,)]
+    assert started == [(1234, 4242)]
 
 
 def test_a_client_that_will_not_answer_is_not_fatal(monkeypatch, run_requests_here) -> None:
@@ -497,3 +505,55 @@ def test_a_delivered_wm_getobject_alone_is_not_enough(monkeypatch, run_requests_
 
     assert calls == [1234, 1234]
     assert 1234 not in winamax_ax_seats._accessibility_asked
+
+
+def test_a_handle_recycled_by_a_restarted_client_is_asked_again(monkeypatch, run_requests_here) -> None:
+    """Windows recycles a closed table's handle to whatever opens next.
+
+    Winamax restarted while the HUD stays alive gets a new process for the same
+    numbers. A handle remembered by its digits alone would tell that new Chromium
+    it had already been asked, and it would never publish its felt -- every hand
+    back to the log-derived seats, then the breaker.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    calls = []
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1],
+    )
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 1000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    winamax_ax_seats.request_windows_accessibility(1234)
+    assert calls == [1234]  # same client, asked once
+
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: 2000)
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert calls == [1234, 1234]
+
+
+def test_an_unreadable_owner_does_not_read_as_already_asked(monkeypatch, run_requests_here) -> None:
+    """GetWindowThreadProcessId answers None for a window that has gone.
+
+    None is a real answer here -- it must not collide with "never asked", or the
+    first read of a window whose owner could not be determined would skip the
+    request outright.
+    """
+    winamax_ax_seats.forget_accessibility_requests()
+    monkeypatch.setattr(winamax_ax_seats.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(winamax_ax_seats, "_window_pid", lambda _hwnd: None)
+    calls = []
+    monkeypatch.setattr(
+        winamax_ax_seats,
+        "_send_get_object",
+        lambda hwnd: (calls.append(hwnd), ([hwnd], 1))[1],
+    )
+    monkeypatch.setattr(winamax_ax_seats, "_ask_for_complete_tree", lambda _hwnd: True)
+
+    winamax_ax_seats.request_windows_accessibility(1234)
+
+    assert calls == [1234]

--- a/test/test_fast_fold_seat_wait_setting.py
+++ b/test/test_fast_fold_seat_wait_setting.py
@@ -50,3 +50,28 @@ def test_a_negative_wait_is_treated_as_none() -> None:
 def test_an_unreadable_value_falls_back_to_the_default(bad) -> None:
     """A typo in the config must not stop a table getting a HUD."""
     assert _wait_ms(fast_fold_seat_wait_ms=bad) == 500
+
+
+def _window_seats(**attributes) -> str:
+    return Config.get_hud_ui_parameters(_hud_ui(**attributes))["fast_fold_window_seats"]
+
+
+def test_the_window_reader_is_on_by_default() -> None:
+    """It is what makes the seats arrive at once, where the client publishes them."""
+    assert _window_seats() == "auto"
+
+
+def test_the_window_reader_can_be_turned_off() -> None:
+    """Each read is 94-218ms of GUI thread; a client that never answers is pure stutter."""
+    assert _window_seats(fast_fold_window_seats="off") == "off"
+
+
+@pytest.mark.parametrize("written", ["OFF", " Off ", "off"])
+def test_the_value_is_read_the_way_a_person_writes_it(written) -> None:
+    assert _window_seats(fast_fold_window_seats=written) == "off"
+
+
+@pytest.mark.parametrize("bad", ["", "no", "false", None, 3])
+def test_anything_unrecognised_leaves_the_reader_on(bad) -> None:
+    """A typo must not silently cost the fast path where it works."""
+    assert _window_seats(fast_fold_window_seats=bad) == "auto"

--- a/test/test_fast_fold_seat_wait_setting.py
+++ b/test/test_fast_fold_seat_wait_setting.py
@@ -75,3 +75,91 @@ def test_the_value_is_read_the_way_a_person_writes_it(written) -> None:
 def test_anything_unrecognised_leaves_the_reader_on(bad) -> None:
     """A typo must not silently cost the fast path where it works."""
     assert _window_seats(fast_fold_window_seats=bad) == "auto"
+
+
+class _Update:
+    def __init__(self, pool: str = "gf.t1.0", hand_id: str = "hand-1") -> None:
+        self.pool, self.hand_id = pool, hand_id
+
+
+def _waiter(wait_ms: int, scheduled: list):
+    """A HudMain stub carrying only what _schedule_seat_wait_recheck touches."""
+    from types import SimpleNamespace
+
+    from fpdb_3_legacy import HUD_main
+
+    return SimpleNamespace(
+        _fast_fold_seat_wait_ms=wait_ms,
+        _ff_seat_wait_scheduled=set(),
+        AX_RECHECK_DELAYS_MS=HUD_main.HudMain.AX_RECHECK_DELAYS_MS,
+        FF_SEAT_WAIT_MEMO_LIMIT=HUD_main.HudMain.FF_SEAT_WAIT_MEMO_LIMIT,
+        _recheck_window=lambda pool: None,
+    ), scheduled
+
+
+def _schedule(app, update, elapsed, monkeypatch, scheduled):
+    from fpdb_3_legacy import HUD_main
+
+    monkeypatch.setattr(
+        HUD_main.QTimer,
+        "singleShot",
+        staticmethod(lambda ms, _slot: scheduled.append(ms)),
+    )
+    HUD_main.HudMain._schedule_seat_wait_recheck(app, update, elapsed)
+
+
+def test_a_long_wait_schedules_its_own_recheck(monkeypatch) -> None:
+    """The hand's other rechecks stop at 1500ms; a 5s wait needs its own.
+
+    Otherwise a short-handed table whose last ring update lands before the
+    deadline is never drawn: nothing looks again until the hand is over, and
+    then it is cleared.
+    """
+    scheduled = []
+    app, _ = _waiter(5000, scheduled)
+
+    _schedule(app, _Update(), elapsed=0.5, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert scheduled == [4500]
+
+
+def test_a_short_wait_leans_on_the_rechecks_already_scheduled(monkeypatch) -> None:
+    """Below AX_RECHECK_DELAYS_MS this would be a second timer saying the same thing."""
+    scheduled = []
+    app, _ = _waiter(500, scheduled)
+
+    _schedule(app, _Update(), elapsed=0.0, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert scheduled == []
+
+
+def test_one_recheck_per_hand_and_table(monkeypatch) -> None:
+    """Every ring update of the hand comes through here; one timer is enough."""
+    scheduled = []
+    app, _ = _waiter(5000, scheduled)
+
+    for elapsed in (0.2, 0.4, 0.8):
+        _schedule(app, _Update(), elapsed=elapsed, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert len(scheduled) == 1
+
+
+def test_two_tables_each_get_one(monkeypatch) -> None:
+    scheduled = []
+    app, _ = _waiter(5000, scheduled)
+
+    _schedule(app, _Update(pool="gf.t1.0"), 0.2, monkeypatch, scheduled)
+    _schedule(app, _Update(pool="gf.t1.1"), 0.2, monkeypatch, scheduled)
+
+    assert len(scheduled) == 2
+
+
+def test_the_memo_does_not_grow_without_bound(monkeypatch) -> None:
+    """A session plays thousands of hands and nothing else prunes this."""
+    scheduled = []
+    app, _ = _waiter(5000, scheduled)
+
+    for hand in range(app.FF_SEAT_WAIT_MEMO_LIMIT + 5):
+        _schedule(app, _Update(hand_id=f"hand-{hand}"), 0.2, monkeypatch, scheduled)
+
+    assert len(app._ff_seat_wait_scheduled) <= app.FF_SEAT_WAIT_MEMO_LIMIT

--- a/test/test_fast_fold_seat_wait_setting.py
+++ b/test/test_fast_fold_seat_wait_setting.py
@@ -163,3 +163,40 @@ def test_the_memo_does_not_grow_without_bound(monkeypatch) -> None:
         _schedule(app, _Update(hand_id=f"hand-{hand}"), 0.2, monkeypatch, scheduled)
 
     assert len(app._ff_seat_wait_scheduled) <= app.FF_SEAT_WAIT_MEMO_LIMIT
+
+
+def test_a_wait_just_past_the_last_recheck_still_gets_a_wakeup(monkeypatch) -> None:
+    """The band the remaining-time test left uncovered.
+
+    At a 2000ms wait, a ring arriving at 600ms leaves 1400 -- which reads as "the
+    rechecks have this" if you compare what is left rather than the setting. They
+    do not: 250, 700 and 1500 all fire before 2000. Every later call inside the
+    hand made the same wrong judgement, so nothing looked again until the hand
+    ended.
+    """
+    scheduled = []
+    app, _ = _waiter(2000, scheduled)
+
+    _schedule(app, _Update(), elapsed=0.6, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert scheduled == [1400]
+
+
+def test_a_wait_level_with_the_last_recheck_leans_on_it(monkeypatch) -> None:
+    """1500 is exactly when the last recheck fires; a second timer adds nothing."""
+    scheduled = []
+    app, _ = _waiter(1500, scheduled)
+
+    _schedule(app, _Update(), elapsed=0.1, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert scheduled == []
+
+
+def test_a_deadline_already_past_wakes_at_once(monkeypatch) -> None:
+    """Arithmetic guard: the remaining time must never go negative into the timer."""
+    scheduled = []
+    app, _ = _waiter(2000, scheduled)
+
+    _schedule(app, _Update(), elapsed=9.0, monkeypatch=monkeypatch, scheduled=scheduled)
+
+    assert scheduled == [0]

--- a/test/test_fast_fold_seat_wait_setting.py
+++ b/test/test_fast_fold_seat_wait_setting.py
@@ -1,0 +1,52 @@
+"""How long a Fast-Fold table waits for its players is the player's call.
+
+The client log names a player only once they have acted, so a six-handed table
+is named over several seconds -- +734ms, +3265ms, +15890ms in measured sessions.
+Showing what is known so far means blocks appearing one at a time; waiting for
+the ring means they appear together, later. Neither is right for everyone, and
+the wait used to be 500ms with no way to say otherwise.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from fpdb_3_legacy.Configuration import Config
+
+
+def _hud_ui(**attributes) -> Config:
+    config = Config.__new__(Config)
+    config.ui = SimpleNamespace(**attributes)
+    return config
+
+
+def _wait_ms(**attributes) -> int:
+    config = _hud_ui(**attributes)
+    # get_hud_ui_parameters reads many attributes; only ours is under test, and
+    # the rest fall back to their own defaults through the same getattr guards.
+    return Config.get_hud_ui_parameters(config)["fast_fold_seat_wait_ms"]
+
+
+def test_the_default_is_what_the_hud_has_always_done() -> None:
+    assert _wait_ms() == 500
+
+
+def test_a_longer_wait_is_honoured() -> None:
+    """Blocks together, later: the whole point of exposing this."""
+    assert _wait_ms(fast_fold_seat_wait_ms="5000") == 5000
+
+
+def test_zero_shows_the_first_player_at_once() -> None:
+    assert _wait_ms(fast_fold_seat_wait_ms="0") == 0
+
+
+def test_a_negative_wait_is_treated_as_none() -> None:
+    assert _wait_ms(fast_fold_seat_wait_ms="-1") == 0
+
+
+@pytest.mark.parametrize("bad", ["", "soon", "5s", None])
+def test_an_unreadable_value_falls_back_to_the_default(bad) -> None:
+    """A typo in the config must not stop a table getting a HUD."""
+    assert _wait_ms(fast_fold_seat_wait_ms=bad) == 500

--- a/test/test_fast_fold_stats_coalescing.py
+++ b/test/test_fast_fold_stats_coalescing.py
@@ -21,25 +21,48 @@ import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from PySide6.QtWidgets import QApplication  # noqa: E402
-
 from fpdb_3_legacy import HUD_main  # noqa: E402
 
 COALESCE_MS = HUD_main.HudMain.FF_STATS_COALESCE_MS
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _qapp():
-    return QApplication.instance() or QApplication([])
+class _FakeTimer:
+    """Stands in for the QTimer the coalescer arms.
+
+    These tests drive the trailing send themselves, so the timer only has to
+    remember whether it is armed. Creating real QTimers here, parented to
+    throwaway QObjects that are never destroyed, aborted the interpreter several
+    hundred files later inside an unrelated Qt teardown test -- and only when
+    this file was collected.
+    """
+
+    def __init__(self, _parent=None) -> None:
+        self.started_with: int | None = None
+        self.timeout = self
+
+    def setSingleShot(self, _single: bool) -> None:  # noqa: N802 - Qt API
+        pass
+
+    def connect(self, _slot) -> None:
+        pass
+
+    def isActive(self) -> bool:  # noqa: N802 - Qt API
+        return self.started_with is not None
+
+    def start(self, ms: int) -> None:
+        self.started_with = ms
+
+    def stop(self) -> None:
+        self.started_with = None
+
+    def deleteLater(self) -> None:  # noqa: N802 - Qt API
+        pass
 
 
 class _Recorder(HUD_main.HudMain):
     """A HudMain with only the coalescing collaborators, recording what is sent."""
 
     def __init__(self) -> None:  # noqa: D107 - deliberately not HudMain.__init__
-        from PySide6.QtCore import QObject
-
-        QObject.__init__(self)
         self.sent: list[tuple[str, dict[int, str], str]] = []
         self._ff_last_request_at = {}
         self._ff_coalesced = {}
@@ -55,6 +78,7 @@ class _Recorder(HUD_main.HudMain):
 def app(monkeypatch):
     clock = {"now": 1000.0}
     monkeypatch.setattr(HUD_main.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(HUD_main, "QTimer", _FakeTimer)
     recorder = _Recorder()
     recorder._clock = clock
     return recorder

--- a/test/test_fast_fold_stats_coalescing.py
+++ b/test/test_fast_fold_stats_coalescing.py
@@ -1,0 +1,138 @@
+"""One hand must not cost a database round trip per player named.
+
+The client log names a player only once they have acted, so a six-handed
+Fast-Fold table grows its ring a name at a time. Every growth was its own stats
+request, round trip and redraw. Measured on a real session, two tables:
+
+    stats-requested ... request=1   seats={4: 'jejellyroll', 5: 'ded40'}
+    stats-requested ... request=2   seats={1: ..., 2: ..., 3: ..., 4: ..., 5: ..., 6: ...}
+    ... fourteen of them in one hand
+
+each repainting blocks the player was already reading. The first answer must
+still be immediate -- that is the one they are waiting for -- so this is a
+leading-edge burst with a single trailing send carrying the newest map.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from fpdb_3_legacy import HUD_main  # noqa: E402
+
+COALESCE_MS = HUD_main.HudMain.FF_STATS_COALESCE_MS
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class _Recorder(HUD_main.HudMain):
+    """A HudMain with only the coalescing collaborators, recording what is sent."""
+
+    def __init__(self) -> None:  # noqa: D107 - deliberately not HudMain.__init__
+        from PySide6.QtCore import QObject
+
+        QObject.__init__(self)
+        self.sent: list[tuple[str, dict[int, str], str]] = []
+        self._ff_last_request_at = {}
+        self._ff_coalesced = {}
+        self._ff_coalesce_timers = {}
+        self._ff_trace = lambda *_a, **_k: None
+        self.hud_dict = {}
+
+    def _request_fast_fold_stats(self, temp_key, hud, seat_map, hand_id) -> None:
+        self.sent.append((temp_key, dict(seat_map), hand_id))
+
+
+@pytest.fixture
+def app(monkeypatch):
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(HUD_main.time, "monotonic", lambda: clock["now"])
+    recorder = _Recorder()
+    recorder._clock = clock
+    return recorder
+
+
+def _ask(app, seats, hand_id="hand-1", key="Colorado 11", hud=None):
+    hud = hud if hud is not None else object()
+    app.hud_dict[key] = hud
+    app._request_fast_fold_stats_coalesced(key, hud, seats, hand_id)
+    return hud
+
+
+def test_the_first_map_of_a_burst_is_sent_at_once(app) -> None:
+    _ask(app, {4: "jejellyroll", 5: "ded40"})
+
+    assert len(app.sent) == 1
+    assert app.sent[0][1] == {4: "jejellyroll", 5: "ded40"}
+
+
+def test_maps_chasing_it_are_held_back(app) -> None:
+    hud = _ask(app, {4: "hero"})
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b"}, hud=hud)
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b", 6: "c"}, hud=hud)
+
+    assert len(app.sent) == 1
+
+
+def test_only_the_newest_held_map_is_ever_sent(app) -> None:
+    """An intermediate ring that was already superseded is not worth a round trip."""
+    hud = _ask(app, {4: "hero"})
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b"}, hud=hud)
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b", 6: "c"}, hud=hud)
+
+    app._flush_coalesced_fast_fold_stats("Colorado 11")
+
+    assert len(app.sent) == 2
+    assert app.sent[1][1] == {4: "hero", 5: "b", 6: "c"}
+
+
+def test_a_map_arriving_after_the_window_is_sent_at_once(app) -> None:
+    hud = _ask(app, {4: "hero"})
+    app._clock["now"] += COALESCE_MS / 1000 + 0.01
+    _ask(app, {4: "hero", 5: "b"}, hud=hud)
+
+    assert len(app.sent) == 2
+
+
+def test_a_table_torn_down_while_waiting_is_not_asked_about(app) -> None:
+    """The answer would be applied to a HUD nobody is looking at."""
+    hud = _ask(app, {4: "hero"})
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b"}, hud=hud)
+    app.hud_dict["Colorado 11"] = object()  # rebuilt
+
+    app._flush_coalesced_fast_fold_stats("Colorado 11")
+
+    assert len(app.sent) == 1
+
+
+def test_forgetting_a_table_drops_what_was_held(app) -> None:
+    hud = _ask(app, {4: "hero"})
+    app._clock["now"] += 0.05
+    _ask(app, {4: "hero", 5: "b"}, hud=hud)
+
+    app._forget_coalesced_fast_fold_stats("Colorado 11")
+    app._flush_coalesced_fast_fold_stats("Colorado 11")
+
+    assert len(app.sent) == 1
+    assert "Colorado 11" not in app._ff_coalesce_timers
+
+
+def test_two_tables_do_not_hold_each_other_back(app) -> None:
+    """Each table's burst is its own; one busy table must not mute the other."""
+    _ask(app, {4: "hero"}, key="Colorado 11")
+    _ask(app, {4: "hero"}, key="Colorado 12")
+
+    assert len(app.sent) == 2

--- a/test/test_winamax_ax_seats_windows.py
+++ b/test/test_winamax_ax_seats_windows.py
@@ -403,3 +403,21 @@ def test_a_known_handle_is_read_without_searching_the_desktop(windows) -> None:
 
     assert reader.read_window("Winamax Bucarest 3", 6, window_id=61825) == {0: "jejellyroll"}
     reader._read_window_windows.assert_called_once_with(61825, 6)
+
+
+def test_a_partial_ring_off_frame_is_refused_until_a_full_one_is_seen(monkeypatch) -> None:
+    """Seating people from a centre nobody measured puts stats on the wrong chairs.
+
+    The client reports its content in a different space from its frame, so the
+    centre has to come from the players -- and a partial ring's bounding box is
+    not the table's centre. The hero would still land on slot 0 and the answer
+    be accepted, with the neighbours two chairs from where they sit.
+    """
+    ax.forget_table_centres()
+    ax.reset_windows_uia()
+    # A window at 3840..4800 whose players report at 1767..2259, as measured.
+    window = UIAElement("Winamax Colorado 1", Rect(3840, 0, 4800, 739))
+    partial = seated_table({"jejellyroll": (2000, 365), "depor81": (1783, 329)})
+    install_uia(monkeypatch, window=window, descendants=partial)
+
+    assert ax.WinamaxAXSeatReader()._read_window_windows(1234, 6) == {}

--- a/test/test_winamax_ax_seats_windows.py
+++ b/test/test_winamax_ax_seats_windows.py
@@ -413,7 +413,7 @@ def test_a_partial_ring_off_frame_is_refused_until_a_full_one_is_seen(monkeypatc
     not the table's centre. The hero would still land on slot 0 and the answer
     be accepted, with the neighbours two chairs from where they sit.
     """
-    ax.forget_table_centres()
+    ax.forget_window_state()
     ax.reset_windows_uia()
     # A window at 3840..4800 whose players report at 1767..2259, as measured.
     window = UIAElement("Winamax Colorado 1", Rect(3840, 0, 4800, 739))

--- a/tools/diagnose_winamax_seats.py
+++ b/tools/diagnose_winamax_seats.py
@@ -65,10 +65,23 @@ def _report_table(reader_module, table) -> int:
     for label in labels:
         print(f"      {label.login!r:24} @ ({label.x},{label.y})")
     if labels:
-        xs = [label.x for label in labels]
-        print(f"  label x range {min(xs)}..{max(xs)} -- compare with the window rect above:")
-        print("      same scale        -> positions are usable")
-        print("      roughly half/double -> the process and the client disagree on DPI")
+        # Each label against the window it is supposed to be inside, rather than
+        # a min/max over all of them: the window's own title reports itself at
+        # the window origin and a stray "Notifications" node reports (0,0), so a
+        # range spanning both looked like it covered the window when not one of
+        # the client's own labels was inside it.
+        outside = [
+            label
+            for label in labels
+            if not (rect.left <= label.x <= rect.right and rect.top <= label.y <= rect.bottom)
+        ]
+        print(f"  labels outside the window rect: {len(outside)} of {len(labels)}")
+        if outside:
+            print("      the client is not reporting positions in the window's coordinate space,")
+            print("      so the table centre computed from that rect puts every player on the")
+            print("      wrong chair -- the hero comes back off the bottom-centre slot.")
+            for label in outside[:5]:
+                print(f"        {label.login!r} @ ({label.x},{label.y})")
     print(f"  seats_from_labels: {reader_module.seats_from_labels(labels)}")
     print(f"  read_window      : {reader_module.read_window_for(hwnd, table.title)}")
     return len(labels)

--- a/tools/diagnose_winamax_seats.py
+++ b/tools/diagnose_winamax_seats.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Report what a Winamax table window publishes about its seats (Windows).
+
+The Fast-Fold HUD reads a table's chairs from the window itself, because the
+client log only names a player once they have acted -- and a HUD built from the
+log fills in one block at a time over the first betting round. When the window
+read comes back empty, or partial, the HUD silently falls back to that log and
+the session looks slow for reasons nothing in the log explains.
+
+This asks the same questions the reader asks, and prints every answer:
+
+    python tools/diagnose_winamax_seats.py
+    python tools/diagnose_winamax_seats.py --wait 60
+
+* which windows the table detector can see at all, the lobby included
+* whether the UIAutomation client can be built (comtypes, COM, the wrapper)
+* the window's own rectangle, and every label under it with its position --
+  the two together are what shows a coordinate-space mismatch, which sends
+  every player to the wrong chair even when the names are read correctly
+* what seats_from_labels and read_window make of those labels
+
+Chromium builds its accessibility tree only when an assistive client asks, so
+the request is sent here too, exactly as the HUD sends it. The tree is built
+asynchronously: --wait polls until a table publishes something, which is what
+you want when the labels only appear while a hand is being dealt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _tables():
+    """Every Winamax window the detector can see, tables first."""
+    from fpdb.infrastructure.platform import get_table_detector
+
+    windows = get_table_detector().find_tables("Winamax")
+    tables = [w for w in windows if w.title and w.title.strip() != "Winamax"]
+    return windows, tables
+
+
+def _report_table(reader_module, table) -> int:
+    """Print everything one table window will say. Returns the label count."""
+    hwnd = int(table.window_id)
+    reader_module.request_windows_accessibility(hwnd)
+    client = reader_module._windows_uia()
+    if client is None:
+        print("  no UIAutomation client on this machine")
+        return 0
+
+    element = client.automation.ElementFromHandle(hwnd)
+    if element is None:
+        print(f"  hwnd {hwnd} has no UIAutomation element")
+        return 0
+
+    rect = element.CurrentBoundingRectangle
+    print(f"  window rect ({rect.left},{rect.top})-({rect.right},{rect.bottom})")
+    labels = client.collect_labels(element)
+    print(f"  labels: {len(labels)}")
+    for label in labels:
+        print(f"      {label.login!r:24} @ ({label.x},{label.y})")
+    if labels:
+        xs = [label.x for label in labels]
+        print(f"  label x range {min(xs)}..{max(xs)} -- compare with the window rect above:")
+        print("      same scale        -> positions are usable")
+        print("      roughly half/double -> the process and the client disagree on DPI")
+    print(f"  seats_from_labels: {reader_module.seats_from_labels(labels)}")
+    print(f"  read_window      : {reader_module.read_window_for(hwnd, table.title)}")
+    return len(labels)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the diagnosis; exit 1 when no table published anything."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--wait",
+        type=int,
+        default=0,
+        metavar="SECONDS",
+        help="keep polling until a table publishes labels (default: report once and stop)",
+    )
+    args = parser.parse_args(argv)
+
+    from fpdb_3_legacy import winamax_ax_seats
+
+    deadline = time.monotonic() + args.wait
+    while True:
+        windows, tables = _tables()
+        print(f"Winamax windows detected: {len(windows)} ({len(tables)} look like tables)")
+        for window in windows:
+            kind = "table" if window in tables else "lobby/other"
+            print(f"  [{kind}] hwnd={window.window_id} {window.title!r}")
+
+        found = 0
+        for table in tables:
+            print(f"\n--- {table.title!r}")
+            found += _report_table(winamax_ax_seats, table)
+
+        if found or time.monotonic() >= deadline:
+            if not tables:
+                print("\nNo table window found. Open a Fast-Fold table and run this again,")
+                print("or pass --wait 60 and open one while it polls.")
+            return 0 if found else 1
+        time.sleep(2)
+        print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/diagnose_winamax_seats.py
+++ b/tools/diagnose_winamax_seats.py
@@ -12,6 +12,11 @@ This asks the same questions the reader asks, and prints every answer:
     python tools/diagnose_winamax_seats.py
     python tools/diagnose_winamax_seats.py --wait 60
 
+``--wait`` polls until a table publishes *seats*, not merely labels: Chromium
+exposes its own frame and controls before the felt, so a window answering with a
+dozen labels and no players is the state worth waiting through rather than
+stopping at.
+
 * which windows the table detector can see at all, the lobby included
 * whether the UIAutomation client can be built (comtypes, COM, the wrapper)
 * the window's own rectangle, and every label under it with its position --
@@ -45,7 +50,15 @@ def _tables():
 
 
 def _report_table(reader_module, table) -> int:
-    """Print everything one table window will say. Returns the label count."""
+    """Print everything one table window will say. Returns the seats it yielded.
+
+    Seats, not labels. Chromium publishes its native frame and controls before
+    it publishes the felt, so a table can be answering with a dozen labels and
+    not one player -- which is the state this tool exists to tell apart from a
+    client that answers nothing. Counting labels made --wait stop there and
+    report success at exactly the wrong moment. Reported by Codex on the pull
+    request.
+    """
     hwnd = int(table.window_id)
     reader_module.request_windows_accessibility(hwnd)
     client = reader_module._windows_uia()
@@ -82,9 +95,13 @@ def _report_table(reader_module, table) -> int:
             print("      wrong chair -- the hero comes back off the bottom-centre slot.")
             for label in outside[:5]:
                 print(f"        {label.login!r} @ ({label.x},{label.y})")
-    print(f"  seats_from_labels: {reader_module.seats_from_labels(labels)}")
-    print(f"  read_window      : {reader_module.read_window_for(hwnd, table.title)}")
-    return len(labels)
+    players = reader_module.seats_from_labels(labels)
+    seats = reader_module.read_window_for(hwnd, table.title)
+    print(f"  seats_from_labels: {players}")
+    print(f"  read_window      : {seats}")
+    if labels and not seats:
+        print("  the window is answering, but not with seats yet -- still waiting")
+    return len(seats)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -95,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=0,
         metavar="SECONDS",
-        help="keep polling until a table publishes labels (default: report once and stop)",
+        help="keep polling until a table publishes its seats (default: report once and stop)",
     )
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
The Fast-Fold HUD on Windows filled in one block at a time over the first
betting round, taking up to 17 seconds to show a six-handed table. It now shows
all six at hand start.

```
before   +765ms {3,4}  +1656ms {3,4,5}  +16172ms {1,3,4,5,6}  +17781ms {1..6}   source=log-ring
after    +406ms players=6 slots={0: 'jejellyroll', ...} empty=[]                 source=window
         +937ms  (second table, same session)                                    source=window
```

## Why it was blind, and what unlocked it

The seats are read off the table window. On macOS that works, because the reader
switches the client's accessibility tree on first:

```python
# Chromium only builds its web accessibility tree when an assistive
# client asks for it; without this the windows expose nothing but
# their titles.
AXUIElementSetAttributeValue(self._app, "AXManualAccessibility", True)
```

Windows never asked, and measured exactly what that note predicts: a whole poker
table, mid-hand, gave 7 nodes in the control view, 6 in the raw view, **none of
them named**.

`WM_GETOBJECT` with `OBJID_CLIENT` gets Chromium as far as its "native APIs"
mode — the frame, the Views widgets, the dialogs. That is what came back next:
`'Autorebuy'`, `'Confirmer'`, the hero's own seat, and not one opponent, because
the felt is web content and web content needs the *complete* mode.

Querying **IAccessible2** through `IServiceProvider` is what a screen reader
does, and what Chromium watches for. On the same live table, immediately after:
32 labels became 54, and `seats_from_labels` went from the hero alone to all six
players with their stacks. Per process and reversible, unlike the
`SPI_SETSCREENREADER` system flag, which would change how every application on
the desktop behaves.

The extraction itself needed nothing: `seats_from_labels` pairs a name with the
stack drawn beneath it, and it is already shared with macOS. Verified on the
Windows sample — `'jejellyroll' @ (3960,548)` with `'0 BB' @ (3969,572)`, dy 24
inside the allowed (2, 45).

One thing did need fixing. The client reports its content in a different space
from its frame — a window at x 3840..4800 whose players sit at x 1767..2259 — so
a centre taken from the window rectangle lies to one side of every player and
the whole ring collapses into one slot:

```
centre from the window rect : {2: 'CTroPinJust'}
centre from the players     : {0: 'jejellyroll', 1: 'depor81', 2: 'BluffTesMots', ...}
```

The players are all in one space as each other, which is the only space the
angles have to agree in.

## The rest of the branch

Everything before that commit is what made it findable, and is worth keeping on
its own:

- **the failure was invisible** — losing the reader logged at `INFO`, and
  `prewarm()` returned silently when comtypes was missing, under a root logger
  pinned to `WARNING`. Both are WARNINGs now.
- **`_ax_slots` traced only reads that changed**, so a reader returning nothing
  returned the same nothing and logged absolutely nothing, even with
  `FPDB_HUD_TRACE=1`. It traces every read; that is what produced the evidence
  above.
- **the HUD was reading its own blocks back.** They are transient children of the
  table, so a real walk returned `'HUD - stats'`, `'VP 0.0'`, `'3B -'`.
  Own-process elements are skipped, failing open.
- **a reader that cannot seat anyone is given up on**, per table, after two
  hands. It counted *empty* reads at first, which a client answering with the
  hero and one neighbour never produces — so it never fired while six reads a
  hand at 94-218ms went on freezing the GUI thread. Fruitless now means "could
  not be acted on", tested with the caller's own condition.
- **stats requests are coalesced** (leading edge, then one trailing send) and the
  worker **drops superseded reads before running them** — fourteen round trips
  and repaints in one hand became a handful.
- **two settings**: `hud_ui/@fast_fold_seat_wait_ms` for how long to wait for the
  log ring, and `hud_ui/@fast_fold_window_seats` to turn the window reader off
  where a client never answers.
- **`tools/diagnose_winamax_seats.py`**, which reports what a table window
  publishes and flags a coordinate-space mismatch.

## Known limit, and why it is safe

Sampling two tables outside a hand once returned labels from the other table's
coordinate space, mapping the hero off slot 0. The caller already requires
`HERO_SLOT in slots`, so such a read is discarded and that table falls back to
the client log exactly as before: a table whose seats cannot be trusted shows
none rather than wrong ones. It did not occur in live multi-table play, where
both tables read `source=window`.

## Tests

`test_fast_fold_seat_reader_visibility.py` (11), `test_fast_fold_ax_circuit_breaker.py`
(9), `test_fast_fold_stats_coalescing.py` (7), `test_fast_fold_latest_only_queue.py`
(6), `test_fast_fold_seat_wait_setting.py` (12). Every test pinning new behaviour
was checked against the previous commit.

Both modes CI runs: `-m "not qt and not perf"` 163 passed on the touched suites,
`-m qt` 168 passed. `ruff` clean.
