### PR TITLE
fix(hud): keep a table's HUD when its configuration has simply aged

### DIFF
--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -3824,14 +3824,56 @@ class Config:
         """Gets the list of mucked window formats in the configuration."""
         return list(self.aux_windows.keys())
 
+    @staticmethod
+    def _aux_name_key(name):
+        """A form of an aux window name that survives a rename of its spelling.
+
+        Aux windows have been respelled over the years -- "Classic_HUD" became
+        "ClassicHud" -- and a user configuration written before a rename keeps
+        the old spelling in its ``aux=`` references while its ``<aw>`` blocks
+        carry the new one. Comparing on this key lets the reference still find
+        its definition, so a configuration that has simply aged does not cost
+        the player their HUD.
+        """
+        return str(name).replace("_", "").replace("-", "").replace(" ", "").casefold()
+
+    def _resolve_aux_name(self, name):
+        """The configured aux window this name refers to, or None.
+
+        An exact name always wins; only a name no ``<aw>`` block defines falls
+        back to the respelling match, so a valid configuration resolves exactly
+        as it always did.
+        """
+        if name in self.aux_windows:
+            return name
+        wanted = self._aux_name_key(name)
+        matches = [defined for defined in self.aux_windows if self._aux_name_key(defined) == wanted]
+        if len(matches) != 1:
+            # No match, or an ambiguous one: refuse to guess which was meant.
+            return None
+        # Said once per name: this is asked again for every aux window of every
+        # HUD built, so logging each time would bury the rest of a busy session.
+        warned = self.__dict__.setdefault("_respelled_aux_warned", set())
+        if name not in warned:
+            warned.add(name)
+            log.warning(
+                "Configuration asks for aux window %r, which no <aw> defines; using %r, "
+                "which differs only in spelling. Update %s to silence this.",
+                name,
+                matches[0],
+                self.file,
+            )
+        return matches[0]
+
     def get_aux_parameters(self, name):
         """Gets a dict of mucked window parameters from the named mw."""
         param = {}
-        if name in self.aux_windows:
-            for key in dir(self.aux_windows[name]):
+        resolved = self._resolve_aux_name(name)
+        if resolved is not None:
+            for key in dir(self.aux_windows[resolved]):
                 if key.startswith("__"):
                     continue
-                value = getattr(self.aux_windows[name], key)
+                value = getattr(self.aux_windows[resolved], key)
                 if callable(value):
                     continue
                 param[key] = value

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -3006,6 +3006,29 @@ class HudMain(QObject):
             self._destroy_superseded_hud(claim.superseded.temp_key)
 
         self._hud_generation = claim.generation
