### PR TITLE
feat(importer): add ChipZen normalized hand-history support

### DIFF
--- a/fpdb_3_legacy/ChipZenToFpdb.py
+++ b/fpdb_3_legacy/ChipZenToFpdb.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python
+"""ChipZen normalized JSONL hand-history converter.
+
+The file format consumed here is deliberately an fpdb-owned normalization of
+ChipZen's public v1 transport + NLHE protocol, not a scrape of the website.  A
+single line is one completed hand and carries the match/round metadata, every
+``phase_change`` needed to reconstruct the board, optional ``turn_results`` for
+amount validation, and the canonical ``round_result.action_history``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, ClassVar
+
+from fpdb_3_legacy.HandHistoryConverter import FpdbParseError, HandHistoryConverter
+from fpdb_3_legacy.http_capture_hand_builder import CaptureNotImportableError, build_fpdb_hand
+from fpdb_3_legacy.loggingFpdb import get_logger
+
+log = get_logger("chipzen_parser")
+
+
+class ChipZen(HandHistoryConverter):
+    """Import ``fpdb-chipzen-hand/v1`` records as normal fpdb Hold'em hands."""
+
+    sitename = "ChipZen"
+    siteId = 141
+    filetype = "text"
+    codepage = ("utf8",)
+    copyGameHeader = False
+    summaryInFile = False
+
+    re_identify = re.compile(r'"schema"\s*:\s*"fpdb-chipzen-hand/v1"')
+    # JSONL: every physical line is one complete normalized hand.  The splitter
+    # consumes only the newline so the JSON object itself stays intact.
+    re_split_hands = re.compile(r"\n+")
+    re_SplitHands = re_split_hands
+
+    _PHASE_TO_STREET: ClassVar[dict[str, str]] = {
+        "preflop": "PREFLOP",
+        "flop": "FLOP",
+        "turn": "TURN",
+        "river": "RIVER",
+    }
+    _EXPECTED_BOARD_LEN: ClassVar[dict[str, int]] = {"flop": 3, "turn": 4, "river": 5}
+
+    @staticmethod
+    def stable_hand_id(match_id: str, round_id: str | None, hand_number: int | str | None) -> int:
+        """Return a deterministic positive signed-BIGINT id for one ChipZen hand."""
+        discriminator = round_id or str(hand_number or "")
+        if not match_id or not discriminator:
+            raise FpdbParseError("ChipZen hand is missing match_id/round_id identity")
+        raw = f"{match_id}:{discriminator}".encode("utf-8")
+        digest = hashlib.blake2b(raw, digest_size=8, person=b"fpdb-cz1").digest()
+        return int.from_bytes(digest, "big") & 0x7FFF_FFFF_FFFF_FFFF
+
+    @staticmethod
+    def _record(text: str) -> dict[str, Any]:
+        try:
+            record = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise FpdbParseError(f"Invalid ChipZen JSON: {exc}") from exc
+        if not isinstance(record, dict) or record.get("schema") != "fpdb-chipzen-hand/v1":
+            raise FpdbParseError("Unsupported ChipZen normalized hand schema")
+        return record
+
+    @staticmethod
+    def _seat_names(record: dict[str, Any]) -> dict[int, str]:
+        seats = record.get("match", {}).get("seats") or []
+        names: dict[int, str] = {}
+        for entry in seats:
+            if not isinstance(entry, dict) or not isinstance(entry.get("seat"), int):
+                continue
+            seat = int(entry["seat"])
+            name = entry.get("display_name") or entry.get("name") or f"ChipZen-seat-{seat}"
+            names[seat] = str(name)
+        return names
+
+    @classmethod
+    def _community(cls, record: dict[str, Any]) -> dict[str, list[str]]:
+        phase_changes = record.get("phase_changes") or []
+        community: dict[str, list[str]] = {}
+        seen: set[str] = set()
+        for change in phase_changes:
+            state = change.get("state", change) if isinstance(change, dict) else {}
+            phase = str(state.get("phase") or "").lower()
+            if phase not in cls._EXPECTED_BOARD_LEN:
+                continue
+            board = state.get("board")
+            if not isinstance(board, list) or len(board) != cls._EXPECTED_BOARD_LEN[phase]:
+                raise FpdbParseError(
+                    f"ChipZen invalid {phase} board: expected {cls._EXPECTED_BOARD_LEN[phase]} cards, got {board!r}"
+                )
+            if len(set(board)) != len(board):
+                raise FpdbParseError(f"ChipZen {phase} board contains duplicate cards: {board!r}")
+            if phase == "flop":
+                community["FLOP"] = [str(card) for card in board]
+            elif phase == "turn":
+                community["TURN"] = [str(board[-1])]
+            else:
+                community["RIVER"] = [str(board[-1])]
+            seen.add(phase)
+
+        # If the action history says a street was reached, its phase_change is
+        # mandatory because round_result deliberately does not carry the board.
+        actions = record.get("round_result", {}).get("result", {}).get("action_history") or []
+        reached = {str(a.get("phase") or "").lower() for a in actions if isinstance(a, dict)}
+        for phase in ("flop", "turn", "river"):
+            if phase in reached and phase not in seen:
+                raise FpdbParseError(f"ChipZen hand reached {phase} but the required phase_change is missing")
+        return community
+
+    @staticmethod
+    def _turn_result_index(record: dict[str, Any]) -> dict[tuple[int, str, str, int], list[dict[str, Any]]]:
+        """Index optional post-action snapshots without assuming one export spelling."""
+        indexed: dict[tuple[int, str, str, int], list[dict[str, Any]]] = defaultdict(list)
+        for item in record.get("turn_results") or []:
+            details = item.get("details", item) if isinstance(item, dict) else {}
+            try:
+                key = (
+                    int(details["seat"]),
+                    str(details["action"]),
+                    str(details.get("phase") or ""),
+                    int(details.get("amount") or 0),
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+            indexed[key].append(details)
+        return indexed
+
+    @classmethod
+    def _actions(cls, record: dict[str, Any], names: dict[int, str]) -> list[dict[str, Any]]:
+        history = record.get("round_result", {}).get("result", {}).get("action_history")
+        if not isinstance(history, list) or not history:
+            raise FpdbParseError("ChipZen round_result.action_history is missing")
+
+        actions: list[dict[str, Any]] = []
+        contributions: dict[tuple[str, int], Decimal] = defaultdict(Decimal)
+        for entry in history:
+            if not isinstance(entry, dict):
+                raise FpdbParseError("ChipZen action_history contains a non-object entry")
+            try:
+                seat = int(entry["seat"])
+                kind = str(entry["action"])
+                phase = str(entry["phase"]).lower()
+                amount = Decimal(str(entry.get("amount", 0)))
+            except (KeyError, TypeError, ValueError, ArithmeticError) as exc:
+                raise FpdbParseError(f"Malformed ChipZen action: {entry!r}") from exc
+            if seat not in names:
+                raise FpdbParseError(f"ChipZen action references unknown seat {seat}")
+            if phase not in cls._PHASE_TO_STREET:
+                raise FpdbParseError(f"ChipZen action has unknown phase {phase!r}")
+            street = cls._PHASE_TO_STREET[phase]
+            player = names[seat]
+            key = (phase, seat)
+
+            if kind == "post_small_blind":
+                actions.append({"type": "small blind", "player": player, "amount": amount})
+                contributions[key] += amount
+            elif kind == "post_big_blind":
+                actions.append({"type": "big blind", "player": player, "amount": amount})
+                contributions[key] += amount
+            elif kind == "post_ante":
+                actions.append({"type": "ante", "player": player, "amount": amount})
+            elif kind == "fold":
+                actions.append({"type": "folds", "street": street, "player": player})
+            elif kind == "check":
+                actions.append({"type": "checks", "street": street, "player": player})
+            elif kind == "call":
+                # The v1 prose says ActionEntry.amount is chips committed by
+                # the action.  Preserve that definition here.  Real captures
+                # with turn_result snapshots are expected in conformance tests
+                # because one prose example historically used a call-to value.
+                actions.append({"type": "calls", "street": street, "player": player, "amount": amount})
+                contributions[key] += amount
+            elif kind == "raise":
+                # ChipZen turn_action / turn_result explicitly define raises as
+                # raise-to totals, which maps directly to Hand.addRaiseTo().
+                actions.append({"type": "raises", "street": street, "player": player, "to": amount})
+                prior = contributions[key]
+                if amount < prior:
+                    raise FpdbParseError(
+                        f"ChipZen raise-to {amount} is below prior street contribution {prior} for {player}"
+                    )
+                contributions[key] = amount
+            else:
+                raise FpdbParseError(f"Unsupported ChipZen NLHE action {kind!r}")
+
+            if entry.get("is_timeout"):
+                log.debug("ChipZen timeout action imported: seat=%s phase=%s action=%s", seat, phase, kind)
+        return actions
+
+    @classmethod
+    def normalize_record(cls, record: dict[str, Any]) -> dict[str, Any]:
+        """Translate one ChipZen bundle into fpdb's normalized capture model."""
+        match = record.get("match") or {}
+        game = match.get("game_config") or {}
+        round_start = record.get("round_start") or {}
+        start_state = round_start.get("state") or {}
+        round_result = record.get("round_result") or {}
+        result = round_result.get("result") or {}
+
+        if game.get("variant") not in (None, "nlhe"):
+            raise FpdbParseError(f"Unsupported ChipZen variant {game.get('variant')!r}; MVP supports NLHE only")
+
+        names = cls._seat_names(record)
+        num_players = int(game.get("num_players") or len(names) or 0)
+        if num_players < 2 or num_players > 6 or len(names) < 2:
+            raise FpdbParseError(f"Invalid ChipZen table size/seats: num_players={num_players}, seats={names!r}")
+
+        stacks = start_state.get("stacks")
+        if not isinstance(stacks, list) or len(stacks) < num_players:
+            raise FpdbParseError("ChipZen round_start.state.stacks is missing/incomplete")
+
+        match_id = str(match.get("match_id") or round_start.get("match_id") or round_result.get("match_id") or "")
+        round_id = str(round_start.get("round_id") or round_result.get("round_id") or "") or None
+        hand_number = start_state.get("hand_number", result.get("hand_number"))
+        hand_id = cls.stable_hand_id(match_id, round_id, hand_number)
+        short_match = match_id.replace("-", "")[:8] or "unknown"
+
+        players = []
+        hero = ""
+        for seat in range(num_players):
+            name = names.get(seat, f"ChipZen-seat-{seat}")
+            players.append({"seat_idx": seat, "name": name, "starting_stack": stacks[seat], "dealt": True})
+            seat_meta = next((s for s in match.get("seats") or [] if isinstance(s, dict) and s.get("seat") == seat), {})
+            if seat_meta.get("is_self"):
+                hero = name
+
+        holecards = []
+        hero_cards = start_state.get("your_hole_cards")
+        if hero and isinstance(hero_cards, list) and hero_cards:
+            holecards.append({"player": hero, "cards": list(hero_cards), "street": "PREFLOP", "dealt": True})
+
+        for shown in result.get("showdown") or []:
+            if not isinstance(shown, dict) or shown.get("seat") not in names:
+                continue
+            cards = shown.get("hole_cards")
+            if cards:
+                holecards.append(
+                    {
+                        "player": names[int(shown["seat"])],
+                        "cards": list(cards),
+                        "street": "PREFLOP",
+                        "shown": True,
+                        "dealt": True,
+                    }
+                )
+
+        collections = []
+        for payout in result.get("payouts") or []:
+            if not isinstance(payout, dict):
+                continue
+            seat = payout.get("seat")
+            if seat not in names:
+                raise FpdbParseError(f"ChipZen payout references unknown seat {seat!r}")
+            collections.append({"player": names[int(seat)], "pot": payout.get("amount", 0)})
+        if not collections:
+            raise FpdbParseError("ChipZen completed hand has no payouts")
+
+        sb = game.get("small_blind", 0)
+        bb = game.get("big_blind", 0)
+        ante = game.get("ante", 0)
+        timestamp = round_start.get("server_ts") or round_result.get("server_ts") or match.get("started_at")
+        button = start_state.get("dealer_seat")
+
+        return {
+            "site": "ChipZen",
+            "hand_id": hand_id,
+            "table_id": f"ChipZen {short_match}",
+            "timestamp": timestamp,
+            "hero": hero,
+            "buttonpos": int(button) + 1 if button is not None else None,
+            "game": {"base": "hold", "category": "holdem", "fpdb_supported": True},
+            "gametype": {
+                "type": "ring",
+                "base": "hold",
+                "category": "holdem",
+                "limitType": "nl",
+                "currency": "play",
+                "sb": str(sb),
+                "bb": str(bb),
+                "ante": str(ante),
+                "maxSeats": num_players,
+                "mix": "none",
+            },
+            "players": players,
+            "community": cls._community(record),
+            "holecards": holecards,
+            "actions": cls._actions(record, names),
+            "collections": collections,
+            "metadata": {
+                "source": "chipzen",
+                "schema": record["schema"],
+                "match_id": match_id,
+                "round_id": round_id,
+                "hand_number": hand_number,
+                "state_model": "event",
+            },
+        }
+
+    def processHand(self, handText):  # noqa: N802 - legacy API
+        record = self._record(handText)
+        normalized = self.normalize_record(record)
+        try:
+            hand = build_fpdb_hand(normalized, config=self.config, hhc=self, hand_text=handText)
+        except CaptureNotImportableError as exc:
+            raise FpdbParseError(f"ChipZen hand cannot be imported: {exc}") from exc
+        hand.rake = Decimal("0")
+        self._warn_if_hand_missing_expected_data(hand)
+        return hand
+
+    # HandHistoryConverter's normal text-parsing surface is abstract.  This
+    # converter overrides processHand() because its source is structured JSON;
+    # these methods therefore exist only to satisfy the common converter API.
+    def readSupportedGames(self):  # noqa: N802
+        return [["ring", "hold", "nl"]]
+
+    def determineGameType(self, handText):  # noqa: N802
+        return self.normalize_record(self._record(handText))["gametype"]
+
+    def readHandInfo(self, hand):  # noqa: N802
+        return None
+
+    def readPlayerStacks(self, hand):  # noqa: N802
+        return None
+
+    def compilePlayerRegexs(self, hand):  # noqa: N802
+        return None
+
+    def markStreets(self, hand):  # noqa: N802
+        return None
+
+    def readBlinds(self, hand):  # noqa: N802
+        return None
+
+    def readSTP(self, hand):  # noqa: N802
+        return None
+
+    def readAntes(self, hand):  # noqa: N802
+        return None
+
+    def readBringIn(self, hand):  # noqa: N802
+        return None
+
+    def readButton(self, hand):  # noqa: N802
+        return None
+
+    def readHoleCards(self, hand):  # noqa: N802
+        return None
+
+    def readAction(self, hand, street):  # noqa: N802
+        return None
+
+    def readCollectPot(self, hand):  # noqa: N802
+        return None
+
+    def readShownCards(self, hand):  # noqa: N802
+        return None
+
+    def readTourneyResults(self, hand):  # noqa: N802
+        return None
+
+    def readSummaryInfo(self, summaryInfoList):  # noqa: N802
+        return False

--- a/fpdb_3_legacy/ChipZenToFpdb.py
+++ b/fpdb_3_legacy/ChipZenToFpdb.py
@@ -2,7 +2,7 @@
 """ChipZen normalized JSONL hand-history converter.
 
 The file format consumed here is deliberately an fpdb-owned normalization of
-ChipZen's public v1 transport + NLHE protocol, not a scrape of the website.  A
+ChipZen's public v1 transport + NLHE protocol, not a scrape of the website. A
 single line is one completed hand and carries the match/round metadata, every
 ``phase_change`` needed to reconstruct the board, optional ``turn_results`` for
 amount validation, and the canonical ``round_result.action_history``.
@@ -13,7 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from collections import defaultdict
+from collections import defaultdict, deque
 from decimal import Decimal
 from typing import Any, ClassVar
 
@@ -35,7 +35,7 @@ class ChipZen(HandHistoryConverter):
     summaryInFile = False
 
     re_identify = re.compile(r'"schema"\s*:\s*"fpdb-chipzen-hand/v1"')
-    # JSONL: every physical line is one complete normalized hand.  The splitter
+    # JSONL: every physical line is one complete normalized hand. The splitter
     # consumes only the newline so the JSON object itself stays intact.
     re_split_hands = re.compile(r"\n+")
     re_SplitHands = re_split_hands
@@ -47,6 +47,9 @@ class ChipZen(HandHistoryConverter):
         "river": "RIVER",
     }
     _EXPECTED_BOARD_LEN: ClassVar[dict[str, int]] = {"flop": 3, "turn": 4, "river": 5}
+    _SYNTHETIC_ACTIONS: ClassVar[frozenset[str]] = frozenset(
+        {"post_small_blind", "post_big_blind", "post_ante"}
+    )
 
     @staticmethod
     def stable_hand_id(match_id: str, round_id: str | None, hand_number: int | str | None) -> int:
@@ -85,6 +88,8 @@ class ChipZen(HandHistoryConverter):
         phase_changes = record.get("phase_changes") or []
         community: dict[str, list[str]] = {}
         seen: set[str] = set()
+        all_cards: list[str] = []
+
         for change in phase_changes:
             state = change.get("state", change) if isinstance(change, dict) else {}
             phase = str(state.get("phase") or "").lower()
@@ -95,15 +100,27 @@ class ChipZen(HandHistoryConverter):
                 raise FpdbParseError(
                     f"ChipZen invalid {phase} board: expected {cls._EXPECTED_BOARD_LEN[phase]} cards, got {board!r}"
                 )
+            board = [str(card) for card in board]
             if len(set(board)) != len(board):
                 raise FpdbParseError(f"ChipZen {phase} board contains duplicate cards: {board!r}")
+
             if phase == "flop":
-                community["FLOP"] = [str(card) for card in board]
+                community["FLOP"] = board
             elif phase == "turn":
-                community["TURN"] = [str(board[-1])]
+                if "FLOP" not in community or board[:3] != community["FLOP"]:
+                    raise FpdbParseError("ChipZen turn board does not extend the recorded flop")
+                community["TURN"] = [board[-1]]
             else:
-                community["RIVER"] = [str(board[-1])]
+                expected_prefix = community.get("FLOP", []) + community.get("TURN", [])
+                if len(expected_prefix) != 4 or board[:4] != expected_prefix:
+                    raise FpdbParseError("ChipZen river board does not extend the recorded turn")
+                community["RIVER"] = [board[-1]]
+
+            all_cards = board
             seen.add(phase)
+
+        if len(all_cards) != len(set(all_cards)):
+            raise FpdbParseError(f"ChipZen board contains duplicate cards: {all_cards!r}")
 
         # If the action history says a street was reached, its phase_change is
         # mandatory because round_result deliberately does not carry the board.
@@ -115,22 +132,99 @@ class ChipZen(HandHistoryConverter):
         return community
 
     @staticmethod
-    def _turn_result_index(record: dict[str, Any]) -> dict[tuple[int, str, str, int], list[dict[str, Any]]]:
-        """Index optional post-action snapshots without assuming one export spelling."""
-        indexed: dict[tuple[int, str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    def _turn_result_amounts(record: dict[str, Any]) -> dict[tuple[int, str], deque[Decimal]]:
+        """Return chronological authoritative amounts from optional turn results.
+
+        ChipZen's current v1 documentation has a deliberate/legacy mismatch in
+        its worked example: ``action_history`` records a preflop BB call as 30
+        (the matched street total), while the corresponding ``turn_result``
+        records 20 (the chips actually added by that action). ``turn_result``
+        explicitly defines calls as incremental and raises as raise-to totals,
+        so when it is present we use it to disambiguate the canonical history.
+        """
+        amounts: dict[tuple[int, str], deque[Decimal]] = defaultdict(deque)
         for item in record.get("turn_results") or []:
             details = item.get("details", item) if isinstance(item, dict) else {}
-            try:
-                key = (
-                    int(details["seat"]),
-                    str(details["action"]),
-                    str(details.get("phase") or ""),
-                    int(details.get("amount") or 0),
-                )
-            except (KeyError, TypeError, ValueError):
+            if not isinstance(details, dict):
                 continue
-            indexed[key].append(details)
-        return indexed
+            try:
+                seat = int(details["seat"])
+                action = str(details["action"])
+                amount = Decimal(str(details.get("amount", 0)))
+            except (KeyError, TypeError, ValueError, ArithmeticError):
+                continue
+            amounts[(seat, action)].append(amount)
+        return amounts
+
+    @staticmethod
+    def _next_turn_result_amount(
+        amounts: dict[tuple[int, str], deque[Decimal]], seat: int, action: str
+    ) -> Decimal | None:
+        queue = amounts.get((seat, action))
+        if not queue:
+            return None
+        return queue.popleft()
+
+    @staticmethod
+    def _highest_contribution(contributions: dict[tuple[str, int], Decimal], phase: str) -> Decimal:
+        values = [value for (street_phase, _seat), value in contributions.items() if street_phase == phase]
+        return max(values, default=Decimal(0))
+
+    @classmethod
+    def _call_increment(
+        cls,
+        *,
+        history_amount: Decimal,
+        turn_result_amount: Decimal | None,
+        prior: Decimal,
+        highest: Decimal,
+        player: str,
+        phase: str,
+    ) -> Decimal:
+        """Normalize a ChipZen call to the incremental amount fpdb expects."""
+        expected = max(Decimal(0), highest - prior)
+
+        if turn_result_amount is not None:
+            if turn_result_amount < 0:
+                raise FpdbParseError(f"ChipZen call has negative turn_result amount for {player}")
+            if turn_result_amount > expected and expected > 0:
+                raise FpdbParseError(
+                    f"ChipZen call turn_result amount {turn_result_amount} exceeds {expected} to call for {player} on {phase}"
+                )
+            if history_amount != turn_result_amount:
+                log.debug(
+                    "ChipZen call amount normalized from action_history=%s to turn_result=%s for %s on %s",
+                    history_amount,
+                    turn_result_amount,
+                    player,
+                    phase,
+                )
+            return turn_result_amount
+
+        # Current docs contain both conventions in examples. If the canonical
+        # history carries the final matched street total, convert it back to the
+        # increment. If it already carries the increment, preserve it.
+        if history_amount == expected:
+            return history_amount
+        if expected > 0 and history_amount == highest:
+            log.debug(
+                "ChipZen call amount %s interpreted as call-to total; importing increment %s for %s on %s",
+                history_amount,
+                expected,
+                player,
+                phase,
+            )
+            return expected
+        # A short all-in call can be less than the amount required to match the
+        # current bet. Without a turn_result/stack delta this is the only safe
+        # additional case we can accept.
+        if Decimal(0) <= history_amount < expected:
+            return history_amount
+        if expected == 0 and history_amount == 0:
+            return Decimal(0)
+        raise FpdbParseError(
+            f"Ambiguous ChipZen call amount {history_amount} for {player} on {phase}; expected increment {expected}"
+        )
 
     @classmethod
     def _actions(cls, record: dict[str, Any], names: dict[int, str]) -> list[dict[str, Any]]:
@@ -140,6 +234,8 @@ class ChipZen(HandHistoryConverter):
 
         actions: list[dict[str, Any]] = []
         contributions: dict[tuple[str, int], Decimal] = defaultdict(Decimal)
+        turn_result_amounts = cls._turn_result_amounts(record)
+
         for entry in history:
             if not isinstance(entry, dict):
                 raise FpdbParseError("ChipZen action_history contains a non-object entry")
@@ -154,9 +250,15 @@ class ChipZen(HandHistoryConverter):
                 raise FpdbParseError(f"ChipZen action references unknown seat {seat}")
             if phase not in cls._PHASE_TO_STREET:
                 raise FpdbParseError(f"ChipZen action has unknown phase {phase!r}")
+            if amount < 0:
+                raise FpdbParseError(f"ChipZen action has negative amount: {entry!r}")
+
             street = cls._PHASE_TO_STREET[phase]
             player = names[seat]
             key = (phase, seat)
+            observed = None if kind in cls._SYNTHETIC_ACTIONS else cls._next_turn_result_amount(
+                turn_result_amounts, seat, kind
+            )
 
             if kind == "post_small_blind":
                 actions.append({"type": "small blind", "player": player, "amount": amount})
@@ -171,22 +273,30 @@ class ChipZen(HandHistoryConverter):
             elif kind == "check":
                 actions.append({"type": "checks", "street": street, "player": player})
             elif kind == "call":
-                # The v1 prose says ActionEntry.amount is chips committed by
-                # the action.  Preserve that definition here.  Real captures
-                # with turn_result snapshots are expected in conformance tests
-                # because one prose example historically used a call-to value.
-                actions.append({"type": "calls", "street": street, "player": player, "amount": amount})
-                contributions[key] += amount
-            elif kind == "raise":
-                # ChipZen turn_action / turn_result explicitly define raises as
-                # raise-to totals, which maps directly to Hand.addRaiseTo().
-                actions.append({"type": "raises", "street": street, "player": player, "to": amount})
                 prior = contributions[key]
-                if amount < prior:
+                highest = cls._highest_contribution(contributions, phase)
+                increment = cls._call_increment(
+                    history_amount=amount,
+                    turn_result_amount=observed,
+                    prior=prior,
+                    highest=highest,
+                    player=player,
+                    phase=phase,
+                )
+                actions.append({"type": "calls", "street": street, "player": player, "amount": increment})
+                contributions[key] += increment
+            elif kind == "raise":
+                # turn_result and turn_action both define raises as raise-to
+                # totals, which maps directly to Hand.addRaiseTo().
+                raise_to = observed if observed is not None else amount
+                prior = contributions[key]
+                highest = cls._highest_contribution(contributions, phase)
+                if raise_to < prior or raise_to <= highest:
                     raise FpdbParseError(
-                        f"ChipZen raise-to {amount} is below prior street contribution {prior} for {player}"
+                        f"ChipZen raise-to {raise_to} is not above the current contribution {highest} for {player}"
                     )
-                contributions[key] = amount
+                actions.append({"type": "raises", "street": street, "player": player, "to": raise_to})
+                contributions[key] = raise_to
             else:
                 raise FpdbParseError(f"Unsupported ChipZen NLHE action {kind!r}")
 
@@ -236,20 +346,28 @@ class ChipZen(HandHistoryConverter):
         if hero and isinstance(hero_cards, list) and hero_cards:
             holecards.append({"player": hero, "cards": list(hero_cards), "street": "PREFLOP", "dealt": True})
 
+        shown_players: set[str] = set()
         for shown in result.get("showdown") or []:
             if not isinstance(shown, dict) or shown.get("seat") not in names:
                 continue
             cards = shown.get("hole_cards")
             if cards:
+                player = names[int(shown["seat"])]
+                shown_players.add(player)
                 holecards.append(
                     {
-                        "player": names[int(shown["seat"])],
+                        "player": player,
                         "cards": list(cards),
                         "street": "PREFLOP",
                         "shown": True,
                         "dealt": True,
                     }
                 )
+
+        # Avoid adding the hero twice when their private cards are also present
+        # in showdown. The shown version is richer and should win.
+        if hero in shown_players:
+            holecards = [entry for entry in holecards if entry.get("player") != hero or entry.get("shown")]
 
         collections = []
         for payout in result.get("payouts") or []:
@@ -314,7 +432,7 @@ class ChipZen(HandHistoryConverter):
         self._warn_if_hand_missing_expected_data(hand)
         return hand
 
-    # HandHistoryConverter's normal text-parsing surface is abstract.  This
+    # HandHistoryConverter's normal text-parsing surface is abstract. This
     # converter overrides processHand() because its source is structured JSON;
     # these methods therefore exist only to satisfy the common converter API.
     def readSupportedGames(self):  # noqa: N802

--- a/fpdb_3_legacy/parser_registry.py
+++ b/fpdb_3_legacy/parser_registry.py
@@ -15,6 +15,7 @@ from fpdb_3_legacy.BossToFpdb import Boss
 from fpdb_3_legacy.BovadaSummary import BovadaSummary
 from fpdb_3_legacy.BovadaToFpdb import Bovada
 from fpdb_3_legacy.CakeToFpdb import Cake
+from fpdb_3_legacy.ChipZenToFpdb import ChipZen
 from fpdb_3_legacy.CoinPokerToFpdb import CoinPoker
 from fpdb_3_legacy.EnetToFpdb import Enet
 from fpdb_3_legacy.EntractionToFpdb import Entraction
@@ -56,6 +57,7 @@ LEGACY_MODULE_REGISTRY: dict[str, str] = {
     "BovadaSummary": "fpdb_3_legacy.BovadaSummary",
     "BovadaToFpdb": "fpdb_3_legacy.BovadaToFpdb",
     "CakeToFpdb": "fpdb_3_legacy.CakeToFpdb",
+    "ChipZenToFpdb": "fpdb_3_legacy.ChipZenToFpdb",
     "CoinPokerToFpdb": "fpdb_3_legacy.CoinPokerToFpdb",
     "EnetToFpdb": "fpdb_3_legacy.EnetToFpdb",
     "EntractionToFpdb": "fpdb_3_legacy.EntractionToFpdb",
@@ -96,6 +98,7 @@ PARSER_CLASS_REGISTRY: dict[str, type[HandHistoryConverter]] = {
     "Boss": Boss,
     "Bovada": Bovada,
     "Cake": Cake,
+    "ChipZen": ChipZen,
     "CoinPoker": cast(type[HandHistoryConverter], CoinPoker),
     "Enet": Enet,
     "Entraction": Entraction,

--- a/test/test_chipzen_converter.py
+++ b/test/test_chipzen_converter.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from fpdb_3_legacy.ChipZenToFpdb import ChipZen
+from fpdb_3_legacy.HandHistoryConverter import FpdbParseError
+from fpdb_3_legacy.http_capture_hand_builder import HttpCaptureHandConfig, build_fpdb_hand
+
+
+def _record() -> dict:
+    return {
+        "schema": "fpdb-chipzen-hand/v1",
+        "match": {
+            "match_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "started_at": "2026-09-02T07:30:00.000Z",
+            "game_config": {
+                "variant": "nlhe",
+                "starting_stack": 1000,
+                "small_blind": 5,
+                "big_blind": 10,
+                "ante": 0,
+                "num_players": 2,
+            },
+            "seats": [
+                {"seat": 0, "participant_id": "p0", "display_name": "AlphaBot", "is_self": True},
+                {"seat": 1, "participant_id": "p1", "display_name": "BetaBot", "is_self": False},
+            ],
+        },
+        "round_start": {
+            "round_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            "server_ts": "2026-09-02T07:30:01.000Z",
+            "state": {
+                "hand_number": 12,
+                "dealer_seat": 0,
+                "your_hole_cards": ["As", "Kh"],
+                "stacks": [1000, 1000],
+            },
+        },
+        "phase_changes": [
+            {"state": {"phase": "flop", "board": ["Qs", "7h", "3d"]}},
+        ],
+        "round_result": {
+            "round_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            "server_ts": "2026-09-02T07:30:06.100Z",
+            "result": {
+                "hand_number": 12,
+                "winner_seats": [0],
+                "pot": 100,
+                "payouts": [{"seat": 0, "amount": 100}],
+                "showdown": [],
+                "action_history": [
+                    {"seat": 0, "action": "post_small_blind", "amount": 5, "phase": "preflop", "is_timeout": False},
+                    {"seat": 1, "action": "post_big_blind", "amount": 10, "phase": "preflop", "is_timeout": False},
+                    {"seat": 0, "action": "raise", "amount": 30, "phase": "preflop", "is_timeout": False},
+                    {"seat": 1, "action": "call", "amount": 20, "phase": "preflop", "is_timeout": False},
+                    {"seat": 1, "action": "check", "amount": 0, "phase": "flop", "is_timeout": False},
+                    {"seat": 0, "action": "raise", "amount": 40, "phase": "flop", "is_timeout": False},
+                    {"seat": 1, "action": "fold", "amount": 0, "phase": "flop", "is_timeout": False},
+                ],
+                "stacks": [1030, 970],
+                "deck_commitment": "",
+                "deck_reveal": None,
+            },
+        },
+    }
+
+
+def test_stable_hand_id_is_deterministic_and_signed_bigint_safe() -> None:
+    a = ChipZen.stable_hand_id("match-a", "round-a", 1)
+    b = ChipZen.stable_hand_id("match-a", "round-a", 1)
+    c = ChipZen.stable_hand_id("match-b", "round-a", 1)
+    assert a == b
+    assert a != c
+    assert 0 <= a <= (2**63 - 1)
+
+
+def test_normalize_maps_chipzen_to_fpdb_capture_model() -> None:
+    data = ChipZen.normalize_record(_record())
+    assert data["site"] == "ChipZen"
+    assert data["gametype"]["category"] == "holdem"
+    assert data["gametype"]["limitType"] == "nl"
+    assert data["gametype"]["currency"] == "play"
+    assert data["buttonpos"] == 1
+    assert data["players"][0]["seat_idx"] == 0
+    assert data["players"][1]["seat_idx"] == 1
+    assert data["community"] == {"FLOP": ["Qs", "7h", "3d"]}
+    assert data["actions"][0]["type"] == "small blind"
+    assert data["actions"][2] == {"type": "raises", "street": "PREFLOP", "player": "AlphaBot", "to": 30}
+    assert data["actions"][3] == {"type": "calls", "street": "PREFLOP", "player": "BetaBot", "amount": 20}
+    assert data["collections"] == [{"player": "AlphaBot", "pot": 100}]
+
+
+def test_build_real_fpdb_hand_from_chipzen_record() -> None:
+    normalized = ChipZen.normalize_record(_record())
+    config = HttpCaptureHandConfig(site_ids={"ChipZen": 141, "default": 141})
+    hand = build_fpdb_hand(normalized, config=config)
+    assert hand.sitename == "ChipZen"
+    assert hand.tablename.startswith("ChipZen ")
+    assert hand.buttonpos == 1
+    assert hand.maxseats == 2
+    assert [player[1] for player in hand.players] == ["AlphaBot", "BetaBot"]
+    assert hand.board["FLOP"] == ["Qs", "7h", "3d"]
+    assert hand.collected == [["AlphaBot", 100]] or hand.collected == [("AlphaBot", 100)]
+
+
+def test_missing_phase_change_is_rejected_when_street_was_reached() -> None:
+    record = _record()
+    record["phase_changes"] = []
+    with pytest.raises(FpdbParseError, match="required phase_change"):
+        ChipZen.normalize_record(record)
+
+
+def test_same_local_hand_number_in_different_matches_gets_different_id() -> None:
+    first = ChipZen.normalize_record(_record())["hand_id"]
+    second_record = copy.deepcopy(_record())
+    second_record["match"]["match_id"] = "bbbbbbbb-e5f6-7890-abcd-ef1234567890"
+    second = ChipZen.normalize_record(second_record)["hand_id"]
+    assert first != second
+
+
+def test_unknown_seat_action_is_rejected() -> None:
+    record = _record()
+    record["round_result"]["result"]["action_history"].append(
+        {"seat": 4, "action": "fold", "amount": 0, "phase": "flop", "is_timeout": False}
+    )
+    with pytest.raises(FpdbParseError, match="unknown seat"):
+        ChipZen.normalize_record(record)

--- a/test/test_chipzen_converter.py
+++ b/test/test_chipzen_converter.py
@@ -10,11 +10,18 @@ from fpdb_3_legacy.http_capture_hand_builder import HttpCaptureHandConfig, build
 
 
 def _record() -> dict:
+    """Protocol-faithful ChipZen fold-on-flop fixture.
+
+    This mirrors the authoritative full-hand example in
+    docs/protocol/POKER-GAME-STATE-PROTOCOL.md, including its legacy
+    action_history convention where the BB preflop call is recorded as 30 while
+    turn_result reports the actual incremental call of 20.
+    """
     return {
         "schema": "fpdb-chipzen-hand/v1",
         "match": {
-            "match_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            "started_at": "2026-09-02T07:30:00.000Z",
+            "match_id": "m_abc123",
+            "started_at": "2026-04-13T14:00:00.000Z",
             "game_config": {
                 "variant": "nlhe",
                 "starting_stack": 1000,
@@ -24,28 +31,36 @@ def _record() -> dict:
                 "num_players": 2,
             },
             "seats": [
-                {"seat": 0, "participant_id": "p0", "display_name": "AlphaBot", "is_self": True},
-                {"seat": 1, "participant_id": "p1", "display_name": "BetaBot", "is_self": False},
+                {"seat": 0, "participant_id": "p0", "display_name": "Bot A", "is_self": True},
+                {"seat": 1, "participant_id": "p1", "display_name": "Bot B", "is_self": False},
             ],
         },
         "round_start": {
-            "round_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-            "server_ts": "2026-09-02T07:30:01.000Z",
+            "round_id": "r_550e8400-e29b-41d4-a716-446655440000",
+            "server_ts": "2026-04-13T14:00:00.100Z",
             "state": {
-                "hand_number": 12,
+                "hand_number": 1,
                 "dealer_seat": 0,
                 "your_hole_cards": ["As", "Kh"],
                 "stacks": [1000, 1000],
+                "deck_commitment": "",
             },
         },
         "phase_changes": [
-            {"state": {"phase": "flop", "board": ["Qs", "7h", "3d"]}},
+            {"type": "phase_change", "state": {"phase": "flop", "board": ["Qs", "7h", "3d"]}},
+        ],
+        "turn_results": [
+            {"details": {"seat": 0, "action": "raise", "amount": 30}},
+            {"details": {"seat": 1, "action": "call", "amount": 20}},
+            {"details": {"seat": 1, "action": "check", "amount": 0}},
+            {"details": {"seat": 0, "action": "raise", "amount": 40}},
+            {"details": {"seat": 1, "action": "fold", "amount": 0}},
         ],
         "round_result": {
-            "round_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-            "server_ts": "2026-09-02T07:30:06.100Z",
+            "round_id": "r_550e8400-e29b-41d4-a716-446655440000",
+            "server_ts": "2026-04-13T14:00:06.100Z",
             "result": {
-                "hand_number": 12,
+                "hand_number": 1,
                 "winner_seats": [0],
                 "pot": 100,
                 "payouts": [{"seat": 0, "amount": 100}],
@@ -54,7 +69,8 @@ def _record() -> dict:
                     {"seat": 0, "action": "post_small_blind", "amount": 5, "phase": "preflop", "is_timeout": False},
                     {"seat": 1, "action": "post_big_blind", "amount": 10, "phase": "preflop", "is_timeout": False},
                     {"seat": 0, "action": "raise", "amount": 30, "phase": "preflop", "is_timeout": False},
-                    {"seat": 1, "action": "call", "amount": 20, "phase": "preflop", "is_timeout": False},
+                    # Official worked example uses 30 here, while turn_result is 20.
+                    {"seat": 1, "action": "call", "amount": 30, "phase": "preflop", "is_timeout": False},
                     {"seat": 1, "action": "check", "amount": 0, "phase": "flop", "is_timeout": False},
                     {"seat": 0, "action": "raise", "amount": 40, "phase": "flop", "is_timeout": False},
                     {"seat": 1, "action": "fold", "amount": 0, "phase": "flop", "is_timeout": False},
@@ -67,6 +83,54 @@ def _record() -> dict:
     }
 
 
+def _showdown_record() -> dict:
+    record = _record()
+    record["match"]["match_id"] = "m_showdown"
+    record["round_start"]["round_id"] = "r_showdown"
+    record["round_result"]["round_id"] = "r_showdown"
+    record["round_start"]["state"]["your_hole_cards"] = ["Ah", "Kd"]
+    record["phase_changes"] = [
+        {"state": {"phase": "flop", "board": ["Ts", "7h", "2d"]}},
+        {"state": {"phase": "turn", "board": ["Ts", "7h", "2d", "Qc"]}},
+        {"state": {"phase": "river", "board": ["Ts", "7h", "2d", "Qc", "3s"]}},
+    ]
+    record["turn_results"] = [
+        {"details": {"seat": 0, "action": "raise", "amount": 30}},
+        {"details": {"seat": 1, "action": "call", "amount": 20}},
+        {"details": {"seat": 0, "action": "check", "amount": 0}},
+        {"details": {"seat": 1, "action": "check", "amount": 0}},
+        {"details": {"seat": 0, "action": "check", "amount": 0}},
+        {"details": {"seat": 1, "action": "check", "amount": 0}},
+        {"details": {"seat": 0, "action": "check", "amount": 0}},
+        {"details": {"seat": 1, "action": "check", "amount": 0}},
+    ]
+    record["round_result"]["result"].update(
+        {
+            "pot": 60,
+            "winner_seats": [0],
+            "payouts": [{"seat": 0, "amount": 60}],
+            "showdown": [
+                {"seat": 0, "hole_cards": ["Ah", "Kd"], "hand_rank": "pair"},
+                {"seat": 1, "hole_cards": ["Jc", "Tc"], "hand_rank": "high_card"},
+            ],
+            "action_history": [
+                {"seat": 0, "action": "post_small_blind", "amount": 5, "phase": "preflop", "is_timeout": False},
+                {"seat": 1, "action": "post_big_blind", "amount": 10, "phase": "preflop", "is_timeout": False},
+                {"seat": 0, "action": "raise", "amount": 30, "phase": "preflop", "is_timeout": False},
+                {"seat": 1, "action": "call", "amount": 30, "phase": "preflop", "is_timeout": False},
+                {"seat": 0, "action": "check", "amount": 0, "phase": "flop", "is_timeout": False},
+                {"seat": 1, "action": "check", "amount": 0, "phase": "flop", "is_timeout": False},
+                {"seat": 0, "action": "check", "amount": 0, "phase": "turn", "is_timeout": False},
+                {"seat": 1, "action": "check", "amount": 0, "phase": "turn", "is_timeout": False},
+                {"seat": 0, "action": "check", "amount": 0, "phase": "river", "is_timeout": False},
+                {"seat": 1, "action": "check", "amount": 0, "phase": "river", "is_timeout": False},
+            ],
+            "stacks": [1030, 970],
+        }
+    )
+    return record
+
+
 def test_stable_hand_id_is_deterministic_and_signed_bigint_safe() -> None:
     a = ChipZen.stable_hand_id("match-a", "round-a", 1)
     b = ChipZen.stable_hand_id("match-a", "round-a", 1)
@@ -76,7 +140,7 @@ def test_stable_hand_id_is_deterministic_and_signed_bigint_safe() -> None:
     assert 0 <= a <= (2**63 - 1)
 
 
-def test_normalize_maps_chipzen_to_fpdb_capture_model() -> None:
+def test_normalize_maps_official_protocol_example_to_fpdb_capture_model() -> None:
     data = ChipZen.normalize_record(_record())
     assert data["site"] == "ChipZen"
     assert data["gametype"]["category"] == "holdem"
@@ -87,9 +151,17 @@ def test_normalize_maps_chipzen_to_fpdb_capture_model() -> None:
     assert data["players"][1]["seat_idx"] == 1
     assert data["community"] == {"FLOP": ["Qs", "7h", "3d"]}
     assert data["actions"][0]["type"] == "small blind"
-    assert data["actions"][2] == {"type": "raises", "street": "PREFLOP", "player": "AlphaBot", "to": 30}
-    assert data["actions"][3] == {"type": "calls", "street": "PREFLOP", "player": "BetaBot", "amount": 20}
-    assert data["collections"] == [{"player": "AlphaBot", "pot": 100}]
+    assert data["actions"][2] == {"type": "raises", "street": "PREFLOP", "player": "Bot A", "to": 30}
+    # The action_history call-to 30 is normalized with authoritative turn_result=20.
+    assert data["actions"][3] == {"type": "calls", "street": "PREFLOP", "player": "Bot B", "amount": 20}
+    assert data["collections"] == [{"player": "Bot A", "pot": 100}]
+
+
+def test_call_total_is_inferred_without_turn_result_when_unambiguous() -> None:
+    record = _record()
+    record["turn_results"] = []
+    data = ChipZen.normalize_record(record)
+    assert data["actions"][3]["amount"] == 20
 
 
 def test_build_real_fpdb_hand_from_chipzen_record() -> None:
@@ -100,9 +172,23 @@ def test_build_real_fpdb_hand_from_chipzen_record() -> None:
     assert hand.tablename.startswith("ChipZen ")
     assert hand.buttonpos == 1
     assert hand.maxseats == 2
-    assert [player[1] for player in hand.players] == ["AlphaBot", "BetaBot"]
+    assert [player[1] for player in hand.players] == ["Bot A", "Bot B"]
     assert hand.board["FLOP"] == ["Qs", "7h", "3d"]
-    assert hand.collected == [["AlphaBot", 100]] or hand.collected == [("AlphaBot", 100)]
+    assert hand.collected == [["Bot A", 100]] or hand.collected == [("Bot A", 100)]
+
+
+def test_full_board_and_showdown_are_reconstructed() -> None:
+    normalized = ChipZen.normalize_record(_showdown_record())
+    assert normalized["community"] == {
+        "FLOP": ["Ts", "7h", "2d"],
+        "TURN": ["Qc"],
+        "RIVER": ["3s"],
+    }
+    shown = {entry["player"]: entry for entry in normalized["holecards"]}
+    assert shown["Bot A"]["cards"] == ["Ah", "Kd"]
+    assert shown["Bot A"]["shown"] is True
+    assert shown["Bot B"]["cards"] == ["Jc", "Tc"]
+    assert shown["Bot B"]["shown"] is True
 
 
 def test_missing_phase_change_is_rejected_when_street_was_reached() -> None:
@@ -112,10 +198,17 @@ def test_missing_phase_change_is_rejected_when_street_was_reached() -> None:
         ChipZen.normalize_record(record)
 
 
+def test_turn_must_extend_flop() -> None:
+    record = _showdown_record()
+    record["phase_changes"][1]["state"]["board"] = ["As", "Ks", "Qh", "Qc"]
+    with pytest.raises(FpdbParseError, match="does not extend the recorded flop"):
+        ChipZen.normalize_record(record)
+
+
 def test_same_local_hand_number_in_different_matches_gets_different_id() -> None:
     first = ChipZen.normalize_record(_record())["hand_id"]
     second_record = copy.deepcopy(_record())
-    second_record["match"]["match_id"] = "bbbbbbbb-e5f6-7890-abcd-ef1234567890"
+    second_record["match"]["match_id"] = "m_other"
     second = ChipZen.normalize_record(second_record)["hand_id"]
     assert first != second
 
@@ -126,4 +219,12 @@ def test_unknown_seat_action_is_rejected() -> None:
         {"seat": 4, "action": "fold", "amount": 0, "phase": "flop", "is_timeout": False}
     )
     with pytest.raises(FpdbParseError, match="unknown seat"):
+        ChipZen.normalize_record(record)
+
+
+def test_ambiguous_call_amount_is_rejected() -> None:
+    record = _record()
+    record["turn_results"] = []
+    record["round_result"]["result"]["action_history"][3]["amount"] = 25
+    with pytest.raises(FpdbParseError, match="Ambiguous ChipZen call amount"):
         ChipZen.normalize_record(record)


### PR DESCRIPTION
Implements the first slice of #284.

### Included
- native `ChipZenToFpdb.py` structured-JSON converter
- deterministic 63-bit `siteHandNo` derived from ChipZen match/round ids
- NLHE mapping to fpdb's normalized capture/`Hand.py` pipeline
- 0-based ChipZen seat -> 1-based fpdb seat conversion through the shared builder
- button, stacks, hero/showdown cards, blinds/antes, canonical actions and payouts
- required `phase_change` validation/reconstruction for community cards
- timeout actions preserved as their resulting poker action
- parser registry integration
- unit tests for ids, seat/action mapping, real `Hand.py` construction, missing board transitions and malformed seats

### Important protocol caveat
ChipZen's current v1 prose and worked example are inconsistent about `action_history.amount` for calls: the schema says "chips committed for this action", while a worked example historically records a BB call using the final matched total. This PR follows the normative field description for now and rejects malformed structural data rather than guessing. Real production captures should be added before merging and `turn_result`/stack-delta validation can then pin the exact convention.

### Still to do before merge
- add ChipZen (`id=141`, code `CZ`) to the Sites seed/default configuration
- add IdentifySite/config integration fixture
- add real ChipZen production captures (showdown, all-in, timeout, 6-max/split pot)
- run full importer/DB regression suite and fix any amount-semantics mismatch exposed by real captures

No database schema migration and no undocumented ChipZen REST/scraping dependency.