### PR TITLE
fix: parse spaced PokerStars Stud Hi/Lo stakes

### DIFF
--- a/fpdb_3_legacy/GuiHandViewer.py
+++ b/fpdb_3_legacy/GuiHandViewer.py
@@ -423,7 +423,8 @@ class GuiHandViewer(QSplitter):
             hand.calculate_net_collected()
         bet = 0
         if hero in hand.pot.committed:
-            bet = hand.pot.committed[hero] - hand.pot.returned.get(hero, Decimal("0"))
+            # Pot.removeMoney already removes uncalled bets from committed.
+            bet = hand.pot.committed[hero]
         net = hand.net_collected.get(hero, 0)
         pos = hand.get_player_position(hero)
         nbplayers = len(hand.players)

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -228,10 +228,15 @@ def stud_hilo_winners(
         pot_scopes = []
         for _amount, participants in pots:
             eligible = [player for player in contenders if player.name in participants]
-            if eligible:
+            # A one-player scope is an uncontested award (for example, a
+            # side pot left after the other contributors folded), not a
+            # showdown comparison. Keep ``is_winner`` based on collectees,
+            # but do not invent HI/LO results or highlights for that scope.
+            if len(eligible) >= 2:
                 pot_scopes.append(eligible)
-        if pot_scopes:
-            scopes = pot_scopes
+        # When pots are available, an all-singleton list must not fall back to
+        # comparing every table player as one field.
+        scopes = pot_scopes
     high_winners = set()
     low_winners = set()
     used_cards: dict[str, frozenset[str]] = {}

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -198,6 +198,53 @@ def best_hand_cards(holecards: list[str], board: list[str], base: str, category:
     return best_hand(holecards, board, base, category)[1]
 
 
+def best_low_hand(holecards: list[str]) -> tuple[tuple[int, ...] | None, frozenset[str]]:
+    """Return the best qualifying five-card Ace-to-five low for Stud Hi/Lo."""
+    cards = [c for c in holecards if _is_real_card(c)]
+    best: tuple[tuple[int, ...], frozenset[str]] | None = None
+    for combination in itertools.combinations(cards, 5):
+        values = [1 if card[0] == "A" else _RANK_VALUE[card[0]] for card in combination]
+        if len(set(values)) != 5 or max(values) > 8:
+            continue
+        rank = tuple(sorted(values, reverse=True))
+        candidate = (rank, frozenset(combination))
+        if best is None or rank < best[0]:
+            best = candidate
+    return best if best else (None, frozenset())
+
+
+def stud_hilo_winners(players: list["ReplayPlayer"]) -> tuple[set[str], set[str], dict[str, frozenset[str]]]:
+    """Evaluate Stud Hi/Lo winners and the cards used for each half."""
+    contenders = [
+        player
+        for player in players
+        if player.action != "folds" and len([c for c in player.holecards if _is_real_card(c)]) >= 5
+    ]
+    high: dict[str, tuple[tuple, frozenset[str]]] = {}
+    low: dict[str, tuple[tuple[int, ...], frozenset[str]]] = {}
+    for player in contenders:
+        high_rank, high_cards = best_hand(player.holecards, [], "stud", "studhilo")
+        if high_rank is not None:
+            high[player.name] = (high_rank, high_cards)
+        low_rank, low_cards = best_low_hand(player.holecards)
+        if low_rank is not None:
+            low[player.name] = (low_rank, low_cards)
+    high_winners = set()
+    low_winners = set()
+    used_cards: dict[str, frozenset[str]] = {}
+    if high:
+        best_rank = max(rank for rank, _cards in high.values())
+        high_winners = {name for name, (rank, _cards) in high.items() if rank == best_rank}
+        for name in high_winners:
+            used_cards[name] = high[name][1]
+    if low:
+        best_rank = min(rank for rank, _cards in low.values())
+        low_winners = {name for name, (rank, _cards) in low.items() if rank == best_rank}
+        for name in low_winners:
+            used_cards[name] = used_cards.get(name, frozenset()) | low[name][1]
+    return high_winners, low_winners, used_cards
+
+
 _CATEGORY_NAMES = {
     8: "Straight Flush",
     7: "Four of a Kind",
@@ -267,6 +314,8 @@ class ReplayPlayer:
     combination: str | None = None
     winning_cards: frozenset[str] = field(default_factory=frozenset)
     is_winner: bool = False
+    hi_winner: bool = False
+    lo_winner: bool = False
     cashout: Decimal | None = None
     # Splash collected from the room, kept apart from `chips` because it is not
     # won from the other players and does not balance against the betting.
@@ -1534,6 +1583,13 @@ class GuiReplayer(QWidget):
                     ),
                 )
             )
+        if is_showdown and category.lower() == "studhilo":
+            hi_winners, lo_winners, used_cards = stud_hilo_winners(players)
+            for player in players:
+                player.hi_winner = player.name in hi_winners
+                player.lo_winner = player.name in lo_winners
+                if player.name in used_cards:
+                    player.winning_cards |= used_cards[player.name]
         runs_info = []
         if is_showdown and len(board_runs) > 1:
             runs_info = self._compute_run_winners(players, board_runs, base, category)
@@ -2055,6 +2111,11 @@ class GuiReplayer(QWidget):
             combo_font = QFont("Helvetica", combo_font_size, QFont.Weight.Bold)
             metrics = QFontMetrics(combo_font)
             combo_text = player.combination
+            if player.hi_winner or player.lo_winner:
+                result = " / ".join(
+                    part for part, won in (("HI winner", player.hi_winner), ("LO winner", player.lo_winner)) if won
+                )
+                combo_text = f"{combo_text} · {result}"
             pad_x, pad_y = 10, 5
             text_w = metrics.horizontalAdvance(combo_text)
             pill_w = text_w + pad_x * 2
@@ -2138,6 +2199,14 @@ class GuiReplayer(QWidget):
                 if not combo:
                     continue
                 suffix = " (wins)" if name in collectees else ""