+        try:
+            self._build_claimed_hud(args, window_id)
+        except Exception:
+            # The window is claimed before the HUD is built, so a build that
+            # raises leaves the claim behind -- and every later hand for this
+            # table is then refused as a duplicate, which makes one failure
+            # permanent and silent. Hand the window back so the next hand
+            # retries, and let the error travel on to its usual handler.
+            self._window_registry.release(args.temp_key)
+            self.hud_dict.pop(args.temp_key, None)
+            log.warning(
+                "HUD create failed for table %r on window %s; released the window so the next hand can retry",
+                args.temp_key,
+                window_id,
+            )
+            raise
+
+    def _build_claimed_hud(self, args: HUDCreationArgs, window_id: Any) -> None:
+        """Build the HUD for a window this caller has already claimed.
+
+        Separate from ``create_HUD`` only so that the claim can be undone as a
+        whole when any part of the build fails.
+        """
         self.hud_dict[args.temp_key] = Hud.Hud(
             self,
             args.table,

--- a/fpdb_3_legacy/HUD_main.pyw
+++ b/fpdb_3_legacy/HUD_main.pyw
@@ -3006,16 +3006,24 @@ class HudMain(QObject):
             self._destroy_superseded_hud(claim.superseded.temp_key)
 
         self._hud_generation = claim.generation
+        # What this key held before the attempt. A build that fails must leave
+        # it exactly there: the same key can already have a live HUD on an
+        # earlier window of the same table, and that HUD is none of this
+        # attempt's business.
+        previous_hud = self.hud_dict.get(args.temp_key)
         try:
             self._build_claimed_hud(args, window_id)
         except Exception:
             # The window is claimed before the HUD is built, so a build that
             # raises leaves the claim behind -- and every later hand for this
             # table is then refused as a duplicate, which makes one failure
-            # permanent and silent. Hand the window back so the next hand
-            # retries, and let the error travel on to its usual handler.
-            self._window_registry.release(args.temp_key)
-            self.hud_dict.pop(args.temp_key, None)
+            # permanent and silent. Hand back the window *this attempt*
+            # claimed, and let the error travel on to its usual handler.
+            self._window_registry.release_registration(claim.registration)
+            if previous_hud is None:
+                self.hud_dict.pop(args.temp_key, None)
+            else:
+                self.hud_dict[args.temp_key] = previous_hud
             log.warning(
                 "HUD create failed for table %r on window %s; released the window so the next hand can retry",
                 args.temp_key,

--- a/fpdb_3_legacy/Hud.py
+++ b/fpdb_3_legacy/Hud.py
@@ -212,7 +212,21 @@ class Hud:
         if self.supported_games_parameters["aux"] == [""]:
             return
         for aux_str in self.supported_games_parameters["aux"].split(","):
-            aux_params = config.get_aux_parameters(aux_str.strip())
+            aux_name = aux_str.strip()
+            aux_params = config.get_aux_parameters(aux_name)
+            if aux_params is None:
+                # An aux window the configuration names but never defines. This
+                # used to raise out of the HUD constructor, which cost the table
+                # its HUD outright -- and every later hand only ever reported
+                # the window as already claimed, so the cause never appeared
+                # again. Skip the one aux window and say which it was.
+                log.error(
+                    "Aux window %r is named by this game's configuration but no <aw> block defines it; "
+                    "skipping it. Defined aux windows: %s",
+                    aux_name,
+                    ", ".join(sorted(config.get_aux_windows())) or "(none)",
+                )
+                continue
             my_import = importName(aux_params["module"], aux_params["class"])
             if my_import is None or self._skips_aux(aux_params):
                 continue

--- a/fpdb_3_legacy/hud_window_registry.py
+++ b/fpdb_3_legacy/hud_window_registry.py
@@ -132,6 +132,23 @@ class HudWindowRegistry:
                 return registration
         return None
 
+    def release_registration(self, registration: HudRegistration | None) -> bool:
+        """Forget exactly ``registration``, if it is still the one on file.
+
+        Undoing one failed claim needs this rather than ``release``: one key can
+        hold two windows at once -- a table whose client recreated its window
+        keeps the old registration until that HUD is torn down -- and releasing
+        by key would then drop whichever was filed first, usually the *live*
+        HUD's, leaving the window this attempt just claimed registered and every
+        later hand for it refused as a duplicate.
+        """
+        if registration is None or registration.window_id is None:
+            return False
+        if self._by_window.get(registration.window_id) is not registration:
+            return False
+        del self._by_window[registration.window_id]
+        return True
+
     def is_current(self, temp_key: str, generation: int) -> bool:
         """Whether ``generation`` is still the live HUD for ``temp_key``.
 

--- a/test/test_hud.py
+++ b/test/test_hud.py
@@ -9,62 +9,11 @@ import sys
 import unittest
 from unittest.mock import Mock, patch
 
-# Add the parent directory to Python path for imports
-
-
-def _setup_hud_mocks(original_modules: dict) -> None:
-    """Install mocks for fpdb_3_legacy sub-modules required by Hud.py."""
-    modules_to_mock = [
-        "fpdb_3_legacy.Database",
-        "fpdb_3_legacy.Hand",
-        "fpdb_3_legacy.loggingFpdb",
-    ]
-    for module_name in modules_to_mock:
-        if module_name in sys.modules:
-            original_modules[module_name] = sys.modules[module_name]
-        mock_mod = Mock()
-        # loggingFpdb.get_logger is called at module-import time; make it
-        # return a proper Mock logger so the module-level `log = get_logger(…)`
-        # succeeds and `log.warning / log.exception` are callable.
-        if module_name == "fpdb_3_legacy.loggingFpdb":
-            mock_mod.get_logger = Mock(return_value=Mock())
-        sys.modules[module_name] = mock_mod
-
-
-def _teardown_hud_mocks(original_modules: dict) -> None:
-    """Remove mocks installed by _setup_hud_mocks."""
-    modules_to_mock = [
-        "fpdb_3_legacy.Database",
-        "fpdb_3_legacy.Hand",
-        "fpdb_3_legacy.loggingFpdb",
-    ]
-    for module_name in modules_to_mock:
-        if module_name in original_modules:
-            sys.modules[module_name] = original_modules[module_name]
-        elif module_name in sys.modules:
-            del sys.modules[module_name]
+from fpdb_3_legacy.Hud import Hud, importName
 
 
 class TestImportName(unittest.TestCase):
     """Test the importName utility function."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Set up mocks for HUD tests."""
-        cls._original_modules = {}
-        _setup_hud_mocks(cls._original_modules)
-
-        # Evict a previously-cached Hud module so the mocks take effect.
-        sys.modules.pop("fpdb_3_legacy.Hud", None)
-
-        # Import the module to test after mocks are set up
-        global Hud, importName
-        from fpdb_3_legacy.Hud import Hud, importName
-
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up mocks after HUD tests."""
-        _teardown_hud_mocks(cls._original_modules)
 
     def test_import_valid_module(self) -> None:
         """Test importing a valid module and class."""
@@ -90,12 +39,6 @@ class TestImportName(unittest.TestCase):
 
 class TestHudInitialization(unittest.TestCase):
     """Test HUD initialization."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Ensure Hud is importable (mocks installed by TestImportName.setUpClass)."""
-        global Hud, importName
-        from fpdb_3_legacy.Hud import Hud, importName
 
     def setUp(self) -> None:
         """Set up test environment."""
@@ -340,12 +283,6 @@ class TestHudInitialization(unittest.TestCase):
 class TestHudMethods(unittest.TestCase):
     """Test HUD methods."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Ensure Hud is importable (mocks installed by TestImportName.setUpClass)."""
-        global Hud, importName
-        from fpdb_3_legacy.Hud import Hud, importName
-
     def setUp(self) -> None:
         """Set up test HUD instance."""
         # Create a minimal HUD instance for testing
@@ -567,12 +504,6 @@ class TestHudMethods(unittest.TestCase):
 class TestHudIntegration(unittest.TestCase):
     """Test HUD integration scenarios."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Ensure Hud is importable (mocks installed by TestImportName.setUpClass)."""
-        global Hud, importName
-        from fpdb_3_legacy.Hud import Hud, importName
-
     def test_full_hud_lifecycle(self) -> None:
         """Test complete HUD lifecycle from creation to destruction."""
         # Setup
@@ -649,12 +580,6 @@ class TestHudIntegration(unittest.TestCase):
 class TestHudErrorHandling(unittest.TestCase):
     """Test HUD error handling scenarios."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Ensure Hud is importable (mocks installed by TestImportName.setUpClass)."""
-        global Hud, importName
-        from fpdb_3_legacy.Hud import Hud, importName
-
     def test_aux_method_exceptions(self) -> None:
         """Test that HUD handles exceptions in aux window methods gracefully."""
         # Setup HUD with mock aux that raises exceptions
@@ -720,7 +645,7 @@ class TestMuckedCards(unittest.TestCase):
         mock_parent.hud_params = {
             "card_ht": "78",
             "card_wd": "56",
-            "mucked_cards_size": "70"  # 70% scale
+            "mucked_cards_size": "70",  # 70% scale
         }
 
         mock_hud = Mock()
@@ -799,8 +724,10 @@ class TestResizeWindowsRefLayout(unittest.TestCase):
         h = HudClass.__new__(HudClass)
         h.max = 3
         h.layout = types.SimpleNamespace(
-            width=792, height=546,
-            location=[None, (681, 221), (2, 221), (162, 413)], common=(323, 232),
+            width=792,
+            height=546,
+            location=[None, (681, 221), (2, 221), (162, 413)],
+            common=(323, 232),
         )
         h.table = types.SimpleNamespace(width=1360, height=880)
         h.aux_windows = []

--- a/test/test_hud_stale_aux_config.py
+++ b/test/test_hud_stale_aux_config.py
@@ -1,0 +1,273 @@
+"""Regressions for a HUD lost to a configuration that had simply aged.
+
+A Winamax cash table was detected, attached and logged --
+
+    HUD attach: table='Casablanca 04' site=Winamax hwnd=656448
+                title='Winamax Casablanca 04' geometry=(361,250 898x669)
+
+-- and then no HUD ever appeared, on any hand, with nothing in the log but
+
+    HUD create refused: window 656448 already renders table 'Casablanca 04'
+                        at generation 1
+
+The user's configuration asked for the aux window ``Classic_HUD``, the spelling
+of an older fpdb, while its own ``<aw>`` block defined ``ClassicHud``. Looking
+that name up returned None, subscripting None raised out of the HUD
+constructor, and because ``create_HUD`` claims the window *before* it builds,
+the claim outlived the failure: every later hand was refused as a duplicate. So
+one aged attribute cost the table its HUD permanently, and hid the reason after
+the very first hand.
+
+Nothing here is platform-specific -- the same configuration loses the HUD on
+Windows, macOS and Linux alike.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from xml.dom import minidom
+
+import pytest
+
+from fpdb_3_legacy import HUD_main
+from fpdb_3_legacy.Configuration import Config
+from fpdb_3_legacy.hud_window_registry import HudWindowRegistry
+
+
+def _config_with(aux_names: list[str]) -> Config:
+    """A Config carrying only the aux window definitions a name is resolved against."""
+    config = object.__new__(Config)
+    config.file = "HUD_config.xml"
+    config.aux_windows = {
+        name: SimpleNamespace(name=name, module="Aux_Classic_Hud", **{"class": "ClassicHud"}) for name in aux_names
+    }
+    return config
+
+
+# --------------------------------------------------------------------------
+# Resolving an aux window name written by an older fpdb
+# --------------------------------------------------------------------------
+
+
+def test_an_older_spelling_still_finds_its_definition() -> None:
+    """``Classic_HUD`` is what pre-rename configurations say; honour it."""
+    config = _config_with(["ClassicHud", "mucked"])
+
+    assert config._resolve_aux_name("Classic_HUD") == "ClassicHud"
+    assert config.get_aux_parameters("Classic_HUD")["module"] == "Aux_Classic_Hud"
+
+
+def test_an_exact_name_is_used_as_is() -> None:
+    """A current configuration must resolve exactly as it always did."""
+    config = _config_with(["ClassicHud", "classichud"])
+
+    assert config._resolve_aux_name("ClassicHud") == "ClassicHud"
+
+
+def test_an_aux_window_nothing_defines_still_resolves_to_nothing() -> None:
+    """A genuine typo must not be healed into some unrelated window."""
+    config = _config_with(["ClassicHud", "mucked"])
+
+    assert config._resolve_aux_name("Mucked_Cards") is None
+    assert config.get_aux_parameters("Mucked_Cards") is None
+
+
+def test_an_ambiguous_respelling_is_not_guessed() -> None:
+    """Two definitions differing only in spelling say nothing about which was meant."""
+    config = _config_with(["Classic_Hud", "ClassicHud"])
+
+    assert config._resolve_aux_name("CLASSICHUD") is None
+
+
+# --------------------------------------------------------------------------
+# Building the aux windows of a game whose configuration names an unknown one
+# --------------------------------------------------------------------------
+
+
+def _hud_for_aux_build(aux: str) -> object:
+    from fpdb_3_legacy.Hud import Hud
+
+    hud = object.__new__(Hud)
+    hud.aux_windows = []
+    hud.supported_games_parameters = {"aux": aux}
+    hud.hud_context = SimpleNamespace(speed="normal")
+    return hud
+
+
+def test_an_undefined_aux_window_costs_only_itself(monkeypatch) -> None:
+    """The rest of the table's aux windows must still be built."""
+    import fpdb_3_legacy.Hud as hud_module
+
+    built: list[str] = []
+
+    class _Config:
+        @staticmethod
+        def get_aux_parameters(name):
+            if name == "mucked":
+                return {"module": "Mucked", "class": "Flop_Mucked"}
+            return None
+
+        @staticmethod
+        def get_aux_windows():
+            return ["ClassicHud", "mucked"]
+
+    def _fake_import(_module, cls):
+        def _make(*_a, **_k):
+            built.append(cls)
+            return SimpleNamespace(cls=cls)
+
+        return _make
+
+    monkeypatch.setattr(hud_module, "importName", _fake_import)
+    hud = _hud_for_aux_build("Classic_HUD, mucked")
+
+    hud._build_aux_windows(_Config())
+
+    assert built == ["Flop_Mucked"]
+
+
+def test_an_undefined_aux_window_names_itself_in_the_log(monkeypatch, caplog) -> None:
+    """The first report of this said only that the window was already claimed."""
+    import fpdb_3_legacy.Hud as hud_module
+
+    class _Config:
+        @staticmethod
+        def get_aux_parameters(_name):
+            return None
+
+        @staticmethod
+        def get_aux_windows():
+            return ["ClassicHud", "mucked"]
+
+    monkeypatch.setattr(hud_module, "importName", lambda *_a: None)
+    hud = _hud_for_aux_build("Classic_HUD")
+
+    with caplog.at_level("ERROR"):
+        hud._build_aux_windows(_Config())
+
+    assert "Classic_HUD" in caplog.text
+    assert "ClassicHud" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# A build that fails must hand its window back
+# --------------------------------------------------------------------------
+
+
+def _hud_main_for_create() -> HUD_main.HudMain:
+    """A HudMain with only what create_HUD touches."""
+    hud_main = HUD_main.HudMain.__new__(HUD_main.HudMain)
+    hud_main.hud_dict = {}
+    hud_main._window_registry = HudWindowRegistry()
+    hud_main._hud_generation = 0
+    hud_main._fast_fold_tables = set()
+    hud_main.config = MagicMock()
+    hud_main.db_connection = MagicMock()
+    hud_main._prepared_hands = {}
+    hud_main.idle_create = MagicMock()
+    return hud_main
+
+
+def _creation_args(temp_key: str, window_id: int) -> HUD_main.HUDCreationArgs:
+    return HUD_main.HUDCreationArgs(
+        new_hand_id="hand1",
+        table=SimpleNamespace(number=window_id, key=temp_key, hud=None),
+        temp_key=temp_key,
+        max_seats=6,
+        poker_game="holdem",
+        game_type="ring",
+        stat_dict={},
+        cards={},
+        context=SimpleNamespace(speed="normal"),
+        loading=True,
+    )
+
+
+def test_a_failed_build_releases_the_window(monkeypatch) -> None:
+    """A claim outliving its failed build is what made one bad hand permanent."""
+    hud_main = _hud_main_for_create()
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=TypeError("'NoneType' is not subscriptable")))
+
+    with pytest.raises(TypeError):
+        hud_main.create_HUD(_creation_args("Casablanca 04", 656448))
+
+    assert hud_main._window_registry.lookup(656448) is None
+    assert "Casablanca 04" not in hud_main.hud_dict
+
+
+def test_the_next_hand_can_still_build_a_hud_after_a_failed_one(monkeypatch) -> None:
+    """The player's actual symptom: every hand after the first was refused."""
+    hud_main = _hud_main_for_create()
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=TypeError("boom")))
+    with pytest.raises(TypeError):
+        hud_main.create_HUD(_creation_args("Casablanca 04", 656448))
+
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=lambda *a, **k: MagicMock()))
+    hud_main.create_HUD(_creation_args("Casablanca 04", 656448))
+
+    assert hud_main.idle_create.call_count == 1
+    assert "Casablanca 04" in hud_main.hud_dict
+
+
+def test_a_successful_build_keeps_its_claim(monkeypatch) -> None:
+    """Releasing on failure must not release on success."""
+    hud_main = _hud_main_for_create()
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=lambda *a, **k: MagicMock()))
+
+    hud_main.create_HUD(_creation_args("Casablanca 04", 656448))
+
+    registration = hud_main._window_registry.lookup(656448)
+    assert registration is not None
+    assert registration.temp_key == "Casablanca 04"
+
+
+# --------------------------------------------------------------------------
+# The shipped configurations must not carry a dangling reference themselves
+# --------------------------------------------------------------------------
+
+CONFIG_TEMPLATES = ["HUD_config.xml", "HUD_config.xml.example"]
+
+
+def _defined_names(doc: minidom.Document, tag: str) -> set[str]:
+    return {node.getAttribute("name") for node in doc.getElementsByTagName(tag) if node.hasAttribute("name")}
+
+
+def _dangling_references(path: pathlib.Path) -> list[str]:
+    """Every name a configuration refers to but never defines."""
+    doc = minidom.parse(str(path))
+    defined = {tag: _defined_names(doc, tag) for tag in ("aw", "ss", "ls")}
+    dangling = []
+
+    for game in doc.getElementsByTagName("game"):
+        game_name = game.getAttribute("game_name") or "?"
+        for ref in (r.strip() for r in game.getAttribute("aux").split(",")):
+            if ref and ref not in defined["aw"]:
+                dangling.append(f"game {game_name!r}: aux={ref!r} has no <aw>")
+        for attribute, tag in (("stat_set", "ss"), ("layout_set", "ls")):
+            ref = game.getAttribute(attribute).strip()
+            if ref and ref not in defined[tag]:
+                dangling.append(f"game {game_name!r}: {attribute}={ref!r} has no <{tag}>")
+
+    for site in doc.getElementsByTagName("site"):
+        site_name = site.getAttribute("site_name") or "?"
+        for attribute in ("layout_set_ring", "layout_set_tour"):
+            ref = site.getAttribute(attribute).strip()
+            if ref and ref not in defined["ls"]:
+                dangling.append(f"site {site_name!r}: {attribute}={ref!r} has no <ls>")
+
+    return sorted(set(dangling))
+
+
+@pytest.mark.parametrize("template", CONFIG_TEMPLATES)
+def test_a_shipped_configuration_defines_everything_it_refers_to(template: str) -> None:
+    """A dangling name in a shipped template is what a stale user file looks like.
+
+    The aux window is only the one that was noticed: a stat set or layout set
+    the file names but never defines fails the same way, on the player's table
+    rather than here.
+    """
+    path = pathlib.Path(__file__).resolve().parent.parent / template
+
+    assert _dangling_references(path) == []

