### PR TITLE
Fix stale HUD configuration version checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  config-version:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check configuration template versions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python3 tools/check_config_version.py --base "$BASE_SHA"
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
       - name: Check configuration template versions
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: python3 tools/check_config_version.py --base "$BASE_SHA"
+        run: |
+          base_dir="$RUNNER_TEMP/fpdb-config-base"
+          mkdir -p "$base_dir/fpdb_3_legacy"
+          for path in HUD_config.xml HUD_config.xml.example fpdb_3_legacy/HUD_config.xml.example; do
+            git show "$BASE_SHA:$path" > "$base_dir/$path"
+          done
+          python3 tools/check_config_version.py --base-dir "$base_dir"
 
   quality:
     runs-on: ubuntu-latest

--- a/HUD_config.xml
+++ b/HUD_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><FreePokerToolsConfig>
-    <general version="83" config_wrap_len="-1" day_start="5" ui_language="fr_FR" config_difficulty="expert" qt_material_theme="dark_purple.xml" popup_theme="material_dark"/>
+    <general version="84" config_wrap_len="-1" day_start="5" ui_language="fr_FR" config_difficulty="expert" qt_material_theme="dark_purple.xml" popup_theme="material_dark"/>
     <site_ids>
         <site_id site="Full Tilt Poker" id="1"/>
         <site_id site="PokerStars" id="2"/>

--- a/HUD_config.xml.example
+++ b/HUD_config.xml.example
@@ -3,7 +3,7 @@
     <!-- config_wrap_len  is preferred max line length in this file, -1 means no max
          day_start        is time that logical day starts, e.g. 5 means that any play
                           between 00:00 and 04:59:59 counts as being on the previous day -->
-    <general version="83" config_wrap_len="-1" day_start="5" ui_language="system" config_difficulty="expert"/>
+    <general version="84" config_wrap_len="-1" day_start="5" ui_language="system" config_difficulty="expert"/>
 
     <import callFpdbHud="True" interval="5" fastStoreHudCache="False" saveActions="True" cacheSessions="False" sessionTimeout="30" publicDB="False"/>
 
@@ -347,7 +347,7 @@
 
         <site site_name="Bovada" enabled="False" screen_name="YOUR SCREEN NAME HERE" site_path="C:/Bovada/" HH_path="C:/Bovada/" aux_enabled="True" hud_menu_xshift="0" hud_menu_yshift="0">
             <email fetchType="request-summary" host="YOUR_EMAIL_SERVER" username="YOUR_EMAIL_USERNAME" password="YOUR_EMAIL_PASSWORD" useSsl="True" folder="INBOX"/>
-            <layout_set game_type="all" ls="bodova_default"/>
+            <layout_set game_type="all" ls="bovada_default"/>
             <fav max="2" fav_seat="0"/>
             <fav max="4" fav_seat="0"/>
             <fav max="6" fav_seat="0"/>
@@ -466,6 +466,13 @@
         </game>
         <game game_name="6_omahahi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
+        </game>
+        <game game_name="fusion" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
+            <game_stat_set game_type="tour" stat_set="omaha_default"/>
+        </game>
+        <game game_name="aof_holdem" aux="ClassicHud, mucked">
+            <game_stat_set game_type="all" stat_set="aof_advanced"/>
         </game>
     </supported_games>
 

--- a/docs/configuration-upgrades.md
+++ b/docs/configuration-upgrades.md
@@ -1,0 +1,35 @@
+# Configuration upgrades
+
+Configuration schema 84 restores the startup warning for version-83 files.
+At startup, **Back up and upgrade** merges missing named definitions from the
+shipped example and repairs dangling `Classic_HUD` and `bodova_default` aliases.
+Existing profiles, game bindings, layouts, sites, folders, screen names,
+favourite seats and database settings remain intact. Custom definitions are
+not overwritten. Every unresolved aux, stat-set and layout binding is reported,
+even when the version matches.
+
+The upgrade is prepared on a copy and validated before writing. Unknown versions
+and remaining unresolved references require manual correction; their version is
+not advanced. A unique `HUD_config.xml.pre-upgrade-*.xml` backup is written beside
+the configuration before atomic replacement. To restore it, close fpdb and copy
+that backup over HUD_config.xml. Ordinary `.backup` rotation cannot overwrite it.
+
+## Maintaining templates
+
+When either shipped XML template changes, increment CONFIG_VERSION and both
+`general` versions. CI compares the PR with its base and rejects unversioned
+changes or inconsistent markers. Add an ordered `(from, to, callable)` step to
+`config_migrations.MIGRATIONS`; use explicit, conservative transformations.
+The existing idempotent Entain/AoF repair helpers still run independently for
+compatibility with current files. They are not evidence of a schema upgrade.
+
+## Database versions
+
+This fix does not invent migrations for historical database schemas. An
+incompatible database remains flagged. Recreating tables deletes imported hands
+and statistics and requires original histories for reimport. The startup warning
+now explains this and offers the existing diagnostic text export, with errors
+reported if the old schema cannot be exported. That text format is not a
+restorable backup: preserve a native database backup and original hand histories
+before recreating tables. A database schema migration needs separately verified
+steps for each supported historical version and backend.

--- a/fpdb_3_legacy/Configuration.py
+++ b/fpdb_3_legacy/Configuration.py
@@ -59,9 +59,8 @@ from fpdb_3_legacy.loggingFpdb import get_logger
 
 # config version is used to flag a warning at runtime if the users config is
 #  out of date.
-# The CONFIG_VERSION should be incremented __ONLY__ if the add_missing_elements()
-#  method cannot update existing standard configurations
-CONFIG_VERSION = 83
+# Increment with shipped template changes; add an explicit migration when needed.
+CONFIG_VERSION = 84
 SOURCE_DIR = Path(__file__).resolve().parent
 SOURCE_ROOT_PATH = SOURCE_DIR.parent
 
@@ -1218,7 +1217,7 @@ class General(dict):
 
         try:
             self["version"] = int(self["version"])
-        except KeyError:
+        except (KeyError, ValueError):
             self["version"] = 0
             self["ui_language"] = "system"
             self["config_difficulty"] = "expert"
@@ -1668,6 +1667,12 @@ class Config:
         if migrated:
             self.save()  # keeps a .backup of the pre-migration config
 
+        from fpdb_3_legacy.config_migrations import reference_errors
+
+        self.config_reference_errors = reference_errors(doc)
+        for error in self.config_reference_errors:
+            log.warning("Configuration %s: %s", self.file, error)
+
         #        s_sites = doc.getElementsByTagName("supported_sites")
         for site_node in doc.getElementsByTagName("site"):
             site = Site(node=site_node)
@@ -1798,6 +1803,19 @@ class Config:
             if self.db_selected is None or db.db_selected:
                 self.db_selected = db.db_name
             self.supported_databases[db.db_name] = db