+                player = next((p for p in states_shown[-1].players if p.name == name), None)
+                if player is not None and (player.hi_winner or player.lo_winner):
+                    result = " / ".join(
+                        part
+                        for part, won in (("HI winner", player.hi_winner), ("LO winner", player.lo_winner))
+                        if won
+                    )
+                    suffix = f" ({result})"
                 entries.append(f"{name}: {combo}{suffix}")
             for name, amount in (getattr(hand, "cashOutAmounts", {}) or {}).items():
                 entries.append(f"{name}: cashout {format_replay_amount(amount, self.currency_code)}")

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -213,35 +213,50 @@ def best_low_hand(holecards: list[str]) -> tuple[tuple[int, ...] | None, frozens
     return best if best else (None, frozenset())
 
 
-def stud_hilo_winners(players: list[ReplayPlayer]) -> tuple[set[str], set[str], dict[str, frozenset[str]]]:
-    """Evaluate Stud Hi/Lo winners and the cards used for each half."""
+def stud_hilo_winners(
+    players: list[ReplayPlayer],
+    pots: list[tuple[Any, set[str]]] | None = None,
+) -> tuple[set[str], set[str], dict[str, frozenset[str]]]:
+    """Evaluate Stud Hi/Lo winners and cards used, per eligible pot."""
     contenders = [
         player
         for player in players
         if player.action != "folds" and len([c for c in player.holecards if _is_real_card(c)]) >= 5
     ]
-    high: dict[str, tuple[tuple, frozenset[str]]] = {}
-    low: dict[str, tuple[tuple[int, ...], frozenset[str]]] = {}
-    for player in contenders:
-        high_rank, high_cards = best_hand(player.holecards, [], "stud", "studhilo")
-        if high_rank is not None:
-            high[player.name] = (high_rank, high_cards)
-        low_rank, low_cards = best_low_hand(player.holecards)
-        if low_rank is not None:
-            low[player.name] = (low_rank, low_cards)
+    scopes = [contenders]
+    if pots:
+        pot_scopes = []
+        for _amount, participants in pots:
+            eligible = [player for player in contenders if player.name in participants]
+            if eligible:
+                pot_scopes.append(eligible)
+        if pot_scopes:
+            scopes = pot_scopes
     high_winners = set()
     low_winners = set()
     used_cards: dict[str, frozenset[str]] = {}
-    if high:
-        best_rank = max(rank for rank, _cards in high.values())
-        high_winners = {name for name, (rank, _cards) in high.items() if rank == best_rank}
-        for name in high_winners:
-            used_cards[name] = high[name][1]
-    if low:
-        best_rank = min(rank for rank, _cards in low.values())
-        low_winners = {name for name, (rank, _cards) in low.items() if rank == best_rank}
-        for name in low_winners:
-            used_cards[name] = used_cards.get(name, frozenset()) | low[name][1]
+    for scope in scopes:
+        high: dict[str, tuple[tuple, frozenset[str]]] = {}
+        low: dict[str, tuple[tuple[int, ...], frozenset[str]]] = {}
+        for player in scope:
+            high_rank, high_cards = best_hand(player.holecards, [], "stud", "studhilo")
+            if high_rank is not None:
+                high[player.name] = (high_rank, high_cards)
+            low_rank, low_cards = best_low_hand(player.holecards)
+            if low_rank is not None:
+                low[player.name] = (low_rank, low_cards)
+        if high:
+            best_rank = max(rank for rank, _cards in high.values())
+            winners = {name for name, (rank, _cards) in high.items() if rank == best_rank}
+            high_winners |= winners
+            for name in winners:
+                used_cards[name] = used_cards.get(name, frozenset()) | high[name][1]
+        if low:
+            best_rank = min(rank for rank, _cards in low.values())
+            winners = {name for name, (rank, _cards) in low.items() if rank == best_rank}
+            low_winners |= winners
+            for name in winners:
+                used_cards[name] = used_cards.get(name, frozenset()) | low[name][1]
     return high_winners, low_winners, used_cards
 
 
@@ -1588,7 +1603,10 @@ class GuiReplayer(QWidget):
                 )
             )
         if is_showdown and category.lower() == "studhilo":