--- a/test/test_hud_stale_aux_config.py
+++ b/test/test_hud_stale_aux_config.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import pathlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-from xml.dom import minidom
 
 import pytest
 
@@ -223,6 +222,48 @@ def test_a_successful_build_keeps_its_claim(monkeypatch) -> None:
     assert registration.temp_key == "Casablanca 04"
 
 
+def test_the_failed_attempt_is_released_not_the_live_hud_of_the_same_table(monkeypatch) -> None:
+    """One table key can hold two windows, and only the failed one may go.
+
+    A client that recreates a table's window leaves the running HUD registered
+    under the old handle while the next hand claims the new one. Releasing by
+    key drops whichever was filed first -- the live HUD's -- and leaves the
+    window this attempt claimed registered, so every later hand for it is still
+    refused and the recovery path buys nothing.
+    """
+    hud_main = _hud_main_for_create()
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=lambda *a, **k: MagicMock()))
+    hud_main.create_HUD(_creation_args("Casablanca 04", 111))
+    live_hud = hud_main.hud_dict["Casablanca 04"]
+
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=TypeError("boom")))
+    with pytest.raises(TypeError):
+        hud_main.create_HUD(_creation_args("Casablanca 04", 222))
+
+    # The window the failed attempt claimed is free again...
+    assert hud_main._window_registry.lookup(222) is None
+    # ...the running HUD keeps both its registration and its place...
+    assert hud_main._window_registry.lookup(111) is not None
+    assert hud_main.hud_dict["Casablanca 04"] is live_hud
+
+    # ...and the next hand on the new window can actually build.
+    monkeypatch.setattr(HUD_main.Hud, "Hud", MagicMock(side_effect=lambda *a, **k: MagicMock()))
+    hud_main.create_HUD(_creation_args("Casablanca 04", 222))
+    assert hud_main._window_registry.lookup(222) is not None
+
+
+def test_releasing_a_registration_leaves_a_newer_one_alone() -> None:
+    """A claim already superseded by another must not take the live one with it."""
+    registry = HudWindowRegistry()
+    stale = registry.claim(111, "Casablanca 04").registration
+    current = registry.claim(111, "Casablanca 05").registration
+
+    assert registry.release_registration(stale) is False
+    assert registry.lookup(111) is current
+    assert registry.release_registration(current) is True
+    assert registry.lookup(111) is None
+
+
 # --------------------------------------------------------------------------
 # The shipped configurations must not carry a dangling reference themselves
 # --------------------------------------------------------------------------