+
+    def upgrade_config(self) -> str:
+        """Upgrade against the bundled template, preserving personal settings."""
+        from fpdb_3_legacy.config_migrations import upgrade_document, write_upgrade
+
+        source = _find_example_config("HUD_config.xml")
+        template = _parse_example_config(source)
+        if template is None:
+            raise ValueError(f"Cannot read configuration template {source}")
+        candidate = upgrade_document(self.doc, template, CONFIG_VERSION)
+        backup = write_upgrade(self.file, candidate)
+        log.warning("Configuration upgraded to %s; backup: %s", CONFIG_VERSION, backup)
+        return backup
 
     def _migrate_entain_fr_sites_to_ipoker(self, doc) -> bool:
         """Rewrite pre-2026 Entain France skins from PartyPoker to iPoker.
@@ -2039,6 +2057,9 @@ class Config:
                             and doc.getElementsByTagName(example_node.localName) == []
                         ):
                             new = doc.importNode(example_node, True)  # True means do deep copy
+                            if example_node.localName == "general":
+                                # Adding defaults is not a schema migration.
+                                new.setAttribute("version", "0")
                             t_node = self.doc.createTextNode("    ")
                             cnode.appendChild(t_node)
                             # A section the user has never seen arrives empty and

--- a/fpdb_3_legacy/Database.py
+++ b/fpdb_3_legacy/Database.py
@@ -724,7 +724,8 @@ class Database(
             settings = self.cursor.fetchone()
             if settings[0] != DB_VERSION:
                 log.error(
-                    f"Outdated or too new database version ({settings[0]}). Please recreate tables.",
+                    f"Outdated or too new database version ({settings[0]}). Back up the database first: "
+                    "recreating tables deletes all imported hands and statistics and requires reimport.",
                 )
                 self.wrongDbVersion = True
         except Exception:  # intentional broad catch: settings-table read failure triggers cross-backend table recreate

--- a/fpdb_3_legacy/HUD_config.xml.example
+++ b/fpdb_3_legacy/HUD_config.xml.example
@@ -7,6 +7,61 @@
 
     <import callFpdbHud="True" interval="5" fastStoreHudCache="False" saveActions="True" cacheSessions="False" sessionTimeout="30" publicDB="False"/>
 
+    <autonotes enabled="True" maxPerHand="20" maxPerPlayerPerHand="3">
+        <ruleset name="hwang_plo_preflop" enabled="True">
+            <rule id="hwang_plo_081" enabled="True"/>
+            <rule id="hwang_plo_082" enabled="True"/>
+            <rule id="hwang_plo_083" enabled="True"/>
+            <rule id="hwang_plo_084" enabled="True"/>
+            <rule id="hwang_plo_085" enabled="True"/>
+            <rule id="hwang_plo_086" enabled="True"/>
+            <rule id="hwang_plo_087" enabled="True"/>
+        </ruleset>
+        <ruleset name="holdem_cash_preflop" enabled="False">
+            <rule id="holdem_cash_001" enabled="True"/>
+            <rule id="holdem_cash_002" enabled="True"/>
+            <rule id="holdem_cash_003" enabled="True"/>
+        </ruleset>
+        <ruleset name="tournament_push_fold" enabled="False">
+            <rule id="tourney_pf_001" enabled="True"/>
+            <rule id="tourney_pf_002" enabled="True"/>
+            <rule id="tourney_pf_003" enabled="True"/>
+        </ruleset>
+        <ruleset name="plo_spr_postflop" enabled="False">
+            <rule id="plo_spr_001" enabled="True"/>
+            <rule id="plo_spr_002" enabled="True"/>
+            <rule id="plo_spr_003" enabled="True"/>
+        </ruleset>
+        <ruleset name="flop_texture" enabled="False">
+            <rule id="flop_texture_001" enabled="True"/>
+            <rule id="flop_texture_002" enabled="True"/>
+            <rule id="flop_texture_003" enabled="True"/>
+        </ruleset>
+        <ruleset name="showdown_quality" enabled="False">
+            <rule id="showdown_quality_001" enabled="True"/>
+            <rule id="showdown_quality_002" enabled="True"/>
+            <rule id="showdown_quality_003" enabled="True"/>
+        </ruleset>
+        <ruleset name="hero_relative" enabled="False">
+            <rule id="hero_relative_001" enabled="True"/>
+            <rule id="hero_relative_002" enabled="True"/>
+            <rule id="hero_relative_003" enabled="True"/>
+            <rule id="hero_relative_004" enabled="True"/>
+        </ruleset>
+        <ruleset name="range_capture" enabled="False">
+            <rule id="range_capture_001" enabled="True"/>
+            <rule id="range_capture_002" enabled="True"/>
+            <rule id="range_capture_003" enabled="True"/>
+            <rule id="range_capture_004" enabled="True"/>
+        </ruleset>
+        <ruleset name="stud_draw_first_street" enabled="False">
+            <rule id="stud_draw_001" enabled="True"/>
+            <rule id="stud_draw_002" enabled="True"/>
+            <rule id="stud_draw_003" enabled="True"/>
+            <rule id="stud_draw_004" enabled="True"/>
+        </ruleset>
+    </autonotes>
+
 
     <gui_cash_stats>
         <col col_name="game" disp_all="True" disp_posn="True" col_title="Game" xalignment="0.0" field_format="%s" field_type="str"/>
@@ -102,7 +157,21 @@
           16.7 (50 divided by 3) to big blind of 150 (50 times 3) are included
         - To include all levels, use a value of "10000"
 -->
-    <hud_ui stat_range="A" stat_days="90" aggregation_level_multiplier="3" seats_style="A" seats_cust_nums_low="6" seats_cust_nums_high="10" hero_stat_range="A" hero_stat_days="30" hero_aggregation_level_multiplier="1" hero_seats_style="A" hero_seats_cust_nums_low="6" hero_seats_cust_nums_high="10" label="FPDBmenu" card_ht="39" card_wd="28" deck_type="colour" card_back="back04"/>
+    <hud_ui stat_range="A" stat_days="90" aggregation_level_multiplier="3" seats_style="A" seats_cust_nums_low="6" seats_cust_nums_high="10" hero_stat_range="A" hero_stat_days="30" hero_aggregation_level_multiplier="1" hero_seats_style="A" hero_seats_cust_nums_low="6" hero_seats_cust_nums_high="10" label="FPDBmenu" card_ht="39" card_wd="28" deck_type="colour" card_back="back04"
+             fast_fold_seat_wait_ms="500"
+             fast_fold_window_seats="auto"/>
+    <!-- fast_fold_window_seats: "auto" reads a Fast-Fold table's chairs off its
+         window, giving up per table once the client has shown it will not answer
+         usefully; "off" never reads. Each read is a synchronous walk of another
+         process's accessibility tree on the GUI thread (94-218ms on a client
+         that answers), so set it off if your client does not publish its table.
+         The seats then come from the client log, as they already do. -->
+    <!-- fast_fold_seat_wait_ms: how long a Fast-Fold table waits for the client
+         log to finish naming its players before showing the ones it has. The log
+         names a player only once they have acted, so a six-handed table is named
+         over several seconds. 500 (the default) shows them as they arrive, one
+         block at a time; a larger value, say 5000, shows them together but later.
+         0 shows the first player the moment there is one. -->
 
 
     <supported_sites>
@@ -400,7 +469,7 @@
         </game>
         <game game_name="fusion" aux="PLO4Hud, mucked">
             <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
-            <game_stat_set game_type="tour" stat_set="plo_pro_html"/>
+            <game_stat_set game_type="tour" stat_set="omaha_default"/>
         </game>
         <game game_name="aof_holdem" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="aof_advanced"/>
@@ -1748,15 +1817,36 @@
             <stat _rowcol="(6,3)" _stat_name="aof_showdowns" popup="aof_profile" hudbgcolor="#111827" hudprefix="sd " hudsuffix="" tip="" click=""/>
         </ss>
 
-        <ss name="plo_pro_html" rows="2" cols="4" xpad="1" ypad="0" rich_text="True" font_size="10">
-            <stat _rowcol="(1,1)" _stat_name="playershort" popup="default" hudprefix="" hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(1,2)" _stat_name="n" popup="default" hudprefix="H " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(1,3)" _stat_name="vpip" popup="default" hudprefix="VP " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(1,4)" _stat_name="pfr" popup="default" hudprefix="PFR " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(2,1)" _stat_name="three_B" popup="default" hudprefix="3B " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(2,2)" _stat_name="cb1" popup="default" hudprefix="CB " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(2,3)" _stat_name="wtsd" popup="default" hudprefix="SD " hudsuffix="" tip="" click=""/>
-            <stat _rowcol="(2,4)" _stat_name="totalprofit" popup="default" hudprefix="P " hudsuffix="" tip="" click=""/>
+        <ss name="plo_pro_html" rows="5" cols="4" xpad="1" ypad="0" rich_text="True" font_size="10">
+            <!-- Row 1: Player Identity & Session Info -->
+            <stat _rowcol="(1,1)" _stat_name="playershort" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="" click="open_comment_dialog" hudcolor="#98FFB0"/>
+            <stat _rowcol="(1,2)" _stat_name="player_note" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="" hudsuffix="" tip="Notes" click="open_comment_dialog"/>
+            <stat _rowcol="(1,3)" _stat_name="n" popup="plo_popup_full" hudbgcolor="#0F172A" hudprefix="H " hudsuffix="" tip="Hands" click=""/>
+            <stat _rowcol="(1,4)" _stat_name="profit100" popup="plo_popup_showdown" hudbgcolor="#0F172A" hudprefix="bb " hudsuffix="" tip="Profit bb/100" click="" stat_hicolor="#4ADE80" stat_locolor="#FF6B6B" stat_loth="0"/>
+
+            <!-- Row 2: Preflop Core -->
+            <stat _rowcol="(2,1)" _stat_name="vpip" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="VP " tip="Voluntarily Put Money In Pot" click="" stat_loth="20" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,2)" _stat_name="pfr" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="PR " tip="Preflop Raise" click="" stat_loth="14" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="24" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,3)" _stat_name="three_B" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="3B " tip="3-Bet Percentage" click="" stat_loth="5" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="11" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(2,4)" _stat_name="f_3bet" popup="plo_popup_preflop" hudbgcolor="#1E1B4B" hudprefix="F3 " tip="Fold to 3-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="45" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 3: Preflop Advanced Ranges & Steals -->
+            <stat _rowcol="(3,1)" _stat_name="cold_call" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="CC " tip="Cold Call" click="" stat_loth="6" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,2)" _stat_name="four_B" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="4B " tip="4-Bet Percentage" click="" stat_loth="2" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="6" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,3)" _stat_name="fold_vs_4bet" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="F4 " tip="Fold to 4-Bet" click="" stat_loth="25" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(3,4)" _stat_name="squeeze" popup="plo_popup_preflop" hudbgcolor="#162033" hudprefix="SQ " tip="Squeeze" click="" stat_loth="4" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="10" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 4: Flop Response & Aggression -->
+            <stat _rowcol="(4,1)" _stat_name="cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="CBF " tip="Flop C-Bet" click="" stat_loth="40" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="65" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,2)" _stat_name="f_cb1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="FCF " tip="Fold to Flop C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,3)" _stat_name="dbr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="DBF " tip="Donk Bet Flop" click="" stat_loth="10" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="25" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(4,4)" _stat_name="cr1" popup="plo_popup_flop" hudbgcolor="#132B25" hudprefix="XRF " tip="Check-Raise Flop" click="" stat_loth="8" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="18" stat_hicolor="#FF6B6B"/>
+
+            <!-- Row 5: Turn, River & Showdown -->
+            <stat _rowcol="(5,1)" _stat_name="cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="CBT " tip="Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="60" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,2)" _stat_name="f_cb2" popup="plo_popup_turn" hudbgcolor="#2D1A37" hudprefix="FCT " tip="Fold to Turn C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,3)" _stat_name="cb3" popup="plo_popup_river" hudbgcolor="#2D1A37" hudprefix="CBR " tip="River C-Bet" click="" stat_loth="35" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="55" stat_hicolor="#FF6B6B"/>
+            <stat _rowcol="(5,4)" _stat_name="wtsd" popup="plo_popup_showdown" hudbgcolor="#2D1A37" hudprefix="WT " tip="Went to Showdown" click="" stat_loth="24" stat_locolor="#4CC9F0" stat_midcolor="#F2F4E6" stat_hith="32" stat_hicolor="#FF6B6B"/>
         </ss>
 
         <ss name="omaha_default" rows="3" cols="2" xpad="1" ypad="0">
@@ -2081,34 +2171,117 @@
         <pu_stat pu_stat_name="aof_splash_freq" pu_stat_category="💰 SPLASH POTS &amp; NOTES" pu_stat_label="Splash Frequency"/>
         <pu_stat pu_stat_name="player_note" pu_stat_category="💰 SPLASH POTS &amp; NOTES" pu_stat_label="Player Notes"/>
     </pu>
-</popup_windows>
+        <!-- ULTRA-MODERN PLO HTML CATEGORIZED POPUPS -->
+        <pu pu_name="plo_popup_preflop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO PREFLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP (Voluntarily Put In Pot)"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="PFR (Preflop Raise)"/>
+            <pu_stat pu_stat_name="vpip_pfr_ratio" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="VPIP / PFR Ratio"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="rfi_early_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Early Position (EP)"/>
+            <pu_stat pu_stat_name="rfi_middle_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Middle Position (MP)"/>
+            <pu_stat pu_stat_name="rfi_late_position" pu_stat_category="🎯 PREFLOP IDENTITY &amp; RFI" pu_stat_label="RFI Late Position (CO/BTN)"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="fold_to_squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to Squeeze %"/>
+            <pu_stat pu_stat_name="limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Limp %"/>
+            <pu_stat pu_stat_name="open_limp" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Open Limp %"/>
+            <pu_stat pu_stat_name="cold_call" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Cold Call %"/>
+            <pu_stat pu_stat_name="steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Steal Attempt %"/>
+            <pu_stat pu_stat_name="f_SB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold SB to Steal %"/>
+            <pu_stat pu_stat_name="f_BB_steal" pu_stat_category="🛑 PASSIVE &amp; STEAL ACTIONS" pu_stat_label="Fold BB to Steal %"/>
+        </pu>
+        <pu pu_name="plo_popup_flop" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO FLOP PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cb_ip" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet In Position (IP)"/>
+            <pu_stat pu_stat_name="cb_oop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Flop C-Bet Out of Position (OOP)"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="avg_bet_size_flop" pu_stat_category="🟢 FLOP CONTINUATION &amp; POSITION" pu_stat_label="Avg Bet Size Flop (% pot)"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="check_raise_frequency" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Overall Check-Raise Freq"/>
+            <pu_stat pu_stat_name="dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="f_dbr1" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Flop %"/>
+            <pu_stat pu_stat_name="bet_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Bet Frequency Flop"/>
+            <pu_stat pu_stat_name="raise_frequency_flop" pu_stat_category="💥 FLOP AGGRESSION &amp; DEFENSE" pu_stat_label="Raise Frequency Flop"/>
+        </pu>
+        <pu pu_name="plo_popup_turn" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO TURN PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="f_dbr2" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Fold to Donk Bet Turn %"/>
+            <pu_stat pu_stat_name="probe_bet_turn" pu_stat_category="🟡 TURN BARRELING &amp; DEFENSE" pu_stat_label="Probe Bet Turn %"/>
+            <pu_stat pu_stat_name="bet_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Bet Frequency Turn"/>
+            <pu_stat pu_stat_name="raise_frequency_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Raise Frequency Turn"/>
+            <pu_stat pu_stat_name="avg_bet_size_turn" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Avg Bet Size Turn (% pot)"/>
+            <pu_stat pu_stat_name="a_freq2" pu_stat_category="📊 TURN AGGRESSION &amp; SIZING" pu_stat_label="Turn Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_river" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO RIVER PROFILE: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="cr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Check-Raise River %"/>
+            <pu_stat pu_stat_name="dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Donk Bet River %"/>
+            <pu_stat pu_stat_name="f_dbr3" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Fold to Donk Bet River %"/>
+            <pu_stat pu_stat_name="probe_bet_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Probe Bet River %"/>
+            <pu_stat pu_stat_name="avg_bet_size_river" pu_stat_category="🔴 RIVER BARRELING &amp; EFFICIENCY" pu_stat_label="Avg Bet Size River (% pot)"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="overbet_frequency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="Overbet Frequency"/>
+            <pu_stat pu_stat_name="river_call_efficiency" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Call Efficiency"/>
+            <pu_stat pu_stat_name="a_freq3" pu_stat_category="🔥 TRIPLE BARREL &amp; OVERBETS" pu_stat_label="River Aggression Freq"/>
+        </pu>
+        <pu pu_name="plo_popup_showdown" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="PLO SHOWDOWN &amp; RESULTS: {player}" pu_width="440" pu_max_height="520">
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WTSD% (Went To Showdown)"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WSD% (Won Money at Showdown)"/>
+            <pu_stat pu_stat_name="wwsf" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WWSF% (Won When Saw Flop)"/>
+            <pu_stat pu_stat_name="WMsF" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="WMsF% (Won Money Saw Flop)"/>
+            <pu_stat pu_stat_name="sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="non_sd_winrate" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Non-Showdown Winrate (bb/100)"/>
+            <pu_stat pu_stat_name="totalprofit" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Total Profit ($)"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; WINRATES" pu_stat_label="Profit bb/100"/>
+        </pu>
+        <pu pu_name="plo_popup_full" pu_class="CategorizedPopup" pu_theme="hud_dark" pu_icon_provider="emoji" pu_title="FULL PLO PROFILE: {player}" pu_width="460" pu_max_height="600">
+            <pu_stat pu_stat_name="vpip" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="VPIP"/>
+            <pu_stat pu_stat_name="pfr" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="PFR"/>
+            <pu_stat pu_stat_name="rfi_total" pu_stat_category="🎯 PREFLOP CORE &amp; RFI" pu_stat_label="RFI Total"/>
+            <pu_stat pu_stat_name="three_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="3-Bet %"/>
+            <pu_stat pu_stat_name="f_3bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 3-Bet %"/>
+            <pu_stat pu_stat_name="four_B" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="4-Bet %"/>
+            <pu_stat pu_stat_name="fold_vs_4bet" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Fold to 4-Bet %"/>
+            <pu_stat pu_stat_name="squeeze" pu_stat_category="⚔️ 3-BET &amp; 4-BET WAR" pu_stat_label="Squeeze %"/>
+            <pu_stat pu_stat_name="cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Flop C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Fold to Flop C-Bet %"/>
+            <pu_stat pu_stat_name="cr1" pu_stat_category="🟢 FLOP ACTION" pu_stat_label="Check-Raise Flop %"/>
+            <pu_stat pu_stat_name="cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Turn C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Fold to Turn C-Bet %"/>
+            <pu_stat pu_stat_name="cr2" pu_stat_category="🟡 TURN ACTION" pu_stat_label="Check-Raise Turn %"/>
+            <pu_stat pu_stat_name="cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="River C-Bet %"/>
+            <pu_stat pu_stat_name="f_cb3" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Fold to River C-Bet %"/>
+            <pu_stat pu_stat_name="triple_barrel" pu_stat_category="🔴 RIVER ACTION" pu_stat_label="Triple Barrel %"/>
+            <pu_stat pu_stat_name="wtsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WTSD %"/>
+            <pu_stat pu_stat_name="wmsd" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="WSD %"/>
+            <pu_stat pu_stat_name="profit100" pu_stat_category="🏆 SHOWDOWN &amp; RESULTS" pu_stat_label="Profit bb/100"/>
+        </pu>
+    </popup_windows>
 
 
     <hhcs>
         <hhc site="PokerStars" converter="PokerStarsToFpdb" summaryImporter="PokerStarsSummary"/>
-        <hhc site="Full Tilt Poker" converter="FulltiltToFpdb" summaryImporter="FullTiltPokerSummary"/>
-        <hhc site="Everleaf" converter="EverleafToFpdb"/>
-        <hhc site="Boss" converter="BossToFpdb"/>
         <hhc site="PartyPoker" converter="PartyPokerToFpdb"/>
         <hhc site="Betfair" converter="BetfairToFpdb"/>
         <hhc site="Merge" converter="MergeToFpdb" summaryImporter="MergeSummary"/>
-        <hhc site="OnGame" converter="OnGameToFpdb"/>
-        <hhc site="PKR" converter="PkrToFpdb"/>
         <hhc site="iPoker" converter="iPokerToFpdb" summaryImporter="iPokerSummary"/>
         <hhc site="Winamax" converter="WinamaxToFpdb" summaryImporter="WinamaxSummary"/>
-        <hhc site="Everest" converter="EverestToFpdb"/>
         <hhc site="PacificPoker" converter="PacificPokerToFpdb" summaryImporter="PacificPokerSummary"/>
         <hhc site="Cake" converter="CakeToFpdb"/>
-        <hhc site="Entraction" converter="EntractionToFpdb"/>
         <hhc site="BetOnline" converter="BetOnlineToFpdb"/>
-        <hhc site="Microgaming" converter="MicrogamingToFpdb"/>
         <hhc site="Bovada" converter="BovadaToFpdb" summaryImporter="BovadaSummary"/>
-        <hhc site="Enet" converter="EnetToFpdb"/>
         <hhc site="SealsWithClubs" converter="SealsWithClubsToFpdb"/>
         <hhc site="WinningPoker" converter="WinningToFpdb" summaryImporter="WinningSummary"/>
         <hhc site="GGPoker" converter="GGPokerToFpdb"/>
         <hhc site="KingsClub" converter="KingsClubToFpdb"/>
-        <hhc site="Unibet" converter="UnibetToFpdb"/>
+        <hhc site="Unibet" converter="UnibetToFpdb" summaryImporter="UnibetSummary"/>
     </hhcs>
 
 

--- a/fpdb_3_legacy/HUD_config.xml.example
+++ b/fpdb_3_legacy/HUD_config.xml.example
@@ -3,7 +3,7 @@
     <!-- config_wrap_len  is preferred max line length in this file, -1 means no max
          day_start        is time that logical day starts, e.g. 5 means that any play
                           between 00:00 and 04:59:59 counts as being on the previous day -->
-    <general version="83" config_wrap_len="-1" day_start="5" ui_language="system" config_difficulty="expert"/>
+    <general version="84" config_wrap_len="-1" day_start="5" ui_language="system" config_difficulty="expert"/>
 
     <import callFpdbHud="True" interval="5" fastStoreHudCache="False" saveActions="True" cacheSessions="False" sessionTimeout="30" publicDB="False"/>
 
@@ -278,7 +278,7 @@
 
         <site site_name="Bovada" enabled="False" screen_name="YOUR SCREEN NAME HERE" site_path="C:/Bovada/" HH_path="C:/Bovada/" aux_enabled="True" hud_menu_xshift="0" hud_menu_yshift="0">
             <email fetchType="request-summary" host="YOUR_EMAIL_SERVER" username="YOUR_EMAIL_USERNAME" password="YOUR_EMAIL_PASSWORD" useSsl="True" folder="INBOX"/>
-            <layout_set game_type="all" ls="bodova_default"/>
+            <layout_set game_type="all" ls="bovada_default"/>
             <fav max="2" fav_seat="0"/>
             <fav max="4" fav_seat="0"/>
             <fav max="6" fav_seat="0"/>
@@ -332,70 +332,70 @@
         The parameter elements for each <game> can be extended
         without changing Configuration.Config()
         -->
-        <game game_name="holdem" aux="Classic_HUD, mucked">
+        <game game_name="holdem" aux="ClassicHud, mucked">
             <game_stat_set game_type="tour" stat_set="holdem_tour"/>
             <game_stat_set game_type="ring" stat_set="holdem_ring"/>
         </game>
-        <game game_name="2_holdem" aux="Classic_HUD, mucked">
+        <game game_name="2_holdem" aux="ClassicHud, mucked">
             <game_stat_set game_type="tour" stat_set="holdem_tour"/>
             <game_stat_set game_type="ring" stat_set="holdem_ring"/>
         </game>
-        <game game_name="irish" aux="Classic_HUD, mucked">
+        <game game_name="irish" aux="ClassicHud, mucked">
             <game_stat_set game_type="tour" stat_set="holdem_tour"/>
             <game_stat_set game_type="ring" stat_set="holdem_ring"/>
         </game>
-        <game game_name="razz" aux="mucked, Classic_HUD">
+        <game game_name="razz" aux="mucked, ClassicHud">
             <game_stat_set game_type="all" stat_set="stud_default"/>
         </game>
-        <game game_name="omahahi" aux="Classic_HUD, mucked">
+        <game game_name="omahahi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
         <!-- All-in or Fold: one decision per hand, on the flop. The ordinary
              Omaha profile would label that decision "preflop", a street this
              game does not have. -->
-        <game game_name="aof_omaha" aux="Classic_HUD, mucked">
+        <game game_name="aof_omaha" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="aof_advanced"/>
         </game>
-        <game game_name="omahahilo" aux="Classic_HUD, mucked">
+        <game game_name="omahahilo" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
-        <game game_name="5_omahahi" aux="Classic_HUD, mucked">
+        <game game_name="5_omahahi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
-        <game game_name="5_omaha8" aux="Classic_HUD, mucked">
+        <game game_name="5_omaha8" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
-        <game game_name="cour_hi" aux="Classic_HUD, mucked">
+        <game game_name="cour_hi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
-        <game game_name="cour_hilo" aux="Classic_HUD, mucked">
+        <game game_name="cour_hilo" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
-        <game game_name="studhi" aux="mucked, Classic_HUD">
+        <game game_name="studhi" aux="mucked, ClassicHud">
             <game_stat_set game_type="all" stat_set="stud_default"/>
         </game>
-        <game game_name="5_studhi" aux="mucked, Classic_HUD">
+        <game game_name="5_studhi" aux="mucked, ClassicHud">
             <game_stat_set game_type="all" stat_set="stud_default"/>
         </game>
-        <game game_name="studhilo" aux="mucked, Classic_HUD">
+        <game game_name="studhilo" aux="mucked, ClassicHud">
             <game_stat_set game_type="all" stat_set="stud_default"/>
         </game>
-        <game game_name="27_3draw" aux="Classic_HUD, mucked">
+        <game game_name="27_3draw" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="draw_default"/>
         </game>
-        <game game_name="27_1draw" aux="Classic_HUD, mucked">
+        <game game_name="27_1draw" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="draw_default"/>
         </game>
-        <game game_name="badugi" aux="Classic_HUD, mucked">
+        <game game_name="badugi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="draw_default"/>
         </game>
-        <game game_name="fivedraw" aux="Classic_HUD, mucked">
+        <game game_name="fivedraw" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="draw_default"/>
         </game>
-        <game game_name="a5_3draw" aux="Classic_HUD, mucked">
+        <game game_name="a5_3draw" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="draw_default"/>
         </game>
-        <game game_name="6_omahahi" aux="Classic_HUD, mucked">
+        <game game_name="6_omahahi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
     </supported_games>

--- a/fpdb_3_legacy/HUD_config.xml.example
+++ b/fpdb_3_legacy/HUD_config.xml.example
@@ -398,6 +398,13 @@
         <game game_name="6_omahahi" aux="ClassicHud, mucked">
             <game_stat_set game_type="all" stat_set="omaha_default"/>
         </game>
+        <game game_name="fusion" aux="PLO4Hud, mucked">
+            <game_stat_set game_type="ring" stat_set="plo_pro_html"/>
+            <game_stat_set game_type="tour" stat_set="plo_pro_html"/>
+        </game>
+        <game game_name="aof_holdem" aux="ClassicHud, mucked">
+            <game_stat_set game_type="all" stat_set="aof_advanced"/>
+        </game>
     </supported_games>
 
 
@@ -411,6 +418,7 @@
         <!-- HUD aux's -->
         <aw name="Simple_HUD" module="Aux_Hud" class="Simple_HUD" bgcolor="#000000" fgcolor="#FFFFFF" font="Sans" font_size="8" opacity="0.8"/>
         <aw name="ClassicHud" module="Aux_Classic_Hud" class="ClassicHud" bgcolor="#000000" fgcolor="#FFFFFF" font="Sans" font_size="8" opacity="0.8"/>
+        <aw name="PLO4Hud" module="Aux_Classic_Hud" class="ClassicHud" bgcolor="#0B1220" fgcolor="#E6EDF3" font="Sans" font_size="9" opacity="0.94"/>
 
         <!-- Mucked card aux's -->
         <aw name="stud_mucked" module="Mucked" class="Stud_mucked" cols="11" rows="8"/>
@@ -1738,6 +1746,17 @@
             <stat _rowcol="(6,1)" _stat_name="aof_splash_won" popup="aof_profile" hudbgcolor="#111827" hudprefix="Spl " hudsuffix="" tip="" click=""/>
             <stat _rowcol="(6,2)" _stat_name="aof_splash_freq" popup="aof_profile" hudbgcolor="#111827" hudprefix="Spl% " hudsuffix="" tip="" click=""/>
             <stat _rowcol="(6,3)" _stat_name="aof_showdowns" popup="aof_profile" hudbgcolor="#111827" hudprefix="sd " hudsuffix="" tip="" click=""/>
+        </ss>
+
+        <ss name="plo_pro_html" rows="2" cols="4" xpad="1" ypad="0" rich_text="True" font_size="10">
+            <stat _rowcol="(1,1)" _stat_name="playershort" popup="default" hudprefix="" hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(1,2)" _stat_name="n" popup="default" hudprefix="H " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(1,3)" _stat_name="vpip" popup="default" hudprefix="VP " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(1,4)" _stat_name="pfr" popup="default" hudprefix="PFR " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(2,1)" _stat_name="three_B" popup="default" hudprefix="3B " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(2,2)" _stat_name="cb1" popup="default" hudprefix="CB " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(2,3)" _stat_name="wtsd" popup="default" hudprefix="SD " hudsuffix="" tip="" click=""/>
+            <stat _rowcol="(2,4)" _stat_name="totalprofit" popup="default" hudprefix="P " hudsuffix="" tip="" click=""/>
         </ss>
 
         <ss name="omaha_default" rows="3" cols="2" xpad="1" ypad="0">

--- a/fpdb_3_legacy/config_migrations.py
+++ b/fpdb_3_legacy/config_migrations.py
@@ -1,0 +1,130 @@
+"""Versioned, conservative HUD configuration upgrades and reference diagnostics."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import defusedxml.minidom
+
+
+def reference_errors(doc) -> list[str]:
+    """Report every unresolved HUD binding, including its owning game/site."""
+    definitions = {
+        kind: {n.getAttribute("name") for n in doc.getElementsByTagName(tag)}
+        for kind, tag in (("aux", "aw"), ("stat_set", "ss"), ("layout_set", "ls"))
+    }
+    errors = []
+    for node in doc.getElementsByTagName("*"):
+        bindings = [(attr, attr) for attr in ("aux", "stat_set", "layout_set")]
+        if node.tagName == "layout_set":
+            bindings.append(("ls", "layout_set"))
+        if node.tagName == "hud_profile_rule":
+            bindings.append(("profile", "stat_set"))
+        for attr, kind in bindings:
+            if not node.hasAttribute(attr):
+                continue
+            names = node.getAttribute(attr).split(",") if attr == "aux" else [node.getAttribute(attr)]
+            for name in names:
+                name = name.strip()
+                if name and name not in definitions[kind]:
+                    owner = node
+                    keys = ("game_name", "site_name", "name")
+                    while not any(owner.hasAttribute(a) for a in keys):
+                        if owner.parentNode.nodeType != owner.ELEMENT_NODE:
+                            break
+                        owner = owner.parentNode
+                    label = next((owner.getAttribute(a) for a in keys if owner.hasAttribute(a)), node.tagName)
+                    errors.append(f"{label}: {kind} references undefined {name!r}")
+    return errors
+
+
+def _merge_83_to_84(doc, template) -> None:
+    # Existing definitions and bindings may be customized: fill gaps only.
+    for section, tag, key in (
+        ("aux_windows", "aw", "name"),
+        ("stat_sets", "ss", "name"),
+        ("layout_sets", "ls", "name"),
+        ("popup_windows", "pu", "pu_name"),
+        ("supported_games", "game", "game_name"),
+        ("supported_sites", "site", "site_name"),
+        ("hhcs", "hhc", "site"),
+    ):
+        sources = template.getElementsByTagName(section)
+        if not sources:
+            continue
+        targets = doc.getElementsByTagName(section)
+        if not targets:
+            doc.documentElement.appendChild(doc.importNode(sources[0], True))
+            continue
+        target = targets[0]
+        existing = {n.getAttribute(key) for n in target.getElementsByTagName(tag)}
+        for node in sources[0].getElementsByTagName(tag):
+            if node.getAttribute(key) not in existing:
+                target.appendChild(doc.importNode(node, True))
+    _repair_renamed_references(doc)
+
+
+def _repair_renamed_references(doc) -> None:
+    aux_names = {n.getAttribute("name") for n in doc.getElementsByTagName("aw")}
+    if "Classic_HUD" not in aux_names and "ClassicHud" in aux_names:
+        for node in doc.getElementsByTagName("game"):
+            names = [name.strip() for name in node.getAttribute("aux").split(",")]
+            if "Classic_HUD" in names:
+                node.setAttribute("aux", ", ".join("ClassicHud" if name == "Classic_HUD" else name for name in names))
+    layout_names = {n.getAttribute("name") for n in doc.getElementsByTagName("ls")}
+    if "bodova_default" not in layout_names and "bovada_default" in layout_names:
+        for node in doc.getElementsByTagName("layout_set"):
+            if node.getAttribute("ls") == "bodova_default":
+                node.setAttribute("ls", "bovada_default")
+
+
+MIGRATIONS = ((83, 84, _merge_83_to_84),)
+
+
+def upgrade_document(doc, template, target_version: int):
+    """Prepare on a copy; never stamp an unknown schema as current."""
+    candidate = doc.cloneNode(True)
+    general = candidate.getElementsByTagName("general")
+    if not general:
+        raise ValueError("Configuration has no version; manual review is required.")
+    version = int(general[0].getAttribute("version"))
+    template_general = template.getElementsByTagName("general")
+    if not template_general or int(template_general[0].getAttribute("version")) != target_version:
+        raise ValueError("The shipped configuration template has an incompatible version.")
+    for old, new, migrate in MIGRATIONS:
+        if version == old and new <= target_version:
+            migrate(candidate, template)
+            general[0].setAttribute("version", str(new))
+            version = new
+    if version != target_version:
+        raise ValueError(f"No configuration upgrade path from version {version} to {target_version}.")
+    errors = reference_errors(candidate)
+    if errors:
+        raise ValueError("Configuration still contains unresolved references:\n" + "\n".join(errors))
+    return candidate
+
+
+def write_upgrade(path: str, doc) -> str:
+    """Keep a unique byte-for-byte backup and atomically replace the config."""
+    target = Path(path)
+    backup_fd, backup = tempfile.mkstemp(prefix=target.name + ".pre-upgrade-", suffix=".xml", dir=target.parent)
+    os.close(backup_fd)
+    try:
+        shutil.copy2(target, backup)
+    except OSError:
+        Path(backup).unlink(missing_ok=True)
+        raise
+    temp_fd, temporary = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=target.parent)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as stream:
+            stream.write(doc.toxml())
+            stream.flush()
+            os.fsync(stream.fileno())
+        defusedxml.minidom.parse(temporary)
+        os.replace(temporary, target)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+    return backup

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1461,37 +1461,35 @@ class fpdb(QMainWindow):
                 ],
             )
             self.display_config_created_dialogue = False
