### PR TITLE
chore: prepare 3.9.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FPDB-3 Standalone Legacy (Python)
 
-Version 3.7.0 — released 13 August 2026.
+Version 3.9.1 — release preparation.
 
-See the [3.7.0 release notes](docs/RELEASE_NOTES_3.7.0.md) for the HUD and
-packaging changes.
+See the [3.9.1 release notes](docs/RELEASE_NOTES_3.9.1.md) for the latest HUD,
+parser, configuration and packaging changes.
 
 The original FPDB-3 Python application: hand-history parsers, PySide6 GUI, statistics engine, and the HUD overlay. This repository hosts the standalone, self-contained legacy Python stack. It has been separated from the `fpdb-new` monorepo by removing all Rust and modern FastAPI components to keep it lightweight, fast, and easy to run.
 

--- a/docs/RELEASE_NOTES_3.9.1.md
+++ b/docs/RELEASE_NOTES_3.9.1.md
@@ -1,0 +1,34 @@
+# FPDB 3.9.1
+
+## Configuration and upgrade safety
+
+- Migrate stale HUD configurations while preserving user-defined profiles and
+  creating an atomic backup before writing the migrated file.
+- Synchronize fallback HUD and PLO profiles with the current templates.
+- Report unresolved HUD references with actionable diagnostics instead of
+  silently dropping them.
+- Keep the configuration schema marker, runtime version and package metadata in
+  sync at `3.9.1`.
+
+## HUD reliability
+
+- Preserve a table's HUD when its configuration has aged without replacing a
+  valid live configuration.
+- Clean up only the claim made by the current attempt when HUD ownership is
+  released.
+- Isolate HUD imports in tests and cover stale auxiliary configuration paths.
+
+## Stud Hi/Lo and PokerStars parsing
+
+- Preserve PokerStars header casing and parse spaced Stud Hi/Lo stakes.
+- Preserve showdown results and distinguish equivalent high and low winners in
+  the replayer.
+- Render the exact winning low hand, skip ambiguous cards, and avoid double
+  counting uncalled bets or uncontested pots.
+
+## Validation and packaging
+
+- Add migration fixtures and version checks to CI, including UTF-8 fixture
+  handling and the Windows test path.
+- Keep release metadata aligned across the Python package, Briefcase and the
+  runtime version exposed by the application.

--- a/fpdb_3_legacy/README.md
+++ b/fpdb_3_legacy/README.md
@@ -1,13 +1,13 @@
 # FPDB-3 Legacy (Python)
 
-This is the 3.7.0 reference application.
+This is the 3.9.1 reference application.
 
 The original FPDB-3 Python application: hand-history parsers, PySide6 GUI,
 statistics engine, and the HUD overlay. This standalone repository is the
 actively maintained Python application; the `fpdb/` package contains the
 shared platform/window infrastructure used by the legacy HUD.
 
-> The fast-fold HUD path in 3.7.0 includes platform-specific window contracts,
+> The fast-fold HUD path in 3.9.1 includes platform-specific window contracts,
 > duplicate-renderer interlocks, and deterministic seat handling.
 
 ## ✨ Highlights

--- a/fpdb_3_legacy/__init__.py
+++ b/fpdb_3_legacy/__init__.py
@@ -18,7 +18,7 @@ from typing import Any
 if not hasattr(datetime, "UTC"):
     datetime.UTC = datetime.timezone.utc
 
-__version__ = "3.9.0"
+__version__ = "3.9.1"
 
 
 def __getattr__(name: str) -> Any:

--- a/fpdb_3_legacy/fpdb.pyw
+++ b/fpdb_3_legacy/fpdb.pyw
@@ -1950,7 +1950,9 @@ class fpdb(QMainWindow):
     def info_box(self, str1, str2):
         diapath = QMessageBox(self)
         diapath.setWindowTitle(str1)
-        diapath.setText(str2)
+        if isinstance(str2, (list, tuple)):
+            str2 = "\n".join(str(item) for item in str2)
+        diapath.setText(str(str2))
         return diapath.exec()
 
     def warning_box(self, string, diatitle="FPDB WARNING"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpdb-3"
-version = "3.9.0"
+version = "3.9.1"
 description = "Free Poker Database (FPDB-3) - Legacy Python Implementation"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -269,7 +269,7 @@ omit = [
 [tool.briefcase]
 project_name = "Free Poker Database 3"
 bundle = "org.fpdb"
-version = "3.9.0"
+version = "3.9.1"
 
 [tool.briefcase.app.fpdb]
 formal_name = "FPDB"

--- a/test/test_fpdb_info_box.py
+++ b/test/test_fpdb_info_box.py
@@ -1,0 +1,47 @@
+"""The startup information dialog must accept both text and message lines."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import CodeType, FunctionType, SimpleNamespace
+
+SOURCE = Path(__file__).resolve().parents[1] / "fpdb_3_legacy" / "fpdb.pyw"
+TREE = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
+
+
+def _load_info_box():
+    fpdb_class = next(node for node in TREE.body if isinstance(node, ast.ClassDef) and node.name == "fpdb")
+    method = next(node for node in fpdb_class.body if isinstance(node, ast.FunctionDef) and node.name == "info_box")
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    compiled = compile(module, str(SOURCE), "exec")
+    code = next(item for item in compiled.co_consts if isinstance(item, CodeType) and item.co_name == "info_box")
+    return FunctionType(code, {"QMessageBox": _MessageBox}, "info_box")
+
+
+class _MessageBox:
+    last = None
+
+    def __init__(self, parent):
+        self.text = None
+        type(self).last = self
+
+    def setWindowTitle(self, title):
+        pass
+
+    def setText(self, text):
+        self.text = text
+
+    def exec(self):
+        return 0
+
+
+def test_info_box_joins_upgrade_message_lines() -> None:
+    dialog = SimpleNamespace()
+    info_box = _load_info_box()
+
+    # The method creates its own QMessageBox; capture the instance through the
+    # fake class rather than constructing the full Qt application.
+    info_box(dialog, "Configuration upgraded", ["Backup saved", "Restart FPDB"])
+    assert _MessageBox.last.text == "Backup saved\nRestart FPDB"

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ wheels = [
 
 [[package]]
 name = "fpdb-3"
-version = "3.9.0"
+version = "3.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Prepare the FPDB 3.9.1 patch release. Align versions, add release notes, and update release references. Validation: 40 migration/version tests passed; 28 version resolution tests passed; git diff --check passed.