@@ -230,31 +271,28 @@ def test_a_successful_build_keeps_its_claim(monkeypatch) -> None:
 CONFIG_TEMPLATES = ["HUD_config.xml", "HUD_config.xml.example"]
 
 
-def _defined_names(doc: minidom.Document, tag: str) -> set[str]:
-    return {node.getAttribute("name") for node in doc.getElementsByTagName(tag) if node.hasAttribute("name")}
-
-
 def _dangling_references(path: pathlib.Path) -> list[str]:
-    """Every name a configuration refers to but never defines."""
-    doc = minidom.parse(str(path))
-    defined = {tag: _defined_names(doc, tag) for tag in ("aw", "ss", "ls")}
+    """Every name a configuration refers to but never defines.
+
+    Read through ``Config`` rather than by parsing the file here, so the check
+    sees exactly the names the HUD will look up at runtime -- and so the test
+    brings no XML parser of its own into the project.
+    """
+    config = Config(file=str(path))
     dangling = []
 
-    for game in doc.getElementsByTagName("game"):
-        game_name = game.getAttribute("game_name") or "?"
-        for ref in (r.strip() for r in game.getAttribute("aux").split(",")):
-            if ref and ref not in defined["aw"]:
+    for game_name, game in config.supported_games.items():
+        for ref in (r.strip() for r in getattr(game, "aux", "").split(",")):
+            if ref and ref not in config.aux_windows:
                 dangling.append(f"game {game_name!r}: aux={ref!r} has no <aw>")