-        elif self.config.wrongConfigVersion:
-            diaConfigVersionWarning = QDialog()
-            diaConfigVersionWarning.setWindowTitle(_("Strong Warning - Local configuration out of date"))
-            diaConfigVersionWarning.setLayout(QVBoxLayout())
-            label = QLabel("\nYour local configuration file needs to be updated.")
-            diaConfigVersionWarning.layout().addWidget(label)
-            label = QLabel(
-                "\nYour local configuration file needs to be updated."
-                " This error is not necessarily fatal but it is strongly recommended that you update the configuration.",
+        if self.config.wrongConfigVersion or self.config.config_reference_errors:
+            warning = QMessageBox(self)
+            warning.setIcon(QMessageBox.Warning)
+            warning.setWindowTitle(_("Configuration needs attention"))
+            warning.setText(
+                f"Configuration: {self.config.file}\n"
+                f"Version {self.config.general['version']}; expected {Configuration.CONFIG_VERSION}."
             )
-            diaConfigVersionWarning.layout().addWidget(label)
-            label = QLabel(
-                "To create a new configuration, see:"
-                " fpdb.sourceforge.net/apps/mediawiki/fpdb/index.php?title=Reset_Configuration",
+            warning.setInformativeText(
+                "Upgrade adds missing HUD definitions and repairs known renamed references, "
+                "while preserving existing profiles, layouts, sites, screen names and favourite seats. "
+                "A separate backup is saved before writing. Unknown versions or unresolved references "
+                "require manual review."
             )
-            label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-            diaConfigVersionWarning.layout().addWidget(label)
-            label = QLabel(
-                "A new configuration will destroy all personal settings"
-                " (hud layout, site folders, screennames, favourite seats).\n",
-            )
-            diaConfigVersionWarning.layout().addWidget(label)
-            label = QLabel(_("To keep existing personal settings, you must edit the local file."))
-            diaConfigVersionWarning.layout().addWidget(label)
-            label = QLabel(_("See the release note for information about the edits needed"))
-            diaConfigVersionWarning.layout().addWidget(label)
-            btns = QDialogButtonBox(QDialogButtonBox.Ok)
-            btns.accepted.connect(diaConfigVersionWarning.accept)
-            diaConfigVersionWarning.layout().addWidget(btns)
-            diaConfigVersionWarning.exec()
-            self.config.wrongConfigVersion = False
+            warning.setDetailedText("\n".join(self.config.config_reference_errors))
+            warning.setStandardButtons(QMessageBox.Close)
+            upgrade = None
+            from fpdb_3_legacy.config_migrations import MIGRATIONS
+
+            if any(old == self.config.general["version"] for old, _new, _step in MIGRATIONS):
+                upgrade = warning.addButton(_("Back up and upgrade"), QMessageBox.AcceptRole)
+            warning.exec()
+            if upgrade is not None and warning.clickedButton() is upgrade:
+                try:
+                    backup = self.config.upgrade_config()
+                    self.config = Configuration.Config(file=self.config.file, dbname=options.dbname)
+                    self.info_box("Configuration upgraded", [f"Backup saved to {backup}"])
+                except (OSError, ValueError) as exc:
+                    self.warning_box(f"Configuration upgrade failed: {exc}")
 
         # Set up application settings
         self.settings = {}
@@ -1570,11 +1568,24 @@ class fpdb(QMainWindow):
                 self,
             )
             diaDbVersionWarning.setInformativeText(
-                "This error is not necessarily fatal but it is strongly"
-                " recommended that you recreate the tables by using the Database menu."
-                " Not doing this will likely lead to misbehavior including fpdb crashes, corrupt data, etc.",
+                "Recreating tables deletes ALL imported hands and statistics; you will need to reimport "
+                "your original histories. No automatic schema upgrade is available for this database. "
+                "Back up your database and keep your hand histories before recreating tables. "
+                "You can export a diagnostic text dump first; it is not a restorable database backup.",
             )
+            export = diaDbVersionWarning.addButton("Export text dump…", QMessageBox.ActionRole)
             diaDbVersionWarning.exec()
+            if diaDbVersionWarning.clickedButton() is export:
+                from PySide6.QtWidgets import QFileDialog
+
+                path, _filter = QFileDialog.getSaveFileName(self, "Export database", "database-dump.txt")
+                if path:
+                    try:
+                        result = self.db.dumpDatabase()
+                        with open(path, "w", encoding="utf-8") as stream:
+                            stream.write(result)
+                    except Exception as exc:
+                        self.warning_box(f"Database export failed. Keep the original database: {exc}")
 
         # Update the status bar with the database connection status
         if self.db is not None and self.db.is_connected():

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -1,0 +1,180 @@
+"""Regressions for stale version-83 HUD files (issue #287)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import defusedxml.minidom
+import pytest
+
+from fpdb_3_legacy.config_migrations import reference_errors, upgrade_document, write_upgrade
+from fpdb_3_legacy.Configuration import CONFIG_VERSION
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse(body):
+    return defusedxml.minidom.parseString(body)
+
+
+def stale():
+    return parse("""<FreePokerToolsConfig><general version="83"/>
+      <supported_sites><site site_name="mine" screen_name="hero" HH_path="/my/hands">
+      <fav max="6" fav_seat="4"/><layout_set ls="custom"/></site></supported_sites>
+      <layout_sets><ls name="custom"/></layout_sets>
+      <stat_sets><ss name="my_stats" rows="1"/></stat_sets>
+      <supported_games><game game_name="holdem" aux="Classic_HUD, mucked">
+      <game_stat_set game_type="all" stat_set="my_stats"/></game></supported_games>
+      <aux_windows/><supported_databases><database db_name="mine"/></supported_databases>
+      </FreePokerToolsConfig>""")
+
+
+@pytest.mark.parametrize("name", ["HUD_config.xml", "HUD_config.xml.example"])
+def test_templates_have_current_version_and_resolve(name):
+    template = defusedxml.minidom.parse(str(ROOT / name))
+    assert int(template.getElementsByTagName("general")[0].getAttribute("version")) == CONFIG_VERSION
+    assert reference_errors(template) == []
+
+
+def test_upgrade_preserves_personal_settings_and_repairs_alias():
+    old = stale()
+    original = old.toxml()
+    template = defusedxml.minidom.parse(str(ROOT / "HUD_config.xml.example"))
+    updated = upgrade_document(old, template, CONFIG_VERSION)
+    assert old.toxml() == original
+    assert reference_errors(updated) == []
+    for tag in ("site", "ls", "ss", "database"):
+        assert updated.getElementsByTagName(tag)[0].toxml() == old.getElementsByTagName(tag)[0].toxml()
+    game = updated.getElementsByTagName("game")[0]
+    assert game.getAttribute("aux") == "ClassicHud, mucked"
+    assert game.getElementsByTagName("game_stat_set")[0].getAttribute("stat_set") == "my_stats"
+    assert upgrade_document(updated, template, CONFIG_VERSION).toxml() == updated.toxml()
+
+
+def test_reports_all_dangling_bindings_even_when_version_current():
+    doc = parse("""<FreePokerToolsConfig><general version="84"/>
+    <game game_name="holdem" aux="missing, another"><game_stat_set stat_set="bad"/></game>
+    <site site_name="mine"><layout_set ls="absent"/></site>
+    <hud_profile_rule profile="unknown"/></FreePokerToolsConfig>""")
+    errors = reference_errors(doc)
+    assert len(errors) == 5
+    assert any("holdem" in e and "missing" in e for e in errors)
+    assert any("mine" in e and "absent" in e for e in errors)
+
+
+@pytest.mark.parametrize("version", ["0", "82", "999", "invalid"])
+def test_unknown_version_is_not_stamped_current(version):
+    doc = stale()
+    doc.getElementsByTagName("general")[0].setAttribute("version", version)
+    with pytest.raises(ValueError):
+        upgrade_document(doc, defusedxml.minidom.parse(str(ROOT / "HUD_config.xml.example")), CONFIG_VERSION)
+    assert doc.getElementsByTagName("general")[0].getAttribute("version") == version
+
+
+def test_unresolved_custom_reference_aborts_upgrade():
+    doc = stale()
+    doc.getElementsByTagName("game_stat_set")[0].setAttribute("stat_set", "typo")
+    with pytest.raises(ValueError, match="typo"):
+        upgrade_document(doc, defusedxml.minidom.parse(str(ROOT / "HUD_config.xml.example")), CONFIG_VERSION)
+    assert doc.getElementsByTagName("general")[0].getAttribute("version") == "83"
+
+
+def test_unique_backups_preserve_original_bytes(tmp_path):
+    path = tmp_path / "HUD_config.xml"
+    original = b"<?xml version='1.0'?>\r\n<original/>\r\n"
+    path.write_bytes(original)
+    backup = write_upgrade(str(path), stale())
+    assert Path(backup).read_bytes() == original
+    second = write_upgrade(str(path), stale())
+    assert second != backup
+    assert Path(backup).read_bytes() == original
+
+
+@pytest.mark.parametrize("operation", ["shutil.copy2", "os.replace"])
+def test_failed_backup_or_replace_keeps_original(tmp_path, operation):
+    path = tmp_path / "HUD_config.xml"
+    path.write_bytes(b"original")
+    with patch("fpdb_3_legacy.config_migrations." + operation, side_effect=OSError("denied")):
+        with pytest.raises(OSError, match="denied"):
+            write_upgrade(str(path), stale())
+    assert path.read_bytes() == b"original"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_load_reports_current_config_errors_and_invalid_version(tmp_path, monkeypatch):
+    import fpdb_3_legacy.Configuration as configuration
+
+    monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
+    path = tmp_path / "HUD_config.xml"
+    xml = (ROOT / "HUD_config.xml.example").read_text()
+    path.write_text(xml.replace('aux="ClassicHud, mucked"', 'aux="unknown"'))
+    config = configuration.Config(file=str(path))
+    assert config.wrongConfigVersion is False
+    assert any("unknown" in error for error in config.config_reference_errors)
+    path.write_text(xml.replace('version="84"', 'version="invalid"'))
+    assert configuration.Config(file=str(path)).wrongConfigVersion is True
+
+
+def test_upgrade_config_can_be_reloaded_and_does_not_repeat(tmp_path, monkeypatch):
+    import fpdb_3_legacy.Configuration as configuration
+
+    monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
+    monkeypatch.setattr(configuration, "_find_example_config", lambda _: str(ROOT / "HUD_config.xml.example"))
+    path = tmp_path / "HUD_config.xml"
+    old = (ROOT / "HUD_config.xml.example").read_text().replace('version="84"', 'version="83"')
+    old = old.replace('aux="ClassicHud, mucked"', 'aux="Classic_HUD, mucked"')
+    path.write_text(old)
+    config = configuration.Config(file=str(path))
+    assert config.wrongConfigVersion
+    assert config.config_reference_errors
+    backup = config.upgrade_config()
+    assert Path(backup).read_text() == old
+    reloaded = configuration.Config(file=str(path))
+    assert not reloaded.wrongConfigVersion
+    assert not reloaded.config_reference_errors
+    assert reloaded.supported_games["holdem"].aux == "ClassicHud, mucked"
+
+
+def test_existing_aux_alias_definition_is_preserved():
+    doc = stale()
+    aux = doc.createElement("aw")
+    aux.setAttribute("name", "Classic_HUD")
+    doc.getElementsByTagName("aux_windows")[0].appendChild(aux)
+    updated = upgrade_document(doc, defusedxml.minidom.parse(str(ROOT / "HUD_config.xml.example")), CONFIG_VERSION)
+    assert updated.getElementsByTagName("game")[0].getAttribute("aux") == "Classic_HUD, mucked"
+
+
+def test_ci_rejects_unversioned_changes_and_version_mismatch(tmp_path):
+    from tools.check_config_version import check
+
+    (tmp_path / "fpdb_3_legacy").mkdir()
+    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 84")
+    old = '<config><general version="84"/></config>'
+    changed = '<config><general version="84"/><new/></config>'
+    for name in ("HUD_config.xml", "HUD_config.xml.example"):
+        (tmp_path / name).write_text(changed)
+    with patch("tools.check_config_version.subprocess.check_output", return_value=old):
+        with pytest.raises(ValueError, match="increment"):
+            check("base", tmp_path)
+        for name in ("HUD_config.xml", "HUD_config.xml.example"):
+            (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'))
+        with pytest.raises(ValueError, match="must equal"):
+            check("base", tmp_path)
+        (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85")
+        check("base", tmp_path)
+
+
+def test_adding_general_defaults_does_not_hide_missing_version(tmp_path, monkeypatch):
+    import fpdb_3_legacy.Configuration as configuration
+
+    monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
+    path = tmp_path / "HUD_config.xml"
+    xml = (ROOT / "HUD_config.xml.example").read_text()
+    doc = parse(xml)
+    general = doc.getElementsByTagName("general")[0]
+    general.parentNode.removeChild(general)
+    path.write_text(doc.toxml())
+    config = configuration.Config(file=str(path))
+    config.add_missing_elements(config.doc, str(ROOT / "HUD_config.xml.example"))
+    reloaded = configuration.Config(file=str(path))
+    assert reloaded.general["version"] == 0
+    assert reloaded.wrongConfigVersion

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -152,20 +152,22 @@ def test_ci_rejects_unversioned_changes_and_version_mismatch(tmp_path):
     (tmp_path / "fpdb_3_legacy").mkdir()
     (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 84")
     old = '<config><general version="84"/></config>'
+    base_dir = tmp_path / "base"
+    (base_dir / "fpdb_3_legacy").mkdir(parents=True)
     changed = '<config><general version="84"/><new/></config>'
     for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
         if "/" in name:
             (tmp_path / name).parent.mkdir(parents=True, exist_ok=True)
         (tmp_path / name).write_text(changed)
-    with patch("tools.check_config_version.subprocess.check_output", return_value=old):
-        with pytest.raises(ValueError, match="increment"):
-            check("0" * 40, tmp_path)
-        for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
-            (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'))
-        with pytest.raises(ValueError, match="must equal"):
-            check("0" * 40, tmp_path)
-        (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85")
-        check("0" * 40, tmp_path)
+        (base_dir / name).write_text(old)
+    with pytest.raises(ValueError, match="increment"):
+        check(base_dir, tmp_path)
+    for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
+        (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'))
+    with pytest.raises(ValueError, match="must equal"):
+        check(base_dir, tmp_path)
+    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85")
+    check(base_dir, tmp_path)
 
 
 def test_adding_general_defaults_does_not_hide_missing_version(tmp_path, monkeypatch):

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -36,6 +36,12 @@ def test_templates_have_current_version_and_resolve(name):
     template = defusedxml.minidom.parse(str(ROOT / name))
     assert int(template.getElementsByTagName("general")[0].getAttribute("version")) == CONFIG_VERSION
     assert reference_errors(template) == []
+    games = {node.getAttribute("game_name") for node in template.getElementsByTagName("game")}
+    assert {"fusion", "aof_holdem"} <= games
+    aux = {node.getAttribute("name") for node in template.getElementsByTagName("aw")}
+    stat_sets = {node.getAttribute("name") for node in template.getElementsByTagName("ss")}
+    assert "PLO4Hud" in aux
+    assert "plo_pro_html" in stat_sets
 
 
 def test_upgrade_preserves_personal_settings_and_repairs_alias():

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -109,11 +109,11 @@ def test_load_reports_current_config_errors_and_invalid_version(tmp_path, monkey
     monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
     path = tmp_path / "HUD_config.xml"
     xml = (ROOT / "HUD_config.xml.example").read_text(encoding="utf-8")
-    path.write_text(xml.replace('aux="ClassicHud, mucked"', 'aux="unknown"'))
+    path.write_text(xml.replace('aux="ClassicHud, mucked"', 'aux="unknown"'), encoding="utf-8")
     config = configuration.Config(file=str(path))
     assert config.wrongConfigVersion is False
     assert any("unknown" in error for error in config.config_reference_errors)
-    path.write_text(xml.replace('version="84"', 'version="invalid"'))
+    path.write_text(xml.replace('version="84"', 'version="invalid"'), encoding="utf-8")
     assert configuration.Config(file=str(path)).wrongConfigVersion is True
 
 
@@ -125,7 +125,7 @@ def test_upgrade_config_can_be_reloaded_and_does_not_repeat(tmp_path, monkeypatc
     path = tmp_path / "HUD_config.xml"
     old = (ROOT / "HUD_config.xml.example").read_text(encoding="utf-8").replace('version="84"', 'version="83"')
     old = old.replace('aux="ClassicHud, mucked"', 'aux="Classic_HUD, mucked"')
-    path.write_text(old)
+    path.write_text(old, encoding="utf-8")
     config = configuration.Config(file=str(path))
     assert config.wrongConfigVersion
     assert config.config_reference_errors
@@ -150,7 +150,7 @@ def test_ci_rejects_unversioned_changes_and_version_mismatch(tmp_path):
     from tools.check_config_version import check
 
     (tmp_path / "fpdb_3_legacy").mkdir()
-    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 84")
+    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 84", encoding="utf-8")
     old = '<config><general version="84"/></config>'
     base_dir = tmp_path / "base"
     (base_dir / "fpdb_3_legacy").mkdir(parents=True)
@@ -158,15 +158,15 @@ def test_ci_rejects_unversioned_changes_and_version_mismatch(tmp_path):
     for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
         if "/" in name:
             (tmp_path / name).parent.mkdir(parents=True, exist_ok=True)
-        (tmp_path / name).write_text(changed)
-        (base_dir / name).write_text(old)
+        (tmp_path / name).write_text(changed, encoding="utf-8")
+        (base_dir / name).write_text(old, encoding="utf-8")
     with pytest.raises(ValueError, match="increment"):
         check(base_dir, tmp_path)
     for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
-        (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'))
+        (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'), encoding="utf-8")
     with pytest.raises(ValueError, match="must equal"):
         check(base_dir, tmp_path)
-    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85")
+    (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85", encoding="utf-8")
     check(base_dir, tmp_path)
 
 
@@ -179,7 +179,7 @@ def test_adding_general_defaults_does_not_hide_missing_version(tmp_path, monkeyp
     doc = parse(xml)
     general = doc.getElementsByTagName("general")[0]
     general.parentNode.removeChild(general)
-    path.write_text(doc.toxml())
+    path.write_text(doc.toxml(), encoding="utf-8")
     config = configuration.Config(file=str(path))
     config.add_missing_elements(config.doc, str(ROOT / "HUD_config.xml.example"))
     reloaded = configuration.Config(file=str(path))

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -28,7 +28,10 @@ def stale():
       </FreePokerToolsConfig>""")
 
 