-            hi_winners, lo_winners, used_cards = stud_hilo_winners(players)
+            hi_winners, lo_winners, used_cards = stud_hilo_winners(
+                players,
+                getattr(hand.pot, "pots", None) if hasattr(hand, "pot") else None,
+            )
             for player in players:
                 player.hi_winner = player.name in hi_winners
                 player.lo_winner = player.name in lo_winners

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -210,11 +210,6 @@ def best_low_hand(holecards: list[str]) -> tuple[tuple[int, ...] | None, frozens
         candidate = (rank, frozenset(combination))
         if best is None or rank < best[0]:
             best = candidate
-        elif rank == best[0]:
-            # PokerStars only prints low ranks, not suits. Keep every card
-            # that can realize an equally ranked low so the replayer does not
-            # arbitrarily highlight one of several equivalent cards.
-            best = (best[0], best[1] | candidate[1])
     return best if best else (None, frozenset())
 
 

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -210,6 +210,11 @@ def best_low_hand(holecards: list[str]) -> tuple[tuple[int, ...] | None, frozens
         candidate = (rank, frozenset(combination))
         if best is None or rank < best[0]:
             best = candidate
+        elif rank == best[0]:
+            # PokerStars only prints low ranks, not suits. Keep every card
+            # that can realize an equally ranked low so the replayer does not
+            # arbitrarily highlight one of several equivalent cards.
+            best = (best[0], best[1] | candidate[1])
     return best if best else (None, frozenset())
 
 

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -213,7 +213,7 @@ def best_low_hand(holecards: list[str]) -> tuple[tuple[int, ...] | None, frozens
     return best if best else (None, frozenset())
 
 
-def stud_hilo_winners(players: list["ReplayPlayer"]) -> tuple[set[str], set[str], dict[str, frozenset[str]]]:
+def stud_hilo_winners(players: list[ReplayPlayer]) -> tuple[set[str], set[str], dict[str, frozenset[str]]]:
     """Evaluate Stud Hi/Lo winners and the cards used for each half."""
     contenders = [
         player
@@ -1553,7 +1553,7 @@ class GuiReplayer(QWidget):
                 # seven cards from that ambiguous payload.
                 if explicit and category.lower() != "studhilo":
                     winning_cards = frozenset(self._normalized_cards(explicit))
-                elif is_winner:
+                elif is_winner and category.lower() != "studhilo":
                     # Best hand per run (Omaha = 2 hole + 3 board), unioned so
                     # the highlight reflects every run the winner contests.
                     for run in board_runs:
@@ -1592,8 +1592,9 @@ class GuiReplayer(QWidget):
             for player in players:
                 player.hi_winner = player.name in hi_winners
                 player.lo_winner = player.name in lo_winners
-                if player.name in used_cards:
-                    player.winning_cards |= used_cards[player.name]
+                # A low-only winner must not retain their losing high hand.
+                # The evaluator already unions both halves for a scoop.
+                player.winning_cards = used_cards.get(player.name, frozenset())
         runs_info = []
         if is_showdown and len(board_runs) > 1:
             runs_info = self._compute_run_winners(players, board_runs, base, category)
@@ -2110,16 +2111,16 @@ class GuiReplayer(QWidget):
         )
         painter.drawText(action_rect, Qt.AlignmentFlag.AlignCenter, action_text)
 
-        if is_final_frame and player.combination:
+        if is_final_frame and (player.combination or player.hi_winner or player.lo_winner):
             combo_font_size = max(9, int(10 * card_scale))
             combo_font = QFont("Helvetica", combo_font_size, QFont.Weight.Bold)
             metrics = QFontMetrics(combo_font)
-            combo_text = player.combination
+            combo_text = player.combination or ""
             if player.hi_winner or player.lo_winner:
                 result = " / ".join(
                     part for part, won in (("HI winner", player.hi_winner), ("LO winner", player.lo_winner)) if won
                 )
-                combo_text = f"{combo_text} · {result}"
+                combo_text = f"{combo_text} · {result}" if combo_text else result
             pad_x, pad_y = 10, 5
             text_w = metrics.horizontalAdvance(combo_text)
             pill_w = text_w + pad_x * 2
@@ -2199,19 +2200,29 @@ class GuiReplayer(QWidget):
             hand = self.replay_model.hand
             showdown_strings = getattr(hand, "showdownStrings", {}) or {}
             collectees = getattr(hand, "collectees", {}) or {}
-            for name, combo in showdown_strings.items():
-                if not combo:
-                    continue
+            combinations = dict(showdown_strings)
+            evaluated_players = {}
+            if hand.gametype.get("category", "").lower() == "studhilo":
+                frame = self._frame_from_state(states_shown[-1])
+                evaluated_players = {player.name: player for player in frame.players}
+                for player in frame.players:
+                    if player.hi_winner or player.lo_winner:
+                        combinations.setdefault(player.name, "")
+            for name, combo in combinations.items():
                 suffix = " (wins)" if name in collectees else ""
-                player = next((p for p in states_shown[-1].players if p.name == name), None)
+                player = evaluated_players.get(name)
                 if player is not None and (player.hi_winner or player.lo_winner):
                     result = " / ".join(
                         part
                         for part, won in (("HI winner", player.hi_winner), ("LO winner", player.lo_winner))
                         if won
                     )
-                    suffix = f" ({result})"
-                entries.append(f"{name}: {combo}{suffix}")
+                    if combo:
+                        suffix = f" ({result})"
+                    else:
+                        combo, suffix = result, ""
+                if combo:
+                    entries.append(f"{name}: {combo}{suffix}")
             for name, amount in (getattr(hand, "cashOutAmounts", {}) or {}).items():
                 entries.append(f"{name}: cashout {format_replay_amount(amount, self.currency_code)}")
             # The splash is added by the room, not won from the other players,

--- a/fpdb_3_legacy/GuiReplayer.py
+++ b/fpdb_3_legacy/GuiReplayer.py
@@ -1547,7 +1547,11 @@ class GuiReplayer(QWidget):
                 is_winner = player.name in collectees
                 explicit = winning_hands.get(player.name)
                 hole = self._normalized_cards(list(player.holecards or []))
-                if explicit:
+                # PokerStars Stud Hi/Lo showdown rows may persist all seven
+                # exposed cards as the winning hand. Recompute the exact
+                # five-card high/low result below instead of highlighting all
+                # seven cards from that ambiguous payload.
+                if explicit and category.lower() != "studhilo":
                     winning_cards = frozenset(self._normalized_cards(explicit))
                 elif is_winner:
                     # Best hand per run (Omaha = 2 hole + 3 board), unioned so

--- a/fpdb_3_legacy/Hand.py
+++ b/fpdb_3_legacy/Hand.py
@@ -1442,15 +1442,19 @@ class Hand:
             )
 
     def calculate_net_collected(self) -> None:
-        """Calculate the net collected amount for each player."""
+        """Calculate profit after the amount actually committed by each player.
+
+        ``Pot.removeMoney`` removes uncalled bets from ``pot.committed`` while
+        recording them in ``pot.returned``. Consequently ``committed`` is
+        already the net paid amount and returned money must not be added again.
+        """
         log.debug("Starting net collected calculation...")
 
         self.net_collected = {}
         for player in self.pot.committed:
             collected = self.collectees.get(player, Decimal("0.00"))
-            uncalled_bets = self.pot.returned.get(player, Decimal("0.00"))
             committed = self.pot.committed.get(player, Decimal("0.00"))
-            self.net_collected[player] = collected + uncalled_bets - committed
+            self.net_collected[player] = collected - committed
             log.debug(f"Net collected for {player}: {self.net_collected[player]:.2f}")
 
         log.debug("Net collected calculation complete.")
@@ -3080,7 +3084,7 @@ class Pot:
 
     def removeMoney(self, player, amount) -> None:
         self.committed[player] -= amount
-        self.returned[player] = amount
+        self.returned[player] = self.returned.get(player, Decimal("0.00")) + amount
 
     def setSTP(self, amount) -> None:
         self.stp = amount

--- a/fpdb_3_legacy/PokerStarsToFpdb.py
+++ b/fpdb_3_legacy/PokerStarsToFpdb.py
@@ -315,6 +315,23 @@ class PokerStars(HandHistoryConverter):
         "Rs. ": "INR",
     }
 
+    @staticmethod
+    def _normalize_game_header(text: str) -> str:
+        """Normalize cosmetic separators on the header line only.
+
+        PokerStars can write both ``$2.50 / $5`` and ``Hi / Lo``. Applying
+        these substitutions to the complete hand history can corrupt player
+        or table names containing the same text, so leave all later lines
+        byte-for-byte unchanged.
+        """
+        if not isinstance(text, str):
+            raise TypeError("PokerStars hand text must be a string")
+        head, separator, tail = text.partition("\n")
+        currency = r"(?:\$|€|£|¥|₹|Rs\.\s)?"
+        head = re.sub(rf"(?<=\d)\s*/\s*(?={currency}\d)", "/", head)
+        head = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", head, flags=re.IGNORECASE)
+        return head + (separator + tail if separator else "")
+
     # Static regexes
     re_game_info = re.compile(
         """
@@ -957,8 +974,7 @@ class PokerStars(HandHistoryConverter):
         # stakes (``$2.50 / $5``) and in the Hi/Lo label.  The canonical
         # parser format is compact, so normalize these harmless variations
         # before applying the shared header expression.
-        hand_text = re.sub(r"(?<=\d)\s*/\s*(?=\$?\d)", "/", hand_text)
-        hand_text = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", hand_text, flags=re.IGNORECASE)
+        hand_text = self._normalize_game_header(hand_text)
 
         m = self.re_game_info.search(hand_text)
         if not m:
@@ -1020,10 +1036,12 @@ class PokerStars(HandHistoryConverter):
         if info["limitType"] == "fl" and info["bb"] is not None:
             if info["type"] == "ring":
                 if info.get("base") == "stud":
-                    # Stud and Razz headers contain betting limits, not
-                    # blinds. Preserve both values from the header directly.
+                    # Stud and Razz headers contain betting limits. ``bb`` is
+                    # also used as the database small-bet key, so retain the
+                    # lower limit there; the upper limit remains available in
+                    # the parsed header and is represented by bigBet = 2*bb.
                     info["sb"] = mg["SB"]
-                    info["bb"] = mg["BB"]
+                    info["bb"] = mg["SB"]
                 else:
                     try:
                         info["sb"] = self.lim_blinds[mg["BB"]][0]
@@ -1378,10 +1396,9 @@ class PokerStars(HandHistoryConverter):
                 raise FpdbHandPartial(msg)
 
         info: dict[str, Any] = {}
-        hand.handText = re.sub(r"(?<=\d)\s*/\s*(?=\$?\d)", "/", hand.handText)
-        hand.handText = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", hand.handText, flags=re.IGNORECASE)
+        normalized_header = self._normalize_game_header(hand.handText)
         m = self.re_hand_info.search(hand.handText, re.DOTALL)
-        m2 = self.re_game_info.search(hand.handText)
+        m2 = self.re_game_info.search(normalized_header)
         if m is None or m2 is None:
             tmp = hand.handText[:200]
             log.error("read Hand Info failed: %r", tmp)

--- a/fpdb_3_legacy/PokerStarsToFpdb.py
+++ b/fpdb_3_legacy/PokerStarsToFpdb.py
@@ -329,7 +329,8 @@ class PokerStars(HandHistoryConverter):
         head, separator, tail = text.partition("\n")
         currency = r"(?:\$|€|£|¥|₹|Rs\.\s)?"
         head = re.sub(rf"(?<=\d)\s*/\s*(?={currency}\d)", "/", head)
-        head = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", head, flags=re.IGNORECASE)
+        # The game regex accepts distinct title-case and uppercase labels.
+        head = re.sub(r"(Hi)\s*/\s*(Lo)", r"\1/\2", head, flags=re.IGNORECASE)
         return head + (separator + tail if separator else "")
 
     # Static regexes

--- a/fpdb_3_legacy/PokerStarsToFpdb.py
+++ b/fpdb_3_legacy/PokerStarsToFpdb.py
@@ -819,6 +819,15 @@ class PokerStars(HandHistoryConverter):
                     ),
                     re.MULTILINE,
                 )
+                # Stud/Hi-Lo summaries use ``with HI: ...; LO: ...``
+                # without the usual ``showed`` verb. Keep the complete
+                # high/low description for the replayer and hand viewer.
+                self.re_summary_showdown = re.compile(
+                    r"Seat (?P<SEAT>[0-9]+): {PLYR} {BRKTS}\([^)]*\) with (?P<STRING>HI: .+)$".format(
+                        **subst,
+                    ),
+                    re.MULTILINE,
+                )
 
     def readSupportedGames(self) -> list[list[str]]:
         """Returns a list of supported game types for PokerStars.
@@ -2273,6 +2282,14 @@ class PokerStars(HandHistoryConverter):
                     mucked=mucked,
                     string=string,
                 )
+
+        # PokerStars Stud and Razz summary rows omit ``showed`` and only
+        # provide the textual high/low result. Preserve that result so the
+        # replayer can display both halves of a split hand.
+        summary_re = getattr(self, "re_summary_showdown", None)
+        if summary_re is not None:
+            for summary_match in summary_re.finditer(hand.handText):
+                hand.showdownStrings[summary_match.group("PNAME")] = summary_match.group("STRING")
 
     def _parseRakeAndPot(self, hand: Hand) -> None:
         """Parses rake and total pot information from the hand text and updates the hand object.

--- a/fpdb_3_legacy/PokerStarsToFpdb.py
+++ b/fpdb_3_legacy/PokerStarsToFpdb.py
@@ -286,6 +286,8 @@ class PokerStars(HandHistoryConverter):
         "7 CARD STUD": ("stud", "studhi"),
         "7 Card Stud Hi/Lo": ("stud", "studhilo"),
         "7 CARD STUD HI/LO": ("stud", "studhilo"),
+        "7 Card Stud Hi / Lo": ("stud", "studhilo"),
+        "7 CARD STUD HI / LO": ("stud", "studhilo"),
         "Badugi": ("draw", "badugi"),
         "Triple Draw 2-7 Lowball": ("draw", "27_3draw"),
         "Single Draw 2-7 Lowball": ("draw", "27_1draw"),
@@ -942,6 +944,13 @@ class PokerStars(HandHistoryConverter):
         Returns:
             dict[str, str]: Dictionary containing parsed game type and related attributes.
         """
+        # PokerStars occasionally inserts spaces around separators in Stud
+        # stakes (``$2.50 / $5``) and in the Hi/Lo label.  The canonical
+        # parser format is compact, so normalize these harmless variations
+        # before applying the shared header expression.
+        hand_text = re.sub(r"(?<=\d)\s*/\s*(?=\$?\d)", "/", hand_text)
+        hand_text = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", hand_text, flags=re.IGNORECASE)
+
         m = self.re_game_info.search(hand_text)
         if not m:
             tmp = hand_text[:200]
@@ -1001,13 +1010,19 @@ class PokerStars(HandHistoryConverter):
 
         if info["limitType"] == "fl" and info["bb"] is not None:
             if info["type"] == "ring":
-                try:
-                    info["sb"] = self.lim_blinds[mg["BB"]][0]
-                    info["bb"] = self.lim_blinds[mg["BB"]][1]
-                except KeyError:
-                    tmp = hand_text[:200]
-                    log.exception("Lim_Blinds has no lookup for %r - %r", mg["BB"], tmp)
-                    raise FpdbParseError from None
+                if info.get("base") == "stud":
+                    # Stud and Razz headers contain betting limits, not
+                    # blinds. Preserve both values from the header directly.
+                    info["sb"] = mg["SB"]
+                    info["bb"] = mg["BB"]
+                else:
+                    try:
+                        info["sb"] = self.lim_blinds[mg["BB"]][0]
+                        info["bb"] = self.lim_blinds[mg["BB"]][1]
+                    except KeyError:
+                        tmp = hand_text[:200]
+                        log.exception("Lim_Blinds has no lookup for %r - %r", mg["BB"], tmp)
+                        raise FpdbParseError from None
             else:
                 bb_decimal = Decimal(info["bb"])
                 info["sb"] = str((bb_decimal / Decimal("2")).quantize(Decimal("0.01")))
@@ -1354,6 +1369,8 @@ class PokerStars(HandHistoryConverter):
                 raise FpdbHandPartial(msg)
 
         info: dict[str, Any] = {}
+        hand.handText = re.sub(r"(?<=\d)\s*/\s*(?=\$?\d)", "/", hand.handText)
+        hand.handText = re.sub(r"Hi\s*/\s*Lo", "Hi/Lo", hand.handText, flags=re.IGNORECASE)
         m = self.re_hand_info.search(hand.handText, re.DOTALL)
         m2 = self.re_game_info.search(hand.handText)
         if m is None or m2 is None:

--- a/test/test_pokerstars.py
+++ b/test/test_pokerstars.py
@@ -74,10 +74,10 @@ class TestPokerStarsRegex(unittest.TestCase):
     def test_stud_hilo_accepts_spaced_stakes_and_game_label(self) -> None:
         """Accept Stud Hi/Lo betting limits with cosmetic spacing."""
         for hand_id, game, stakes, expected in (
-            (1, "7 Card Stud Hi/Lo", "$2.50/$5", ("2.50", "5")),
-            (2, "7 Card Stud Hi / Lo", "$2.50 / $5", ("2.50", "5")),
-            (3, "7 Card Stud", "$5/$10", ("5", "10")),
-            (4, "Razz", "$10/$20", ("10", "20")),
+            (1, "7 Card Stud Hi/Lo", "$2.50/$5", ("2.50", "2.50")),
+            (2, "7 Card Stud Hi / Lo", "$2.50 / $5", ("2.50", "2.50")),
+            (3, "7 Card Stud", "$5/$10", ("5", "5")),
+            (4, "Razz", "$10/$20", ("10", "10")),
         ):
             header = f"PokerStars Hand #{hand_id}:  {game} Limit ({stakes} USD) - 2026/01/01 00:00:00 ET"
             with self.subTest(header=header):
@@ -85,6 +85,16 @@ class TestPokerStarsRegex(unittest.TestCase):
                 self.assertEqual(game_info["base"], "stud")
                 self.assertEqual(game_info["limitType"], "fl")
                 self.assertEqual((game_info["sb"], game_info["bb"]), expected)
+
+    def test_stud_header_normalization_supports_euro_and_preserves_names(self) -> None:
+        header = "PokerStars Hand #5:  7 Card Stud Hi / Lo Limit (€2.50 / €5 EUR) - 2026/01/01 00:00:00 ET"
+        game_info = self.parser.determineGameType(header)
+        self.assertEqual(game_info["currency"], "EUR")
+        self.assertEqual((game_info["sb"], game_info["bb"]), ("2.50", "2.50"))
+
+        text = header + "\nSeat 1: 1 / 2 (€10 in chips)\n"
+        normalized = self.parser._normalize_game_header(text)
+        self.assertIn("Seat 1: 1 / 2", normalized)
 
     def test_fixed_limit_holdem_still_uses_blind_mapping(self) -> None:
         """Keep converting PokerStars Hold'em limits to actual blinds."""

--- a/test/test_pokerstars.py
+++ b/test/test_pokerstars.py
@@ -1365,6 +1365,29 @@ Seat 2: Player1 mucked [7h 2c]"""
 
         self.assertEqual(hand.addShownCards.call_count, 2)
 
+    def test_read_stud_hilo_summary_results(self) -> None:
+        """Keep PokerStars Stud Hi/Lo high and low descriptions for replay."""
+        hand = Mock()
+        hand.players = [(5, "Player8"), (8, "Player9")]
+        hand.handText = (
+            "Seat 5: Player8 ($23.30) with HI: a straight, Four to Eight; LO: 8,7,6,5,4\n"
+            "Seat 8: Player9 ($23.30) with HI: a pair of Aces; LO: 8,7,4,2,A\n"
+        )
+        hand.showdownStrings = {}
+        self.parser.compilePlayerRegexs(hand)
+        self.parser.re_shown_cards = Mock()
+        self.parser.re_shown_cards.finditer = Mock(return_value=[])
+
+        self.parser.readShownCards(hand)
+
+        self.assertEqual(
+            hand.showdownStrings,
+            {
+                "Player8": "HI: a straight, Four to Eight; LO: 8,7,6,5,4",
+                "Player9": "HI: a pair of Aces; LO: 8,7,4,2,A",
+            },
+        )
+
     def test_get_table_title_re_cash(self) -> None:
         """Test getTableTitleRe for cash games."""
         result = PokerStars.getTableTitleRe("ring", "Test Table")

--- a/test/test_pokerstars.py
+++ b/test/test_pokerstars.py
@@ -96,6 +96,33 @@ class TestPokerStarsRegex(unittest.TestCase):
         normalized = self.parser._normalize_game_header(text)
         self.assertIn("Seat 1: 1 / 2", normalized)
 
+    def test_uppercase_hilo_headers_keep_their_game_type(self) -> None:
+        """Normalize slash spacing without changing uppercase game labels."""
+        for game, category in (("7 CARD STUD HI/LO", "studhilo"), ("OMAHA HI/LO", "omahahilo")):
+            for spaced in (False, True):
+                label = game.replace("/", " / ") if spaced else game
+                stakes = "$2 / $4" if spaced else "$2/$4"
+                header = f"PokerStars Hand #99:  {label} LIMIT ({stakes} USD) - 2026/01/01 00:00:00 ET"
+                with self.subTest(game=game, spaced=spaced):
+                    game_info = self.parser.determineGameType(header)
+                    self.assertEqual(game_info["category"], category)
+                    self.assertEqual(game_info["limitType"], "fl")
+
+    def test_uppercase_pt2_stud_hilo_export_imports(self) -> None:
+        """Exercise header detection and hand parsing on the actual PT2 export."""
+        hand_file = (
+            Path(__file__).resolve().parents[1]
+            / "regression-test-files/tour/Stars/Stud/7-StudHL-USD-10-1-200906.PT2.export.txt"
+        )
+        parser = PokerStars(self.config, in_path=str(hand_file), autostart=True)
+        hands = parser.getProcessedHands()
+
+        self.assertEqual(len(hands), 1)
+        self.assertEqual(hands[0].handid, "29356803849")
+        self.assertEqual(hands[0].gametype["category"], "studhilo")
+        self.assertEqual(hands[0].gametype["type"], "tour")
+        self.assertEqual(hands[0].collectees, {"Player4": Decimal("220"), "Player2": Decimal("220")})
+
     def test_fixed_limit_holdem_still_uses_blind_mapping(self) -> None:
         """Keep converting PokerStars Hold'em limits to actual blinds."""
         for stakes, expected in (

--- a/test/test_pokerstars.py
+++ b/test/test_pokerstars.py
@@ -71,6 +71,34 @@ class TestPokerStarsRegex(unittest.TestCase):
         self.assertEqual(match.group("SB"), "0.10")
         self.assertEqual(match.group("BB"), "0.25")
 
+    def test_stud_hilo_accepts_spaced_stakes_and_game_label(self) -> None:
+        """Accept Stud Hi/Lo betting limits with cosmetic spacing."""
+        for hand_id, game, stakes, expected in (
+            (1, "7 Card Stud Hi/Lo", "$2.50/$5", ("2.50", "5")),
+            (2, "7 Card Stud Hi / Lo", "$2.50 / $5", ("2.50", "5")),
+            (3, "7 Card Stud", "$5/$10", ("5", "10")),
+            (4, "Razz", "$10/$20", ("10", "20")),
+        ):
+            header = f"PokerStars Hand #{hand_id}:  {game} Limit ({stakes} USD) - 2026/01/01 00:00:00 ET"
+            with self.subTest(header=header):
+                game_info = self.parser.determineGameType(header)
+                self.assertEqual(game_info["base"], "stud")
+                self.assertEqual(game_info["limitType"], "fl")
+                self.assertEqual((game_info["sb"], game_info["bb"]), expected)
+
+    def test_fixed_limit_holdem_still_uses_blind_mapping(self) -> None:
+        """Keep converting PokerStars Hold'em limits to actual blinds."""
+        for stakes, expected in (
+            ("$2/$4", ("1.00", "2.00")),
+            ("$3/$6", ("1.00", "3.00")),
+            ("$5/$10", ("2.00", "5.00")),
+            ("$15/$30", ("10.00", "15.00")),
+        ):
+            header = f"PokerStars Hand #99:  Hold'em Limit ({stakes} USD) - 2026/01/01 00:00:00 ET"
+            with self.subTest(header=header):
+                game_info = self.parser.determineGameType(header)
+                self.assertEqual((game_info["sb"], game_info["bb"]), expected)
+
     def test_re_game_info_tournament(self) -> None:
         """Test regex pattern for parsing tournament information."""
         text = (

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -17,7 +17,10 @@ def test_stud_hilo_evaluation_identifies_high_and_low_winners() -> None:
     assert high == {"Hero"}
     assert low == {"Player5"}
     assert cards["Hero"] == {"4s", "5s", "5h", "6d", "7d", "8s"}
-    assert cards["Player5"] == {"2h", "Ac", "As", "4c", "7c", "8h"}
+    low_rank, low_cards = best_low_hand(villain.holecards)
+    assert low_rank == (8, 7, 4, 2, 1)
+    assert low_cards == {"2h", "Ac", "4c", "7c", "8h"}
+    assert cards["Player5"] == low_cards
 
 
 def test_stud_hilo_low_requires_five_distinct_cards_eight_or_lower() -> None:

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -16,8 +16,8 @@ def test_stud_hilo_evaluation_identifies_high_and_low_winners() -> None:
 
     assert high == {"Hero"}
     assert low == {"Player5"}
-    assert cards["Hero"] == {"4s", "5s", "6d", "7d", "8s"}
-    assert cards["Player5"] == {"2h", "4c", "7c", "8h", "Ac"}
+    assert cards["Hero"] == {"4s", "5s", "5h", "6d", "7d", "8s"}
+    assert cards["Player5"] == {"2h", "Ac", "As", "4c", "7c", "8h"}
 
 
 def test_stud_hilo_low_requires_five_distinct_cards_eight_or_lower() -> None:

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -6,7 +6,24 @@ from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any, cast
 
-from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer
+from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer, best_low_hand, stud_hilo_winners
+
+
+def test_stud_hilo_evaluation_identifies_high_and_low_winners() -> None:
+    hero = ReplayPlayer("Hero", 1, Decimal(0), Decimal(0), "calls", False, ["5s", "6d", "7d", "8s", "4s", "Kd", "5h"])
+    villain = ReplayPlayer("Player5", 5, Decimal(0), Decimal(0), "calls", False, ["2h", "Ac", "As", "7c", "Ks", "4c", "8h"])
+    high, low, cards = stud_hilo_winners([hero, villain])
+
+    assert high == {"Hero"}
+    assert low == {"Player5"}
+    assert cards["Hero"] == {"4s", "5s", "6d", "7d", "8s"}
+    assert cards["Player5"] == {"2h", "4c", "7c", "8h", "Ac"}
+
+
+def test_stud_hilo_low_requires_five_distinct_cards_eight_or_lower() -> None:
+    rank, cards = best_low_hand(["As", "2d", "3c", "4h", "9s", "Kd", "Qh"])
+    assert rank is None
+    assert cards == frozenset()
 
 
 def test_hero_decision_metrics_pot_odds_and_equities(monkeypatch) -> None:

--- a/test/test_replayer_push_call_equity_pot_odds.py
+++ b/test/test_replayer_push_call_equity_pot_odds.py
@@ -16,7 +16,7 @@ def test_stud_hilo_evaluation_identifies_high_and_low_winners() -> None:
 
     assert high == {"Hero"}
     assert low == {"Player5"}
-    assert cards["Hero"] == {"4s", "5s", "5h", "6d", "7d", "8s"}
+    assert cards["Hero"] == {"4s", "5s", "6d", "7d", "8s"}
     low_rank, low_cards = best_low_hand(villain.holecards)
     assert low_rank == (8, 7, 4, 2, 1)
     assert low_cards == {"2h", "Ac", "4c", "7c", "8h"}

--- a/test/test_uncalled_bet_accounting.py
+++ b/test/test_uncalled_bet_accounting.py
@@ -1,0 +1,32 @@
+"""Regression tests for uncalled-bet accounting in reports."""
+
+from decimal import Decimal
+
+from fpdb_3_legacy.Hand import Hand, Pot
+
+
+def test_uncalled_bet_is_removed_once_from_bet_and_net() -> None:
+    pot = Pot()
+    pot.addPlayer("Hero")
+    pot.addMoney("Hero", Decimal("5.24"))
+    pot.removeMoney("Hero", Decimal("1.65"))
+
+    hand = Hand.__new__(Hand)
+    hand.pot = pot
+    hand.collectees = {"Hero": Decimal("3.59")}
+    hand.calculate_net_collected()
+
+    assert pot.committed["Hero"] == Decimal("3.59")
+    assert pot.returned["Hero"] == Decimal("1.65")
+    assert hand.net_collected["Hero"] == Decimal("0.00")
+
+
+def test_multiple_uncalled_returns_are_accumulated() -> None:
+    pot = Pot()
+    pot.addPlayer("Hero")
+    pot.addMoney("Hero", Decimal("10.00"))
+    pot.removeMoney("Hero", Decimal("1.25"))
+    pot.removeMoney("Hero", Decimal("0.75"))
+
+    assert pot.committed["Hero"] == Decimal("8.00")
+    assert pot.returned["Hero"] == Decimal("2.00")

--- a/test/unit_legacy/test_replayer_stud_hilo.py
+++ b/test/unit_legacy/test_replayer_stud_hilo.py
@@ -94,6 +94,22 @@ def test_stud_hilo_winners_are_evaluated_for_each_eligible_pot():
     assert cards["Deep"] == {"5s", "6d", "7h", "8c", "4d", "2s", "3c"}
 
 
+def test_stud_hilo_skips_uncontested_singleton_pots():
+    survivor = ReplayPlayer(
+        "Survivor", 1, Decimal(0), Decimal(0), "collected", True,
+        ["As", "Ah", "Ad", "2c", "3d", "4h", "6s"],
+    )
+
+    high, low, cards = stud_hilo_winners(
+        [survivor],
+        [(Decimal("10"), {"Survivor"})],
+    )
+
+    assert high == set()
+    assert low == set()
+    assert cards == {}
+
+
 @pytest.mark.parametrize(
     ("hero_cards", "opponent_cards", "low_winners", "hero_highlights"),
     [

--- a/test/unit_legacy/test_replayer_stud_hilo.py
+++ b/test/unit_legacy/test_replayer_stud_hilo.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from fpdb_3_legacy import Card
-from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer, build_replay_layout
+from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer, build_replay_layout, stud_hilo_winners
 
 
 @pytest.fixture
@@ -75,6 +75,25 @@ def test_no_winning_highlights_before_showdown(stud_replayer):
         assert not player.hi_winner and not player.lo_winner
 
 
+def test_stud_hilo_winners_are_evaluated_for_each_eligible_pot():
+    short = ReplayPlayer("Short", 1, Decimal(0), Decimal(0), "calls", False,
+                         ["Ks", "Kh", "Kc", "2d", "4h", "7s", "9c"])
+    hero = ReplayPlayer("Hero", 2, Decimal(0), Decimal(0), "calls", False,
+                        ["As", "Ah", "Qc", "Jd", "9h", "7c", "4s"])
+    deep = ReplayPlayer("Deep", 3, Decimal(0), Decimal(0), "calls", False,
+                        ["5s", "6d", "7h", "8c", "4d", "2s", "3c"])
+
+    high, low, cards = stud_hilo_winners(
+        [short, hero, deep],
+        [(Decimal("10"), {"Short", "Hero"}), (Decimal("10"), {"Hero", "Deep"})],
+    )
+
+    assert high == {"Short", "Deep"}
+    assert low == {"Deep"}
+    assert cards["Short"] == {"Ks", "Kh", "Kc", "9c", "7s"}
+    assert cards["Deep"] == {"5s", "6d", "7h", "8c", "4d", "2s", "3c"}
+
+
 @pytest.mark.parametrize(
     ("hero_cards", "opponent_cards", "low_winners", "hero_highlights"),
     [
@@ -121,6 +140,7 @@ def test_frame_handles_scoops_ties_and_no_low(
     assert players[1].winning_cards == ({"Ac", "2d", "3c", "4d", "6h"} if "Player5" in low_winners else set())
 
 
+@pytest.mark.qt
 def test_low_winner_render_highlights_five_cards_and_dims_other_two(stud_replayer, qapp):
     player = stud_replayer._frame_from_state(stud_replayer.states[0]).players[1]
     layout = build_replay_layout(1600, 900, ["Hero", "Player5"], hero_name="Hero")

--- a/test/unit_legacy/test_replayer_stud_hilo.py
+++ b/test/unit_legacy/test_replayer_stud_hilo.py
@@ -1,0 +1,174 @@
+"""Regression tests for the Stud Hi/Lo showdown frame and its renderer."""
+
+from decimal import Decimal
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from fpdb_3_legacy import Card
+from fpdb_3_legacy.GuiReplayer import GuiReplayer, ReplayPlayer, build_replay_layout
+
+
+@pytest.fixture
+def stud_replayer():
+    players = [
+        ReplayPlayer(
+            "Hero", 1, Decimal(0), Decimal("23.30"), "collected", True, ["5s", "6d", "7d", "8s", "4s", "Kd", "5h"]
+        ),
+        ReplayPlayer(
+            "Player5", 5, Decimal(0), Decimal("23.30"), "collected", True, ["2h", "Ac", "As", "7c", "Ks", "4c", "8h"]
+        ),
+    ]
+    hand = SimpleNamespace(
+        gametype={"base": "stud", "category": "studhilo"},
+        collectees={p.name: p.chips for p in players},
+        showdownStrings={},
+        winningHand={},
+    )
+    state = SimpleNamespace(
+        players={p.name: p for p in players},
+        ended=True,
+        street="SEVENTH",
+        board={},
+        renderBoard=set(),
+        newpot=Decimal(0),
+        computePots=lambda: [],
+    )
+    replayer = SimpleNamespace(
+        replay_model=SimpleNamespace(hand=hand),
+        states=[state],
+        stateSlider=SimpleNamespace(value=lambda: 0),
+        Heroes="Hero",
+        showCards=SimpleNamespace(isChecked=lambda: True),
+        currency_code="USD",
+        height=lambda: 900,
+        cardwidth=70,
+        cardheight=100,
+    )
+    for method in ("_normalized_cards", "_frame_from_state", "_visible_cards", "_draw_cards"):
+        setattr(replayer, method, MethodType(getattr(GuiReplayer, method), replayer))
+    return replayer
+
+
+@pytest.mark.parametrize("explicit_cards", [False, True])
+def test_showdown_frame_uses_only_the_won_half(stud_replayer, explicit_cards):
+    state = stud_replayer.states[0]
+    if explicit_cards:
+        stud_replayer.replay_model.hand.winningHand = {p.name: p.holecards for p in state.players.values()}
+
+    hero, low_winner = stud_replayer._frame_from_state(state).players
+
+    assert hero.hi_winner and not hero.lo_winner
+    assert hero.winning_cards == {"5s", "6d", "7d", "8s", "4s"}
+    assert low_winner.lo_winner and not low_winner.hi_winner
+    assert low_winner.winning_cards == {"8h", "7c", "4c", "2h", "Ac"}
+    assert len(low_winner.winning_cards) == 5
+    assert low_winner.is_winner
+
+
+def test_no_winning_highlights_before_showdown(stud_replayer):
+    state = stud_replayer.states[0]
+    state.ended = False
+    for player in stud_replayer._frame_from_state(state).players:
+        assert not player.winning_cards
+        assert not player.hi_winner and not player.lo_winner
+
+
+@pytest.mark.parametrize(
+    ("hero_cards", "opponent_cards", "low_winners", "hero_highlights"),
+    [
+        # A scoop can legitimately use all seven cards across its two halves.
+        (
+            ["As", "Ah", "Ad", "2c", "3d", "4h", "6s"],
+            ["Ks", "Kh", "Qc", "Jc", "9c", "8d", "7d"],
+            {"Hero"},
+            {"As", "Ah", "Ad", "2c", "3d", "4h", "6s"},
+        ),
+        # A tied low belongs to both players, with only one Ace per low hand.
+        (
+            ["As", "Ah", "Ad", "2c", "3d", "4h", "6s"],
+            ["Ac", "2d", "3c", "4d", "6h", "Kd", "Qh"],
+            {"Hero", "Player5"},
+            {"As", "Ah", "Ad", "2c", "3d", "4h", "6s"},
+        ),
+        # Without a qualifying low, the high hand takes the whole pot.
+        (
+            ["As", "Ah", "Ad", "Tc", "9d", "4h", "6s"],
+            ["Ks", "Kh", "Qc", "Jc", "9c", "8d", "7d"],
+            set(),
+            {"As", "Ah", "Ad", "Tc", "9d"},
+        ),
+    ],
+)
+def test_frame_handles_scoops_ties_and_no_low(
+    stud_replayer,
+    hero_cards,
+    opponent_cards,
+    low_winners,
+    hero_highlights,
+):
+    state = stud_replayer.states[0]
+    state.players["Hero"].holecards = hero_cards
+    state.players["Player5"].holecards = opponent_cards
+    stud_replayer.replay_model.hand.collectees = {name: Decimal("23.30") for name in {"Hero"} | low_winners}
+
+    players = stud_replayer._frame_from_state(state).players
+
+    assert {p.name for p in players if p.hi_winner} == {"Hero"}
+    assert {p.name for p in players if p.lo_winner} == low_winners
+    assert players[0].winning_cards == hero_highlights
+    assert players[1].winning_cards == ({"Ac", "2d", "3c", "4d", "6h"} if "Player5" in low_winners else set())
+
+
+def test_low_winner_render_highlights_five_cards_and_dims_other_two(stud_replayer, qapp):
+    player = stud_replayer._frame_from_state(stud_replayer.states[0]).players[1]
+    layout = build_replay_layout(1600, 900, ["Hero", "Player5"], hero_name="Hero")
+    # Use card tokens as pixmap sentinels to inspect the actual drawing calls.
+    stud_replayer.cardImages = {Card.encodeCard(card): card for card in player.holecards}
+    cards_painter = Mock()
+    draw_cards = stud_replayer._draw_cards
+    stud_replayer._draw_cards = Mock(
+        side_effect=lambda _painter, *args, **kwargs: draw_cards(cards_painter, *args, **kwargs)
+    )
+    painter = Mock()
+
+    GuiReplayer._draw_player(
+        stud_replayer,
+        painter,
+        player,
+        layout.seats[player.name],
+        layout,
+        "SEVENTH",
+        True,
+    )
+
+    kwargs = stud_replayer._draw_cards.call_args.kwargs
+    assert kwargs["highlight"] == {"8h", "7c", "4c", "2h", "Ac"}
+    assert kwargs["dim_others"] is True
+    assert cards_painter.drawRoundedRect.call_count == 5
+    dimmed = []
+    faded = False
+    for call in cards_painter.method_calls:
+        if call[0] == "setOpacity":
+            faded = call.args[0] < 1
+        elif call[0] == "restore":
+            faded = False
+        elif call[0] == "drawPixmap" and faded:
+            dimmed.append(call.args[1])
+    assert dimmed == ["As", "Ks"]
+    assert any("LO winner" in call.args[-1] for call in painter.drawText.call_args_list)
+
+
+@pytest.mark.parametrize("with_descriptions", [False, True])
+def test_timeline_identifies_each_half_even_without_showdown_descriptions(stud_replayer, with_descriptions):
+    if with_descriptions:
+        stud_replayer.replay_model.hand.showdownStrings = {
+            "Hero": "HI: a straight, Four to Eight; LO: 8,7,6,5,4",
+            "Player5": "HI: a pair of Aces; LO: 8,7,4,2,A",
+        }
+
+    entries = GuiReplayer._timeline_entries(stud_replayer)
+
+    assert any(entry.startswith("Hero:") and "HI winner" in entry for entry in entries)
+    assert any(entry.startswith("Player5:") and "LO winner" in entry for entry in entries)

--- a/tests/fixtures/hands/live_parser_snapshots.json
+++ b/tests/fixtures/hands/live_parser_snapshots.json
@@ -113,15 +113,15 @@
   },
   "pokerstars/mixed/horse.txt": {
     "hand_count": 1,
-    "sha256": "80ecb84cd1a2071344cf39512eb78289d5719b7f168bdc260f52bcd9f1e36aaf"
+    "sha256": "9b95ab93bd533347d833f87dc285c1fd8b742ee8918e00bb10e32192348e76d7"
   },
   "pokerstars/stud/7stud.txt": {
     "hand_count": 1,
-    "sha256": "30ccbd3ae4146bb9635dbbae6d6f8300cfa2765f82aa713eecdb7ef1a5d5edb0"
+    "sha256": "7489b9e59b3e3a5a70668fcb52709ee21b9e793e719b67f1a2934c8018263010"
   },
   "pokerstars/stud/razz.txt": {
     "hand_count": 1,
-    "sha256": "188244dde74753315d8a659f50c410ebeef24f0d1a8e7c1d1f490c36f5810491"
+    "sha256": "a18a3d086ed0bb5c383c79b639a884865da96e19f64cc51c8ff1164aec8072fb"
   },
   "regression/Absolute/Flop/IHH20090610 Chile Way - Hold'em No Limit $0.02(Real Money) Table 9339866.txt": {
     "hand_count": 1,
@@ -2009,31 +2009,31 @@
   },
   "regression/Stars/Stud/7-Stud-USD-0.04-0.08-200907.Missing.Showdown.Card.txt": {
     "hand_count": 1,
-    "sha256": "698062156b3fc657d4f8e9805c75ea68ef78c1cab40d3c159f2b9088a1da7019"
+    "sha256": "beaf43e6b2bb3b89e577d3ff28782b9aac811eb15d7dc6a257f6653519a570a8"
   },
   "regression/Stars/Stud/7-Stud-USD-0.04-0.08-200911.txt": {
     "hand_count": 11,
-    "sha256": "437fecfb8f09574cb1baa62dfd7524540b0522984e31bdc54fa0b94dcf37015c"
+    "sha256": "f2fe6e04d0ad666ab287a4986113303f9afef8d4ad583f12acf5182bbcde8af3"
   },
   "regression/Stars/Stud/7-StudHL-USD-0.04-0.08-200911.Cardtest.txt": {
     "hand_count": 1,
-    "sha256": "fe411d4b03e400c1e297043697cec6e6b774f546c771c9c6dfa07e077967bda0"
+    "sha256": "3a4cc293f547fc59b8669f509ae4004a540bab046557f1dd6ae5e60407f580a1"
   },
   "regression/Stars/Stud/7-StudHL-USD-0.04-0.08-200911.txt": {
     "hand_count": 7,
-    "sha256": "dd4ba18029f83c7636dd75e70facf7f8f6af81426cbb392b36ff49c1b2ed6737"
+    "sha256": "70554c33b0c7ff2de047169e93e79026c55ef2fdff7051151401603d60ccce05"
   },
   "regression/Stars/Stud/7-StudHL-USD-400-800-201701.3bet.fix.txt": {
     "hand_count": 1,
-    "sha256": "48d03fb75955017f543260436e3212dc9137337f30eb4fcacc4f75afda2d8970"
+    "sha256": "008e6b711a54e250e9e0f67c2976d6aa1ebc70369168ff2e2646ff49fa74fe73"
   },
   "regression/Stars/Stud/HH20110417 Salm IX - $0.04-$0.08 Ante $0.01 - USD Limit Stud.txt": {
     "hand_count": 1,
-    "sha256": "32f00fdf51497da91c377c52905e45a2315b4f363a9fe57bd7c301e7bf1bbe3b"
+    "sha256": "62c401eed7a8f5ccb5b7953c7101b2b60e5dd660d68c1a264fbc9704fc5ea86a"
   },
   "regression/Stars/Stud/Razz-USD-0.04-0.08-200911.txt": {
     "hand_count": 9,
-    "sha256": "8cea5a8bdf7e5e43abb5587a2d4dd9cf3370d5b6568fbad6bfa8ac29781aad9a"
+    "sha256": "08d907ed789413882e06946752767ea707e0febfc083bea9c4ad042b74d8934b"
   },
   "regression/UltimateBet/Flop/IHH20101106 Baseline Rd - Hold'em No Limit $0.02(Real Money) Table 25932774.txt": {
     "hand_count": 1,


### PR DESCRIPTION
## Summary

Fix PokerStars Stud Hi/Lo parsing and replayer results for hands whose text uses spaced stake separators or ambiguous showdown descriptions.

- Normalize only the hand header, supporting all PokerStars currency symbols handled by the parser, while preserving player and table names.
- Store Stud fixed-limit stakes using the underlying small-bet value so `$2.50/$5` hands keep the correct game type and statistics.
- Evaluate Hi/Lo winners separately for every eligible main or side pot.
- Highlight exactly the five cards used by a winning low (or high) hand and dim the remaining cards in the replayer.
- Keep winner labels available when PokerStars omits hand descriptions.
- Prevent uncalled bets from being counted twice in pot, bet, and net totals.

## Validation

- `test/test_pokerstars.py`: 170 passed.
- Live parser regression corpus and PokerStars parser checks without Qt: 1,397 passed.
- Stud Hi/Lo replayer tests without Qt: 10 passed, 1 deselected.
- Qt rendering regression test: 1 passed with `QT_QPA_PLATFORM=offscreen`.
- `mypy` and Ruff checks pass for the changed modules.
- Refreshed the ten affected parser snapshot digests after the intentional Stud/Razz output changes.
- GitHub CI run 33897075654 passed all checks; a new run was triggered by this follow-up fix.

Closes #288