-        for attribute, tag in (("stat_set", "ss"), ("layout_set", "ls")):
-            ref = game.getAttribute(attribute).strip()
-            if ref and ref not in defined[tag]:
-                dangling.append(f"game {game_name!r}: {attribute}={ref!r} has no <{tag}>")
+        for game_type, stat_set in game.game_stat_set.items():
+            if stat_set.stat_set and stat_set.stat_set not in config.stat_sets:
+                dangling.append(f"game {game_name!r} ({game_type}): stat_set={stat_set.stat_set!r} has no <ss>")
 
-    for site in doc.getElementsByTagName("site"):
-        site_name = site.getAttribute("site_name") or "?"
+    for site_name, site in config.supported_sites.items():
         for attribute in ("layout_set_ring", "layout_set_tour"):
-            ref = site.getAttribute(attribute).strip()
-            if ref and ref not in defined["ls"]:
+            ref = str(getattr(site, attribute, "") or "").strip()
+            if ref and ref not in config.layout_sets:
                 dangling.append(f"site {site_name!r}: {attribute}={ref!r} has no <ls>")
 
     return sorted(set(dangling))

--- a/test/test_hud_stale_aux_config.py
+++ b/test/test_hud_stale_aux_config.py
@@ -264,6 +264,17 @@ def test_releasing_a_registration_leaves_a_newer_one_alone() -> None:
     assert registry.lookup(111) is None
 
 
+def test_releasing_an_untracked_registration_keeps_live_windows() -> None:
+    """Missing handles and absent claims cannot release another table's HUD."""
+    registry = HudWindowRegistry()
+    live = registry.claim(111, "Casablanca 04").registration
+    untracked = registry.claim(None, "Casablanca 05").registration
+
+    assert registry.release_registration(None) is False
+    assert registry.release_registration(untracked) is False
+    assert registry.snapshot() == {111: live}
+
+
 # --------------------------------------------------------------------------
 # The shipped configurations must not carry a dangling reference themselves
 # --------------------------------------------------------------------------