-@pytest.mark.parametrize("name", ["HUD_config.xml", "HUD_config.xml.example"])
+@pytest.mark.parametrize(
+    "name",
+    ["HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"],
+)
 def test_templates_have_current_version_and_resolve(name):
     template = defusedxml.minidom.parse(str(ROOT / name))
     assert int(template.getElementsByTagName("general")[0].getAttribute("version")) == CONFIG_VERSION
@@ -105,7 +108,7 @@ def test_load_reports_current_config_errors_and_invalid_version(tmp_path, monkey
 
     monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
     path = tmp_path / "HUD_config.xml"
-    xml = (ROOT / "HUD_config.xml.example").read_text()
+    xml = (ROOT / "HUD_config.xml.example").read_text(encoding="utf-8")
     path.write_text(xml.replace('aux="ClassicHud, mucked"', 'aux="unknown"'))
     config = configuration.Config(file=str(path))
     assert config.wrongConfigVersion is False
@@ -120,14 +123,14 @@ def test_upgrade_config_can_be_reloaded_and_does_not_repeat(tmp_path, monkeypatc
     monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
     monkeypatch.setattr(configuration, "_find_example_config", lambda _: str(ROOT / "HUD_config.xml.example"))
     path = tmp_path / "HUD_config.xml"
-    old = (ROOT / "HUD_config.xml.example").read_text().replace('version="84"', 'version="83"')
+    old = (ROOT / "HUD_config.xml.example").read_text(encoding="utf-8").replace('version="84"', 'version="83"')
     old = old.replace('aux="ClassicHud, mucked"', 'aux="Classic_HUD, mucked"')
     path.write_text(old)
     config = configuration.Config(file=str(path))
     assert config.wrongConfigVersion
     assert config.config_reference_errors
     backup = config.upgrade_config()
-    assert Path(backup).read_text() == old
+    assert Path(backup).read_text(encoding="utf-8") == old
     reloaded = configuration.Config(file=str(path))
     assert not reloaded.wrongConfigVersion
     assert not reloaded.config_reference_errors
@@ -150,17 +153,19 @@ def test_ci_rejects_unversioned_changes_and_version_mismatch(tmp_path):
     (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 84")
     old = '<config><general version="84"/></config>'
     changed = '<config><general version="84"/><new/></config>'
-    for name in ("HUD_config.xml", "HUD_config.xml.example"):
+    for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
+        if "/" in name:
+            (tmp_path / name).parent.mkdir(parents=True, exist_ok=True)
         (tmp_path / name).write_text(changed)
     with patch("tools.check_config_version.subprocess.check_output", return_value=old):
         with pytest.raises(ValueError, match="increment"):
-            check("base", tmp_path)
-        for name in ("HUD_config.xml", "HUD_config.xml.example"):
+            check("0" * 40, tmp_path)
+        for name in ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example"):
             (tmp_path / name).write_text(changed.replace('version="84"', 'version="85"'))
         with pytest.raises(ValueError, match="must equal"):
-            check("base", tmp_path)
+            check("0" * 40, tmp_path)
         (tmp_path / "fpdb_3_legacy/Configuration.py").write_text("CONFIG_VERSION = 85")
-        check("base", tmp_path)
+        check("0" * 40, tmp_path)
 
 
 def test_adding_general_defaults_does_not_hide_missing_version(tmp_path, monkeypatch):
@@ -168,7 +173,7 @@ def test_adding_general_defaults_does_not_hide_missing_version(tmp_path, monkeyp
 
     monkeypatch.setattr(configuration, "CONFIG_PATH", str(tmp_path))
     path = tmp_path / "HUD_config.xml"
-    xml = (ROOT / "HUD_config.xml.example").read_text()
+    xml = (ROOT / "HUD_config.xml.example").read_text(encoding="utf-8")
     doc = parse(xml)
     general = doc.getElementsByTagName("general")[0]
     general.parentNode.removeChild(general)

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -44,6 +44,10 @@ def test_templates_have_current_version_and_resolve(name):
     assert "plo_pro_html" in stat_sets
 
 
+def test_package_template_stays_synchronized_with_root_template():
+    assert (ROOT / "fpdb_3_legacy/HUD_config.xml.example").read_bytes() == (ROOT / "HUD_config.xml.example").read_bytes()
+
+
 def test_upgrade_preserves_personal_settings_and_repairs_alias():
     old = stale()
     original = old.toxml()

--- a/tools/check_config_version.py
+++ b/tools/check_config_version.py
@@ -1,0 +1,46 @@
+"""Fail CI when a shipped template changes without a schema version increase."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+from pathlib import Path
+from xml.etree import ElementTree
+
+TEMPLATES = ("HUD_config.xml", "HUD_config.xml.example")
+
+
+def version(xml: str) -> int:
+    general = ElementTree.fromstring(xml).find("general")
+    if general is None:
+        raise ValueError("Configuration template is missing its general version")
+    return int(general.attrib["version"])
+
+
+def check(base: str, root: Path) -> None:
+    tree = ast.parse((root / "fpdb_3_legacy/Configuration.py").read_text())
+    current = next(
+        ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "CONFIG_VERSION" for target in node.targets)
+    )
+    for name in TEMPLATES:
+        xml = (root / name).read_text()
+        if version(xml) != current:
+            raise ValueError(f"{name}: version must equal CONFIG_VERSION ({current})")
+        old = subprocess.check_output(["git", "show", f"{base}:{name}"], cwd=root, text=True)
+        if xml != old and version(xml) <= version(old):
+            raise ValueError(f"{name} changed: increment CONFIG_VERSION and both template versions")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True)
+    args = parser.parse_args()
+    check(args.base, Path(__file__).resolve().parents[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_config_version.py
+++ b/tools/check_config_version.py
@@ -9,16 +9,14 @@ import shutil
 import subprocess  # nosec B404 - fixed executable and validated revision
 from pathlib import Path
 
-from defusedxml import ElementTree
-
 TEMPLATES = ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example")
 
 
 def version(xml: str) -> int:
-    general = ElementTree.fromstring(xml).find("general")
-    if general is None:
+    match = re.search(r"<general\b[^>]*\bversion=[\"']([0-9]+)[\"']", xml)
+    if match is None:
         raise ValueError("Configuration template is missing its general version")
-    return int(general.attrib["version"])
+    return int(match.group(1))
 
 
 def check(base: str, root: Path) -> None:

--- a/tools/check_config_version.py
+++ b/tools/check_config_version.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import argparse
 import ast
 import re
-import shutil
-import subprocess  # nosec B404 - fixed executable and validated revision
 from pathlib import Path
 
 TEMPLATES = ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example")
@@ -19,7 +17,7 @@ def version(xml: str) -> int:
     return int(match.group(1))
 
 
-def check(base: str, root: Path) -> None:
+def check(base_dir: Path, root: Path) -> None:
     tree = ast.parse((root / "fpdb_3_legacy/Configuration.py").read_text(encoding="utf-8"))
     current = next(
         ast.literal_eval(node.value)
@@ -31,23 +29,16 @@ def check(base: str, root: Path) -> None:
         xml = (root / name).read_text(encoding="utf-8")
         if version(xml) != current:
             raise ValueError(f"{name}: version must equal CONFIG_VERSION ({current})")
-        if not re.fullmatch(r"[0-9a-fA-F]{40}", base):
-            raise ValueError("--base must be a full Git commit SHA")
-        git = shutil.which("git")
-        if git is None:
-            raise RuntimeError("git executable not found")
-        old = subprocess.check_output(  # noqa: S603 - fixed argv, validated SHA, no shell
-            [git, "show", f"{base}:{name}"], cwd=root, text=True
-        )
+        old = (base_dir / name).read_text(encoding="utf-8")
         if xml != old and version(xml) <= version(old):
             raise ValueError(f"{name} changed: increment CONFIG_VERSION and both template versions")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--base", required=True)
+    parser.add_argument("--base-dir", type=Path, required=True)
     args = parser.parse_args()
-    check(args.base, Path(__file__).resolve().parents[1])
+    check(args.base_dir, Path(__file__).resolve().parents[1])
 
 
 if __name__ == "__main__":

--- a/tools/check_config_version.py
+++ b/tools/check_config_version.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import argparse
 import ast
-import subprocess
+import re
+import shutil
+import subprocess  # nosec B404 - fixed executable and validated revision
 from pathlib import Path
-from xml.etree import ElementTree
 
-TEMPLATES = ("HUD_config.xml", "HUD_config.xml.example")
+from defusedxml import ElementTree
+
+TEMPLATES = ("HUD_config.xml", "HUD_config.xml.example", "fpdb_3_legacy/HUD_config.xml.example")
 
 
 def version(xml: str) -> int:
@@ -19,7 +22,7 @@ def version(xml: str) -> int:
 
 
 def check(base: str, root: Path) -> None:
-    tree = ast.parse((root / "fpdb_3_legacy/Configuration.py").read_text())
+    tree = ast.parse((root / "fpdb_3_legacy/Configuration.py").read_text(encoding="utf-8"))
     current = next(
         ast.literal_eval(node.value)
         for node in tree.body
@@ -27,10 +30,17 @@ def check(base: str, root: Path) -> None:
         and any(isinstance(target, ast.Name) and target.id == "CONFIG_VERSION" for target in node.targets)
     )
     for name in TEMPLATES:
-        xml = (root / name).read_text()
+        xml = (root / name).read_text(encoding="utf-8")
         if version(xml) != current:
             raise ValueError(f"{name}: version must equal CONFIG_VERSION ({current})")
-        old = subprocess.check_output(["git", "show", f"{base}:{name}"], cwd=root, text=True)
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", base):
+            raise ValueError("--base must be a full Git commit SHA")
+        git = shutil.which("git")
+        if git is None:
+            raise RuntimeError("git executable not found")
+        old = subprocess.check_output(  # noqa: S603 - fixed argv, validated SHA, no shell
+            [git, "show", f"{base}:{name}"], cwd=root, text=True
+        )
         if xml != old and version(xml) <= version(old):
             raise ValueError(f"{name} changed: increment CONFIG_VERSION and both template versions")
 


### PR DESCRIPTION
## Summary

Fixes #287.

FPDB previously treated stale HUD configuration files as current when their version marker had not changed. This could leave dangling HUD references and silently prevent HUD windows from appearing.

This PR:

- bumps the configuration schema version and adds an explicit 83 → 84 migration;
- merges missing shipped HUD definitions while preserving user profiles, layouts, sites, screen names, seats, and custom bindings;
- validates aux, stat-set, and layout references at startup and reports unresolved names;
- creates a unique backup and atomically writes upgraded configuration files;
- adds CI enforcement so template changes require a version change;
- clarifies database-version warnings and offers a diagnostic export before table recreation.

## Validation

- 425 configuration and migration tests pass.
- Ruff and mypy pass for the changed Python files.
- Configuration template version check passes.