--- a/tools/diagnose_windows_tables.py
+++ b/tools/diagnose_windows_tables.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Report what fpdb's Windows detector sees, and what it throws away (Windows only).
+
+Written because a Winamax cash table that is plainly on screen is never found
+on Windows 10, while the same build finds it on Windows 11. The HUD log only
+ever says "Window '...' not found", which does not say *where* the window was
+lost: it may never have been enumerated, or it may have been dropped by the
+title / visibility / DWM-cloak gates, or accepted and then rejected by the
+per-site title match.
+
+So this walks the same path as ``WindowsTableDetector.find_tables`` and prints
+a verdict for every window at each gate, plus the full window tree of the
+poker client -- children included, since an Electron client can draw a table in
+a window whose title only its parent carries.
+
+    python tools/diagnose_windows_tables.py
+    python tools/diagnose_windows_tables.py --match Winamax
+    python tools/diagnose_windows_tables.py --watch 30
+
+``--watch`` polls for the given number of seconds and reports every window that
+appears, disappears, or changes title, which is what tells a window created
+without a title apart from one that is never created at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import sys
+import time
+from ctypes import wintypes
+from dataclasses import dataclass
+
+#: DwmGetWindowAttribute's "is this window cloaked" question. A cloaked window
+#: is composited but not drawn -- another virtual desktop, or a suspended UWP
+#: app. fpdb's enumeration drops cloaked windows.
+DWMWA_CLOAKED = 14
+
+GWL_STYLE = -16
+GWL_EXSTYLE = -20
+WS_VISIBLE = 0x10000000
+WS_MINIMIZE = 0x20000000
+WS_CAPTION = 0x00C00000
+WS_CHILD = 0x40000000
+WS_POPUP = 0x80000000
+WS_EX_TOOLWINDOW = 0x00000080
+WS_EX_NOREDIRECTIONBITMAP = 0x00200000
+
+
+@dataclass(frozen=True)
+class WindowFacts:
+    """Everything the detector's gates look at, for one window."""
+
+    hwnd: int
+    pid: int
+    title: str
+    window_class: str
+    text_length: int
+    win32_visible: bool
+    cloak_hresult: int
+    cloak_value: int
+    style: int
+    exstyle: int
+    rect: tuple[int, int, int, int] | None
+
+    @property
+    def cloaked(self) -> bool:
+        """Cloaked as fpdb reads it: a failed query counts as *not* cloaked."""
+        return self.cloak_hresult == 0 and bool(self.cloak_value)
+
+    @property
+    def kept_by_find_tables(self) -> bool:
+        """Whether find_tables would even consider this window a candidate."""
+        return self.text_length > 0 and self.win32_visible and not self.cloaked and self.rect is not None
+
+    def gate_verdict(self) -> str:
+        """Which gate this window falls at, in the order find_tables applies them."""
+        if self.text_length <= 0:
+            return "DROPPED: GetWindowTextLengthW == 0 (no caption text to match)"
+        if not self.win32_visible:
+            return "DROPPED: IsWindowVisible == False"
+        if self.cloaked:
+            return f"DROPPED: DWM-cloaked (0x{self.cloak_value:x})"
+        if self.rect is None:
+            return "DROPPED: GetWindowRect failed (no geometry)"
+        return "KEPT"
+
+    def flags(self) -> str:
+        names = []
+        for bit, name in (
+            (WS_VISIBLE, "VISIBLE"),
+            (WS_MINIMIZE, "MINIMIZED"),
+            (WS_CHILD, "CHILD"),
+            (WS_POPUP, "POPUP"),
+        ):
+            if self.style & bit:
+                names.append(name)
+        if self.style & WS_CAPTION == WS_CAPTION:
+            names.append("CAPTION")
+        if self.exstyle & WS_EX_TOOLWINDOW:
+            names.append("TOOLWINDOW")
+        if self.exstyle & WS_EX_NOREDIRECTIONBITMAP:
+            names.append("NOREDIRECTIONBITMAP")
+        return "|".join(names) or "-"
+
+
+class Win32:
+    """The handful of Win32 calls this diagnostic needs, with argtypes set.
+
+    argtypes are declared because an HWND is pointer-sized: left to ctypes'
+    default marshalling it is passed as a C int, which is the kind of thing
+    that behaves differently between machines rather than failing outright.
+    """
+
+    def __init__(self) -> None:
+        self.user32 = ctypes.WinDLL("user32", use_last_error=True)
+        self.user32.IsWindowVisible.argtypes = [wintypes.HWND]
+        self.user32.IsWindowVisible.restype = wintypes.BOOL
+        self.user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
+        self.user32.GetWindowTextLengthW.restype = ctypes.c_int
+        self.user32.GetWindowTextW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+        self.user32.GetWindowTextW.restype = ctypes.c_int
+        self.user32.GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+        self.user32.GetClassNameW.restype = ctypes.c_int
+        self.user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]
+        self.user32.GetWindowRect.restype = wintypes.BOOL
+        self.user32.GetWindowThreadProcessId.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+        self.user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+        # GetWindowLongPtrW exists only in 64-bit user32; the 32-bit build has
+        # GetWindowLongW, with identical semantics for the values read here.
+        self._get_long = getattr(self.user32, "GetWindowLongPtrW", self.user32.GetWindowLongW)
+        self._get_long.argtypes = [wintypes.HWND, ctypes.c_int]
+        self._get_long.restype = ctypes.c_ssize_t
+        try:
+            self.dwm = ctypes.WinDLL("dwmapi")
+            self.dwm.DwmGetWindowAttribute.argtypes = [
+                wintypes.HWND,
+                wintypes.DWORD,
+                ctypes.c_void_p,
+                wintypes.DWORD,
+            ]
+            self.dwm.DwmGetWindowAttribute.restype = ctypes.c_long
+        except OSError:
+            self.dwm = None
+
+    def title(self, hwnd: int) -> tuple[int, str]:
+        length = self.user32.GetWindowTextLengthW(hwnd)
+        if length <= 0:
+            return length, ""
+        buff = ctypes.create_unicode_buffer(length + 1)
+        self.user32.GetWindowTextW(hwnd, buff, length + 1)
+        return length, buff.value
+
+    def window_class(self, hwnd: int) -> str:
+        buff = ctypes.create_unicode_buffer(256)
+        self.user32.GetClassNameW(hwnd, buff, 256)
+        return buff.value
+
+    def cloak(self, hwnd: int) -> tuple[int, int]:
+        if self.dwm is None:
+            return (-1, 0)
+        value = wintypes.DWORD()
+        hresult = self.dwm.DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAKED,
+            ctypes.byref(value),
+            ctypes.sizeof(value),
+        )
+        return (hresult, value.value)
+
+    def rect(self, hwnd: int) -> tuple[int, int, int, int] | None:
+        r = wintypes.RECT()
+        if not self.user32.GetWindowRect(hwnd, ctypes.byref(r)):
+            return None
+        return (r.left, r.top, r.right - r.left, r.bottom - r.top)
+
+    def pid(self, hwnd: int) -> int:
+        value = wintypes.DWORD()
+        self.user32.GetWindowThreadProcessId(hwnd, ctypes.byref(value))
+        return value.value
+
+    def facts(self, hwnd: int) -> WindowFacts:
+        length, text = self.title(hwnd)
+        hresult, cloak_value = self.cloak(hwnd)
+        return WindowFacts(
+            hwnd=hwnd,
+            pid=self.pid(hwnd),
+            title=text,
+            window_class=self.window_class(hwnd),
+            text_length=length,
+            win32_visible=bool(self.user32.IsWindowVisible(hwnd)),
+            cloak_hresult=hresult,
+            cloak_value=cloak_value,
+            style=self._get_long(hwnd, GWL_STYLE) & 0xFFFFFFFF,
+            exstyle=self._get_long(hwnd, GWL_EXSTYLE) & 0xFFFFFFFF,
+            rect=self.rect(hwnd),
+        )
+
+    def top_level(self) -> list[int]:
+        found: list[int] = []
+        proc = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+        def collect(hwnd, _lparam):  # noqa: ANN001, ANN202 - ctypes callback
+            found.append(hwnd)
+            return True
+
+        self.user32.EnumWindows(proc(collect), 0)
+        return found
+
+    def children(self, hwnd: int) -> list[int]:
+        found: list[int] = []
+        proc = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+        def collect(child, _lparam):  # noqa: ANN001, ANN202 - ctypes callback
+            found.append(child)
+            return True
+
+        self.user32.EnumChildWindows(hwnd, proc(collect), 0)
+        return found
+
+
+def _line(facts: WindowFacts, indent: str = "") -> str:
+    rect = "-" if facts.rect is None else "{},{} {}x{}".format(*facts.rect)
+    cloak = facts.cloak_value if facts.cloak_hresult == 0 else "n/a"
+    return (
+        f"{indent}hwnd={facts.hwnd:<9} pid={facts.pid:<6} cls={facts.window_class!r:<34} "
+        f"len={facts.text_length:<4} vis={str(facts.win32_visible):<5} cloak={cloak!s:<4} "
+        f"[{facts.flags()}] rect={rect:<20} title={facts.title!r}"
+    )
+
+
+def _print_children(win32: Win32, windows: list[WindowFacts]) -> None:
+    """The child windows of each given window, which is where a table can hide."""
+    print("\n=== children of those windows ===")
+    for facts in windows:
+        kids = win32.children(facts.hwnd)
+        if not kids:
+            continue
+        print(f"-- {facts.hwnd} {facts.title!r}: {len(kids)} descendant(s)")
+        for child in kids[:40]:
+            print(_line(win32.facts(child), "   "))
+
+
+def _print_gates(all_facts: list[WindowFacts]) -> None:
+    """What survives the detector's gates, and what the cloak test takes."""
+    print("\n=== every window fpdb would keep, all processes ===")
+    for facts in all_facts:
+        if facts.kept_by_find_tables:
+            print(_line(facts))
+
+    print("\n=== titled+visible windows fpdb drops on the DWM cloak test ===")
+    dropped = [f for f in all_facts if f.text_length > 0 and f.win32_visible and f.cloaked]
+    for facts in dropped:
+        print(_line(facts))
+    if not dropped:
+        print("  (none)")
+
+
+def _report(win32: Win32, match: str, *, show_children: bool) -> None:
+    needle = match.casefold()
+    all_facts = [win32.facts(h) for h in win32.top_level()]
+    interesting = [f for f in all_facts if needle in f.title.casefold() or needle in f.window_class.casefold()]
+    pids = {f.pid for f in interesting}
+    # A client draws its tables from the same process as its lobby, so widen
+    # the report to every window of those processes -- including the untitled
+    # ones, which is exactly where a table window goes missing.
+    same_process = [f for f in all_facts if f.pid in pids]
+
+    print(f"Windows enumerated: {len(all_facts)}")
+    print(f"Candidates find_tables would keep: {sum(1 for f in all_facts if f.kept_by_find_tables)}")
+    print(f"Matching {match!r}: {len(interesting)} window(s) in {len(pids)} process(es)\n")
+
+    print(f"=== every top-level window of the {match!r} process(es) ===")
+    for facts in same_process:
+        print(_line(facts))
+        print(f"    -> {facts.gate_verdict()}")
+    if not same_process:
+        print(f"  (none -- is the {match} client running?)")
+
+    if show_children:
+        _print_children(win32, same_process)
+    _print_gates(all_facts)
+
+
+def _client_pids(win32: Win32, needle: str) -> set[int]:
+    """Processes owning at least one window that names the client.
+
+    Tracking by process rather than by title is the whole point: a table window
+    can be created untitled, or titled only once it has finished loading, and a
+    title-based watch would not see it appear at all.
+    """
+    pids = set()
+    for hwnd in win32.top_level():
+        facts = win32.facts(hwnd)
+        if needle in facts.title.casefold() or needle in facts.window_class.casefold():
+            pids.add(facts.pid)
+    return pids
+
+
+def _watched_state(facts: WindowFacts) -> tuple:
+    """The part of a window that a watch reports a change in."""
+    return (facts.title, facts.win32_visible, facts.cloaked, facts.rect)
+
+
+def _print_changes(
+    before: dict[int, WindowFacts],
+    now: dict[int, WindowFacts],
+    *,
+    first_pass: bool,
+) -> None:
+    """Report windows that appeared, changed, or went away between two passes."""
+    for hwnd, facts in now.items():
+        was = before.get(hwnd)
+        if was is None:
+            print(f"[+] {'(initial) ' if first_pass else ''}{_line(facts)}")
+            print(f"     -> {facts.gate_verdict()}")
+        elif _watched_state(was) != _watched_state(facts):
+            print(f"[~] {_line(facts)}")
+            print(f"     -> {facts.gate_verdict()}")
+    for hwnd, facts in before.items():
+        if hwnd not in now:
+            print(f"[-] gone: hwnd={hwnd} title={facts.title!r} cls={facts.window_class!r}")
+
+
+def _watch(win32: Win32, match: str, seconds: float) -> None:
+    """Poll and report window arrivals, departures and title changes."""
+    needle = match.casefold()
+    pids = _client_pids(win32, needle)
+    if not pids:
+        print(f"No window names {match!r} -- start the client first.")
+        return
+    print(f"Watching every window of pid(s) {sorted(pids)} for {seconds:.0f}s -- open, play and close a table now.\n")
+    seen: dict[int, WindowFacts] = {}
+    deadline = time.monotonic() + seconds
+    first_pass = True
+    while time.monotonic() < deadline:
+        current: dict[int, WindowFacts] = {}
+        for hwnd in win32.top_level():
+            facts = win32.facts(hwnd)
+            # Match on the process, and re-check the needle too: a table may be
+            # drawn by a second process the client spawns after this started.
+            if facts.pid in pids or needle in facts.title.casefold() or needle in facts.window_class.casefold():
+                pids.add(facts.pid)
+                current[hwnd] = facts
+                for child in win32.children(hwnd):
+                    current[child] = win32.facts(child)
+        _print_changes(seen, current, first_pass=first_pass)
+        seen = current
+        first_pass = False
+        time.sleep(0.5)
+    print("\nWatch finished.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    if sys.platform != "win32":
+        print("This diagnostic only runs on Windows.")
+        return 1
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--match", default="Winamax", help="client name to look for in titles and window classes")
+    parser.add_argument("--watch", type=float, metavar="SECONDS", help="poll for changes instead of a single report")
+    parser.add_argument("--no-children", action="store_true", help="skip the child-window tree")
+    args = parser.parse_args(argv)
+
+    print(f"Windows version: {sys.getwindowsversion()}")
+    print(f"Python: {sys.version}\n")
+    win32 = Win32()
+    if args.watch:
+        _watch(win32, args.match, args.watch)
+    else:
+        _report(win32, args.match, show_children=not args.no_children)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What went wrong

A Winamax cash table on Windows 10 never got a HUD. It looked like a window-detection bug — but the HUD log says detection worked:

```
HUD attach: table='Casablanca 04' site=Winamax hwnd=656448 title='Winamax Casablanca 04' geometry=(361,250 898x669)
```

and then, on every hand after the first:

```
HUD create refused: window 656448 already renders table 'Casablanca 04' at generation 1
```

The user configuration in `%APPDATA%\fpdb` asked for the aux window `Classic_HUD`, the spelling of an older fpdb, while its own `<aw>` block defined `ClassicHud`. `get_aux_parameters` returned `None`, `Hud._build_aux_windows` subscripted it (`TypeError: 'NoneType' object is not subscriptable`), and because `create_HUD` claims the window **before** it builds, the claim outlived the failure — so every later hand was refused as a duplicate. One aged attribute cost the table its HUD permanently, and hid the reason after the very first hand.

Not platform-specific: the same configuration loses the HUD on Windows, macOS and Linux alike. Windows 11 was unaffected only because that machine's configuration was current.

## Changes

- **`Configuration.get_aux_parameters`** — a name no `<aw>` defines falls back to a match differing only in spelling (case, `_`, `-`), warning once with the name it healed and the file to update. An exact name still wins, so a valid configuration resolves exactly as before; an ambiguous respelling is refused rather than guessed.
- **`Hud._build_aux_windows`** — an aux window nothing defines costs only itself: skipped, with an error naming it and listing the defined ones, instead of taking the whole HUD down.
- **`HUD_main.create_HUD`** — a build that raises hands its window back to the registry, so the next hand retries instead of being refused forever.
- **`tools/diagnose_windows_tables.py`** (new) — replays `find_tables`' gates and reports which one drops each window, with a `--watch` mode for appearances and title changes. For the next time a window really is at fault.

## Tests

11 new in `test/test_hud_stale_aux_config.py`, covering each fix plus a guard that both shipped templates define every name they refer to — aux windows, stat sets and layout sets — since a dangling name there fails on a player's table rather than in CI. The neighbouring suites (`test_hud_single_renderer_regression`, `test_hud_seat_mapping`, `test_configuration`) still pass. `ruff check` and `ruff format` clean.

Verified end to end against the real stale configuration: `get_aux_parameters('Classic_HUD')` → `('Aux_Classic_Hud', 'ClassicHud')`.
